### PR TITLE
Automatically deploy on push to master

### DIFF
--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -214,6 +214,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: read
     needs:
       - build_and_push_frontend
       - build_and_push_frontend

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -219,8 +219,6 @@ jobs:
       - build_and_push_frontend
       - build_and_push_web_socket_server
       - build_and_push_reverse_proxy
-    env:
-      PRIVATE_KEY_FILE: ${{ runner.temp }}/github-ec2.pem
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -228,16 +226,16 @@ jobs:
       - name: Write SSH Key
         id: write-ssh-key
         run: |
-          cat > "${PRIVATE_KEY_FILE}" << _EOF_
+          cat > "${{ runner.temp }}/github-ec2.pem" << _EOF_
           ${{ secrets.EC2_TEST_PRIVATE_KEY }}
           _EOF_
-          chmod 400 "${PRIVATE_KEY_FILE}"
+          chmod 400 "${{ runner.temp }}/github-ec2.pem"
 
       - name: Copy docker-compose.yml to remote host
         id: copy-docker-compose-to-remote-host
         run: |
           REMOTE_HOST="${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}"
-          scp -i "${PRIVATE_KEY_FILE}" docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
+          scp -i "${{ runner.temp }}/github-ec2.pem" docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
 
       - name: Deploy via SSH
         id: deploy-ssh
@@ -281,7 +279,7 @@ jobs:
           unset SSH_SCRIPT
 
           ssh \
-            -i "${PRIVATE_KEY_FILE}" \
+            -i "${{ runner.temp }}/github-ec2.pem" \
             -o StrictHostKeyChecking=no \
             "${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}" \
             CURRENT_VERSION_TAG="${CURRENT_VERSION_TAG}" bash -e - < "${SSH_SCRIPT_FILE}"

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -8,11 +8,6 @@ on:
     branches:
       - master
   workflow_call:
-    # TODO: check env syntax
-    env:
-      CURRENT_VERSION_TAG:
-        description: Version with which to tag images
-        required: true
     secrets:
       EC2_TEST_PRIVATE_KEY:
         description: "The key to use to ssh into the ec2 instance"
@@ -35,6 +30,10 @@ on:
       EC2_TEST_SSL_CERT:
         description: "Certificate to be placed in ReverseProxy/cert.pem"
         required: true
+
+env:
+  CURRENT_VERSION_TAG: 0.1.0
+
 jobs:
   build_and_push_frontend:
     name: Build and Push Frontend

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -75,7 +75,7 @@ jobs:
           context: Frontend
           target: release
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:${CURRENT_VERSION_TAG}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:${{ env.CURRENT_VERSION_TAG }}
 
           # cache settings
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:buildcache
@@ -118,7 +118,7 @@ jobs:
           context: RestAPI
           target: release
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/rest_api:${CURRENT_VERSION_TAG}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/rest_api:${{ env.CURRENT_VERSION_TAG }}
 
           # cache settings
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/rest_api:buildcache
@@ -161,7 +161,7 @@ jobs:
           context: WebSocketServer
           target: release
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/web_socket_server:${CURRENT_VERSION_TAG}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/web_socket_server:${{ env.CURRENT_VERSION_TAG }}
 
           # cache settings
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/web_socket_server:buildcache
@@ -203,7 +203,7 @@ jobs:
           context: ReverseProxy
           target: release
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/reverse_proxy:${CURRENT_VERSION_TAG}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/reverse_proxy:${{ env.CURRENT_VERSION_TAG }}
 
           # cache settings
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/reverse_proxy:buildcache
@@ -241,7 +241,6 @@ jobs:
         id: deploy-ssh
         env:
           # Enclose entire script to run on remote host here
-          SSH_SCRIPT_FILE: ${{ runner.temp }}/script.sh
           SSH_SCRIPT: |
             # === cd to deployment directory ===================================
             cd ${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}
@@ -263,7 +262,7 @@ jobs:
 
             # === Pull images from container registry ==========================
             export WHITEBOARD_EDITOR_CR_URI="ghcr.io/whiteboard_editor"
