### PR TITLE
bugfix/fix dev mode

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -25,6 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "dotenv": "^17.2.3",
     "its-fine": "^2.0.0",
     "konva": "^9.3.22",
     "lucide-react": "^0.542.0",

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -1,12 +1,26 @@
-import { defineConfig } from 'vite'
-import { fileURLToPath } from 'url';
+import {
+  defineConfig,
+} from 'vite'
+import {
+  fileURLToPath,
+} from 'url';
+import dotenv from 'dotenv';
 import path from 'path';
+import fs from 'fs';
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite';
 
-// TypeScript workaround
+// -- TypeScript workaround
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// -- Configure environment using .env file in project root directory (parent of
+// this service directory)
+const envFilePath = path.join(path.dirname(__dirname), '.env');
+
+if (fs.existsSync(envFilePath)) {
+  dotenv.config({ path: envFilePath });
+}
 
 // Port at which to redirect proxy
 const SERVER_PORT = process.env.WHITEBOARD_EDITOR_HTTP_PORT || '8080';

--- a/Frontend/yarn.lock
+++ b/Frontend/yarn.lock
@@ -1363,6 +1363,11 @@ devalue@^5.3.2:
   resolved "https://registry.npmjs.org/devalue/-/devalue-5.3.2.tgz"
   integrity sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==
 
+dotenv@^17.2.3:
+  version "17.2.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
+  integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"


### PR DESCRIPTION
Fixes the useContextBridge problem by adding its-fine as a dependency, just like
you showed me.

Also automatically fetches the localhost post to use for the vite server proxy
from .env.

Make sure dev mode works on your end before you approve this one (it should,
since I'm pretty sure this is how you were doing it before, but just to be
safe).

- **Updated react-konva version in Frontend/package.json to resolve dependency mismatch.**
- **Use dotenv parsing in vite.config.ts in Frontend to automatically inject WHITEBOARD_EDITOR_HTTP_PORT env var.**