-            export WHITEBOARD_EDITOR_TAG="${CURRENT_VERSION_TAG}"
+            export WHITEBOARD_EDITOR_TAG="${{ env.CURRENT_VERSION_TAG }}"
 
             docker login --username ${{ github.actor }} --password-stdin ghcr.io << _EOF_
             ${{ secrets.GITHUB_TOKEN }}
@@ -275,11 +274,11 @@ jobs:
             docker compose up --detach
         run: |
           # Write script to a tempfile
-          printenv SSH_SCRIPT > "${SSH_SCRIPT_FILE}"
+          printenv SSH_SCRIPT > "${{ runner.temp }}/script.sh"
           unset SSH_SCRIPT
 
           ssh \
             -i "${{ runner.temp }}/github-ec2.pem" \
             -o StrictHostKeyChecking=no \
             "${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}" \
-            CURRENT_VERSION_TAG="${CURRENT_VERSION_TAG}" bash -e - < "${SSH_SCRIPT_FILE}"
+            bash -e - < "${{ runner.temp }}/script.sh"

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -287,4 +287,4 @@ jobs:
             -i "${{ runner.temp }}/github-ec2.pem" \
             -o StrictHostKeyChecking=no \
             "${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}" \
-            bash -e - < "${{ runner.temp }}/script.sh"
+            bash -ve - < "${{ runner.temp }}/script.sh"

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - master
+      # TODO: only for testing; remove before merge to master
+      - feat/deploy_on_push_to_main
   workflow_call:
     secrets:
       EC2_TEST_PRIVATE_KEY:

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -238,7 +238,10 @@ jobs:
         id: copy-docker-compose-to-remote-host
         run: |
           REMOTE_HOST="${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}"
-          scp -v -i "${{ runner.temp }}/github-ec2.pem" docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
+          scp -v \
+            -i "${{ runner.temp }}/github-ec2.pem" \
+            -o StrictHostKeyChecking=no \
+            docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
 
       - name: Deploy via SSH
         id: deploy-ssh

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -261,7 +261,7 @@ jobs:
             _EOF_
 
             # === Pull images from container registry ==========================
-            export WHITEBOARD_EDITOR_CR_URI="ghcr.io/whiteboard_editor"
+            export WHITEBOARD_EDITOR_CR_URI="ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}"
             export WHITEBOARD_EDITOR_TAG="${{ env.CURRENT_VERSION_TAG }}"
 
             docker login --username ${{ github.actor }} --password-stdin ghcr.io << _EOF_

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -1,11 +1,18 @@
 # Automatically rebuilds and restarts the EC2 instance when a push to the
-# production branch occurs.
+# master branch occurs.
 # Derived from https://www.baeldung.com/ops/github-actions-deploy-ec2
+name: Deploy Test EC2 Instance
+
 on:
   push:
     branches:
-      - testing
+      - master
   workflow_call:
+    # TODO: check env syntax
+    env:
+      CURRENT_VERSION_TAG:
+        description: Version with which to tag images
+        required: true
     secrets:
       EC2_TEST_PRIVATE_KEY:
         description: "The key to use to ssh into the ec2 instance"
@@ -16,10 +23,7 @@ on:
       EC2_TEST_HOST:
         description: "Hostname of the EC2 instance"
         required: true
-      EC2_TEST_REPO_URL:
-        description: "URL at which the upstream repository is located"
-        required: true
-      EC2_TEST_REPO_DIR:
+      EC2_TEST_DEPLOYMENT_DIR:
         description: "Location of the git repository on the EC2 instance"
         required: true
       EC2_TEST_ENV_FILE:
@@ -32,37 +36,247 @@ on:
         description: "Certificate to be placed in ReverseProxy/cert.pem"
         required: true
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+  build_and_push_frontend:
+    name: Build and Push Frontend
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Deploy to EC2
-        env:
-          PRIVATE_KEY: ${{ secrets.EC2_TEST_PRIVATE_KEY }}
-          HOST: ${{ secrets.EC2_TEST_HOST }}
-          USER: ${{ secrets.EC2_TEST_USER }}
-          REPO_URL: ${{ secrets.EC2_TEST_REPO_URL }}
-          REPO_DIR: ${{ secrets.EC2_TEST_REPO_DIR }}
-          ENV_FILE: ${{ secrets.EC2_TEST_ENV_FILE }}
-          SSL_KEY: ${{ secrets.EC2_TEST_SSL_KEY }}
-          SSL_CERT: ${{ secrets.EC2_TEST_SSL_CERT }}
-          TARGET_BRANCH: testing
+      - name: Check out repository
+        id: checkout-repo
+        uses: actions/checkout@v5
+
+      - name: Set up Docker
+        id: docker-setup
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Log into Github Container Registry
+        id: login-ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build-and-push-image
+        uses: docker/build-push-action@v6
+        with:
+          context: Frontend
+          target: release
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:${CURRENT_VERSION_TAG}
+
+          # cache settings
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:buildcache,mode=max
+
+  # rest_api
+  build_and_push_frontend:
+    name: Build and Push Frontend
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Log into Github Container Registry
+        id: login-ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build-and-push-image
+        uses: docker/build-push-action@v6
+        with:
+          context: RestAPI
+          target: release
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/rest_api:${CURRENT_VERSION_TAG}
+
+          # cache settings
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/rest_api:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/rest_api:buildcache,mode=max
+
+  # web_socket_server
+  build_and_push_web_socket_server:
+    name: Build and Push Web Socket Server
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Log into Github Container Registry
+        id: login-ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build-and-push-image
+        uses: docker/build-push-action@v6
+        with:
+          context: WebSocketServer
+          target: release
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/web_socket_server:${CURRENT_VERSION_TAG}
+
+          # cache settings
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/web_socket_server:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/web_socket_server:buildcache,mode=max
+
+  build_and_push_reverse_proxy:
+    name: Build and Push Reverse Proxy
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Log into Github Container Registry
+        id: login-ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build-and-push-image
+        uses: docker/build-push-action@v6
+        with:
+          context: ReverseProxy
+          target: release
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/reverse_proxy:${CURRENT_VERSION_TAG}
+
+          # cache settings
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/reverse_proxy:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/reverse_proxy:buildcache,mode=max
+
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    needs:
+      - build_and_push_frontend
+      - build_and_push_frontend
+      - build_and_push_web_socket_server
+      - build_and_push_reverse_proxy
+    env:
+      PRIVATE_KEY_FILE: ${{ runner.temp }}/github-ec2.pem
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Write SSH Key
+        id: write-ssh-key
         run: |
-          echo "${PRIVATE_KEY}" > github-ec2.pem && chmod 400 github-ec2.pem
-          ssh -o StrictHostKeyChecking=no -i github-ec2.pem "${USER}@${HOST}" "
-          eval `ssh-agent -s`
-          if [[ ! -d \"${REPO_DIR}/.git\" ]]
-          then
-            git clone \"${REPO_URL}\" \"${REPO_DIR}\"
-          fi
-          cd \"${REPO_DIR}\"
-          git fetch
-          git checkout \"${TARGET_BRANCH}\"
-          git pull
-          echo \"${ENV_FILE}\" > .env
-          echo \"${SSL_KEY}\" > ReverseProxy/key.pem
-          echo \"${SSL_CERT}\" > ReverseProxy/cert.pem
-          docker compose down
-          docker compose up --build --detach
-          "
-          chmod 600 github-ec2.pem
-          shred -u github-ec2.pem
+          cat > "${PRIVATE_KEY_FILE}" << _EOF_
+          ${{ secrets.EC2_TEST_PRIVATE_KEY }}
+          _EOF_
+          chmod 400 "${PRIVATE_KEY_FILE}"
+
+      - name: Copy docker-compose.yml to remote host
+        id: copy-docker-compose-to-remote-host
+        run: |
+          REMOTE_HOST="${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}"
+          scp -i "${PRIVATE_KEY_FILE}" docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
+
+      - name: Deploy via SSH
+        id: deploy-ssh
+        env:
+          # Enclose entire script to run on remote host here
+          SSH_SCRIPT_FILE: ${{ runner.temp }}/script.sh
+          SSH_SCRIPT: |
+            # === cd to deployment directory ===================================
+            cd ${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}
+
+            # === deploy secret files ==========================================
+            cat > .env << _EOF_
+            ${{ secrets.EC2_TEST_ENV_FILE }}
+            _EOF_
+
+            mkdir -p .secrets
+
+            cat > .secrets/key.pem << _EOF_
+            ${{ secrets.EC2_TEST_SSL_KEY }}
+            _EOF_
+
+            cat > .secrets/cert.pem << _EOF_
+            ${{ secrets.EC2_TEST_SSL_CERT }}
+            _EOF_
+
+            # === Pull images from container registry ==========================
+            # NOTE: Locating container registry depends on contents of .env
+            # (EC2_TEST_ENV_FILE)
+            docker compose pull
+
+            # === Restart containers ===========================================
+            docker compose down
+            docker compose up --detach
+        run: |
+          # Write script to a tempfile
+          printenv SSH_SCRIPT > "${SSH_SCRIPT_FILE}"
+          unset SSH_SCRIPT
+
+          ssh \
+            -i "${PRIVATE_KEY_FILE}" \
+            -o StrictHostKeyChecking=no \
+            "${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}" \
+            bash -e - < "${SSH_SCRIPT_FILE}"

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - master
-      # TODO: only for testing; remove before merge to master
-      - feat/deploy_on_push_to_main
   workflow_call:
     secrets:
       EC2_TEST_PRIVATE_KEY:

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -82,8 +82,8 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ github.repository_id }}/frontend:buildcache,mode=max
 
   # rest_api
-  build_and_push_frontend:
-    name: Build and Push Frontend
+  build_and_push_rest_api:
+    name: Build and Push RestAPI
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -226,16 +226,19 @@ jobs:
       - name: Write SSH Key
         id: write-ssh-key
         run: |
+          eval `ssh-agent -s`
           cat > "${{ runner.temp }}/github-ec2.pem" << _EOF_
           ${{ secrets.EC2_TEST_PRIVATE_KEY }}
           _EOF_
           chmod 400 "${{ runner.temp }}/github-ec2.pem"
+          ssh-keygen -y -f "${{ runner.temp }}/github-ec2.pem" > "${{ runner.temp }}/github-ec2.pem.pub"
+          ssh-add "${{ runner.temp }}/github-ec2.pem"
 
       - name: Copy docker-compose.yml to remote host
         id: copy-docker-compose-to-remote-host
         run: |
           REMOTE_HOST="${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}"
-          scp -i "${{ runner.temp }}/github-ec2.pem" docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
+          scp -v -i "${{ runner.temp }}/github-ec2.pem" docker-compose.yml "${REMOTE_HOST}:${{ secrets.EC2_TEST_DEPLOYMENT_DIR }}"
 
       - name: Deploy via SSH
         id: deploy-ssh
@@ -277,7 +280,7 @@ jobs:
           printenv SSH_SCRIPT > "${{ runner.temp }}/script.sh"
           unset SSH_SCRIPT
 
-          ssh \
+          ssh -v \
             -i "${{ runner.temp }}/github-ec2.pem" \
             -o StrictHostKeyChecking=no \
             "${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}" \

--- a/.github/workflows/ec2_deploy_testing.yml
+++ b/.github/workflows/ec2_deploy_testing.yml
@@ -264,8 +264,12 @@ jobs:
             _EOF_
 
             # === Pull images from container registry ==========================
-            # NOTE: Locating container registry depends on contents of .env
-            # (EC2_TEST_ENV_FILE)
+            export WHITEBOARD_EDITOR_CR_URI="ghcr.io/whiteboard_editor"
+            export WHITEBOARD_EDITOR_TAG="${CURRENT_VERSION_TAG}"
+
+            docker login --username ${{ github.actor }} --password-stdin ghcr.io << _EOF_
+            ${{ secrets.GITHUB_TOKEN }}
+            _EOF_
             docker compose pull
 
             # === Restart containers ===========================================
@@ -280,4 +284,4 @@ jobs:
             -i "${PRIVATE_KEY_FILE}" \
             -o StrictHostKeyChecking=no \
             "${{ secrets.EC2_TEST_USER }}@${{ secrets.EC2_TEST_HOST }}" \
-            bash -e - < "${SSH_SCRIPT_FILE}"
+            CURRENT_VERSION_TAG="${CURRENT_VERSION_TAG}" bash -e - < "${SSH_SCRIPT_FILE}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ node_modules
 # .env file(s)
 .env
 
+# secret files
+.secrets
+
 # Signing certificate and key files
 *.pem
 *.csr

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -15,7 +15,7 @@ RUN \
   npm run build
 
 # ---- Stage 2: Serve with a static web server ----
-FROM nginx:stable-alpine
+FROM nginx:stable-alpine AS release
 
 # Remove default nginx static assets
 RUN rm -rf /usr/share/nginx/html/*

--- a/ReverseProxy/Dockerfile
+++ b/ReverseProxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine
+FROM nginx:stable-alpine AS release
 
 # Copy nginx.conf
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/WebSocketServer/Dockerfile
+++ b/WebSocketServer/Dockerfile
@@ -162,7 +162,7 @@ RUN \
     ${DEST_DIR}/web_socket_server
 
 # ---- Stage: Prepare Release Runtime Environment ----
-FROM debian:trixie-slim AS release_runtime
+FROM debian:trixie-slim AS release
 
 ARG BUILD_DIR
 ARG DEST_DIR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     # Built in Rust.
     build:
       context: WebSocketServer
-      target: release_runtime
+      target: release
       <<: *cache_settings
     image: ${WHITEBOARD_EDITOR_CR_URI-whiteboard_editor}/web_socket_server:${WHITEBOARD_EDITOR_TAG-latest}
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
       WHITEBOARD_EDITOR_WS_PORT: ${WHITEBOARD_EDITOR_WS_PORT-4000}
     volumes:
       - type: bind
-        source: ReverseProxy/key.pem
+        source: .secrets/key.pem
         target: /app/key.pem
       - type: bind
-        source: ReverseProxy/cert.pem
+        source: .secrets/cert.pem
         target: /app/cert.pem
     depends_on:
       - frontend


### PR DESCRIPTION
As part of our CI/CD process, we'll now automatically redeploy our EC2 instance every time we merge a pull request into master. Since we have testing and reviews set up on all pull requests into master, we can reasonably ensure that updates to our instance will be production-ready.

One important change to be aware of is that the ssl key and certificate files (key.pem, cert.pem) have been moved from ReverseProxy to .secrets, which is located directly under the repository root directory (it's included in .gitignore, so no files placed under .secrets should be pushed to Github). Make sure to change the location of key.pem and cert.pem before testing again on your own machine.

- **Moved location of ssl key and certificate files from ReverseProxy to .secrets directory under root of repository.**
- **Final runtime stage of all Dockerfiles is named 'release'**
- **Complete overhaul of 'Deploy EC2 Instance' workflow. Workflow now builds all images within runners, then pushes them to the container registry. SSH script run on remote host now pulls from container registry before running the services, instead of building from the github repository.**
- **Set CURRENT_VERSION_TAG in workflow-scoped env block instead of in environment in ec2_deploy_testing workflow.**
- **ec2_deploy_testing workflow triggers on push to feature branch for testing purposes (TODO: set to master branch only before merge).**
- **Log into github container registry from remote host on deployment to EC2 instance.**
- **Bugfix: properly name build_and_push_rest_api job in Deploy Test EC2 Instance workflow.**
- **Replaced PRIVATE_KEY_FILE env var with raw name of key file in deploy job of Deploy Test EC2 Instance job.**
- **Misc bugfixes around env var parsing in Deploy Test EC2 Instance workflow.**
- **Set proper WHITEBOARD_EDITOR_CR_URI in deployment ssh script in Deploy Test EC2 Instance workflow.**
- **Deploy Test EC2 Instance workflow generates public key, adds key to agent, runs scp and ssh in verbose mode.**
- **Disabled StrictHostKeyChecking in Deploy Test EC2 Instance workflow.**
- **Run ssh deployment script in verbose mode in Deploy Test EC2 Instance workflow.**
- **Added read packages permission to Deploy to EC2 job in Deploy Test EC2 Instance workflow.**
- **Changed web_socket_server target build stage to release (from release_runtime).**
- **Removed feature branch from list of branches that trigger Deploy Test EC2 Instance Workflow.**
