### PR TITLE
Recoverable User Permissions

### DIFF
--- a/Frontend/src/pages/AccountSettings.tsx
+++ b/Frontend/src/pages/AccountSettings.tsx
@@ -13,6 +13,11 @@ import {
 } from "@tanstack/react-form";
 
 import {
+  toast,
+  Bounce,
+} from 'react-toastify';
+
+import {
   useModal,
 } from "@/components/Modal";
 
@@ -81,7 +86,7 @@ export default function AccountSettings() {
         }
       }
     },
-    [api, navigate, locationEncoded]
+    [navigate, locationEncoded, setUser]
   );
 
   const profileForm = useForm({
@@ -120,7 +125,7 @@ export default function AccountSettings() {
         }
       }
     },
-    [api, setUser, navigate, locationEncoded]
+    [setUser, navigate, locationEncoded]
   );
 
   const securityForm = useForm({
@@ -140,14 +145,41 @@ export default function AccountSettings() {
       value: DeleteFormFieldsType,
     }) => {
       try {
-        const res : AxiosResponse<User> = await api.patch("/users/me", {
-          password: value.password
+        const res = await api.request({
+          method: 'delete',
+          url: "/users/me",
+          data: {
+            password: value.password
+         },
         });
 
-        if (res.status === 201) {
+        if (res.status === 200) {
           setUser(null);
           localStorage.removeItem("user");
-          alert("Account deleted successfully");
+          console.log('User account deleted successfully.');
+          toast.success('Account deleted successfully', {
+            position: "bottom-center",
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+            progress: undefined,
+            theme: "colored",
+            transition: Bounce,
+          });
+          navigate('/');
+        } else {
+          console.error(`Account deletion failed ${res.status}:`, res.data);
+          toast.error('Account deletion failed', {
+            position: "bottom-center",
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+            progress: undefined,
+            theme: "colored",
+            transition: Bounce,
+          });
         }
       } catch (err: unknown) {
         const apiErr = err as AxiosError;
@@ -160,7 +192,7 @@ export default function AccountSettings() {
         }
       }
     },
-    [api, setUser, navigate, locationEncoded]
+    [setUser, navigate, locationEncoded]
   );
 
   const deleteForm = useForm({

--- a/Frontend/src/types/APIProtocol.ts
+++ b/Frontend/src/types/APIProtocol.ts
@@ -57,6 +57,7 @@ export const USER_PERMISSION_TYPES = [
 export interface UserPermissionByUser {
   type: 'user';
   user: User;
+  email?: string;
   permission: UserPermissionEnum;
 }
 

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -40,6 +40,7 @@ import {
 } from "../models/User";
 
 import {
+  Whiteboard,
   type IWhiteboardPermissionEnum,
 } from '../models/Whiteboard';
 
@@ -166,44 +167,78 @@ export const handlePatchOwnUser = async (
   req: Request<{}, any, PatchPermanentUserRequest>,
   res: Response
 ) => {
-    const { authUser } = req.body;
-    const patchData: Partial<PatchPermanentUserRequest> = ({ ...req.body });
-    const { id: userId } = authUser;
-    const resp = await getUserById(userId);
-
-    switch (resp.status) {
-        case 'bad_request':
-          return res.status(400).json({ message: resp.message });
-        case 'not_found':
-          return res.status(404).json({ message: `User ${userId} not found` });
-        case 'ok':
-        {
-            const {
-              user,
-            } = resp;
-
-            if (! user) {
-              return res.status(400).json({
-                message: `Could not find user with id ${userId}`
+  const {
+    authUser,
+  } = req.body;
+  const patchData: Partial<PatchPermanentUserRequest> = ({
+    ...req.body
+  });
+  const {
+    id: userId,
+  } = authUser;
+  const resp = await getUserById(userId);
+  
+  switch (resp.status) {
+      case 'bad_request':
+        return res.status(400).json({ message: resp.message });
+      case 'not_found':
+        return res.status(404).json({ message: `User ${userId} not found` });
+      case 'ok':
+      {
+        const {
+          user,
+        } = resp;
+        
+        if (! user) {
+          return res.status(400).json({
+            message: `Could not find user with id ${userId}`
+          });
+        } else if (! isIPermanentUser(user)) {
+          return res.status(400).json({
+            message: `User ${userId} is not permanent`
+          })
+        } else {
+          const origUser = {
+            ...user
+          };
+          delete patchData.authUser;
+          const patchUserRes = await patchUser(user, patchData);
+        
+          if (patchUserRes.type === 'error') {
+            return res.status(400).json({ message: patchUserRes.message });
+          } else {
+            // -- update user permissions if email has been changed
+            if (patchUserRes.data.email !== origUser.email) {
+              const usersWhiteboards = await Whiteboard.find({
+                'user_permissions.user': origUser._id,
               });
-            } else if (!isIPermanentUser(user)) {
-              return res.status(400).json({
-                message: `User ${userId} is not permanent`
-              })
-            } else {
-              delete patchData.authUser;
-              const patchUserRes = await patchUser(user, patchData);
 
-              if (patchUserRes.type === 'error') {
-                return res.status(400).json({ message: patchUserRes.message });
-              } else {
-                return res.status(201).json(patchUserRes.data);
-              }
+              for (const whiteboard of usersWhiteboards) {
+                whiteboard.set(
+                  'user_permissions',
+                  whiteboard.user_permissions.map(perm => {
+                    if ((perm.type === 'user') && (perm.user === origUser._id)) {
+                      return ({
+                        ...perm,
+                        email: patchUserRes.data.email,
+                      });
+                    } else {
+                      return perm;
+                    }
+                  })
+                );
+
+                whiteboard.save();
+              }// -- end for whiteboard
             }
+
+            return res.status(201).json(patchUserRes.data);
+          }
         }
-        default:
-          throw new Error(`Unhandled case: ${resp}`);
-    }
+      }
+      default:
+        throw new Error(`Unhandled case: ${resp}`);
+  }
 };// -- end handlePatchOwnUser
 
 // === DELETE /users/me ========================================================

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -36,6 +36,7 @@ import {
   User,
   type PatchPermanentUserRequest,
   type CreatePermanentUserRequest,
+  type DeletePermanentUserRequest,
   isIPermanentUser,
 } from "../models/User";
 
@@ -245,17 +246,45 @@ export const handlePatchOwnUser = async (
 // 
 // =============================================================================
 export const handleDeleteOwnUser = async (
-  req: Request<{}, any, AuthorizedRequestBody>,
+  req: Request<{}, any, DeletePermanentUserRequest>,
   res: Response
 ) => {
-  const { authUser } = req.body;
-  const { id: userId } = authUser;
+  const {
+    authUser,
+    password,
+  } = req.body;
+  const {
+    id: userId,
+  } = authUser;
+  const user = await User.findOne({
+    '_id': userId,
+  });
+
+  if (! user) {
+    return res.status(404).json({
+      message: 'User not found',
+    });
+  }
+
+  if (user.kind === 'permanent') {
+      // ensure request is authenticated
+      if (! password) {
+        return res.status(400).json({
+          message: 'Password required to delete user',
+        });
+      } else if (! await bcrypt.compare(password, user.passwordHashed)) {
+        return res.status(400).json({
+          message: 'Password incorrect',
+        });
+      }
+  }
+
   const resp = await deleteUser(userId);
 
   if (resp.result === 'err') {
-    res.status(400).json({ message: resp.err });
+    return res.status(400).json({ message: resp.err });
   } else {
-    res.status(200).json(resp.data);
+    return res.status(200).json(resp.data);
   }
 };// -- end handleDeleteOwnUser
 

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -198,9 +198,7 @@ export const handlePatchOwnUser = async (
             message: `User ${userId} is not permanent`
           })
         } else {
-          const origUser = {
-            ...user
-          };
+          const origUser = user.toObject();
           delete patchData.authUser;
           const patchUserRes = await patchUser(user, patchData);
         
@@ -217,9 +215,9 @@ export const handlePatchOwnUser = async (
                 whiteboard.set(
                   'user_permissions',
                   whiteboard.user_permissions.map(perm => {
-                    if ((perm.type === 'user') && (perm.user === origUser._id)) {
+                    if ((perm.type === 'user') && (perm.user.equals(origUser._id))) {
                       return ({
-                        ...perm,
+                        ...perm.toObject(),
                         email: patchUserRes.data.email,
                       });
                     } else {
@@ -228,7 +226,7 @@ export const handlePatchOwnUser = async (
                   })
                 );
 
-                whiteboard.save();
+                await whiteboard.save();
               }// -- end for whiteboard
             }
 

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -304,8 +304,12 @@ export const handleGetSharedWhiteboardsByUser = async (
   const {
     userId,
   } = req.params;
-  const { authUser } = req.body;
-  const { id: authUserId } = authUser;
+  const {
+    authUser,
+  } = req.body;
+  const {
+    id: authUserId,
+  } = authUser;
 
   const targetUserId = (userId === 'me') ?
     authUserId

--- a/RestAPI/src/controllers/whiteboards.ts
+++ b/RestAPI/src/controllers/whiteboards.ts
@@ -139,6 +139,7 @@ export const handleCreateWhiteboard = async (
         return {
           type: 'user',
           user: user._id,
+          email: user.email,
           permission: collaboratorPermissionsByEmail[user.email].permission,
         }
       });

--- a/RestAPI/src/controllers/whiteboards.ts
+++ b/RestAPI/src/controllers/whiteboards.ts
@@ -45,48 +45,56 @@ export const handleGetWhiteboardById = async (
   req: Request<{ whiteboardId: string }, any, AuthorizedRequestBody>,
   res: Response
 ) => {
-    const { authUser } = req.body;
-    const { id: userId } = authUser;
-    const { whiteboardId } = req.params;
-
-    // fetch whiteboard by id
-    const resp = await getWhiteboardById(whiteboardId);
-
-    switch (resp.status) {
-      case 'server_error':
-        return res.status(500).json({ message: 'An unexpected error occurred' });
-      case 'invalid_id':
-        return res.status(400).json({ message: 'Invalid whiteboard id' });
-      case 'not_found':
-        return res.status(404).json({ message: 'Whiteboard not found' });
-      case 'ok':
-      {
-          const { whiteboard } = resp;
-          
-          console.log('Received whiteboard:', JSON.stringify(whiteboard, null, 2));
-
-          const isValidUserPerm = (perm: IWhiteboardUserPermissionModel<IUser>): perm is IWhiteboardUserPermissionById <IUser> => {
-            return (perm.type === 'user') && (!! perm.user);
-          };
-          const validUserIdSet: Record<string, boolean> = Object.fromEntries(
-              whiteboard.user_permissions.filter(perm => isValidUserPerm(perm)).map(perm => [
-              perm.user.id, true 
-            ])
-          );
-
-          if (! (userId.toString() in validUserIdSet)) {
-            return res.status(403).json({
-              message: 'You are not authorized to view this resource'
-            });
-          } else {
-            const wbAttribView = whiteboard.toAttribView();
-
-            return res.status(200).json(wbAttribView);
-          }
-      }
-      default:
-        return res.status(500).json({ message: 'Unexpected error occurred' });
+  const {
+    authUser,
+  } = req.body;
+  const {
+    id: userId,
+  } = authUser;
+  const {
+    whiteboardId,
+  } = req.params;
+  
+  // fetch whiteboard by id
+  const resp = await getWhiteboardById(whiteboardId);
+  
+  switch (resp.status) {
+    case 'server_error':
+      return res.status(500).json({ message: 'An unexpected error occurred' });
+    case 'invalid_id':
+      return res.status(400).json({ message: 'Invalid whiteboard id' });
+    case 'not_found':
+      return res.status(404).json({ message: 'Whiteboard not found' });
+    case 'ok':
+    {
+        const {
+          whiteboard,
+        } = resp;
+        
+        console.log('Received whiteboard:', JSON.stringify(whiteboard, null, 2));
+  
+        const isValidUserPerm = (perm: IWhiteboardUserPermissionModel<IUser>): perm is IWhiteboardUserPermissionById <IUser> => {
+          return (perm.type === 'user') && (!! perm.user);
+        };
+        const validUserIdSet: Record<string, boolean> = Object.fromEntries(
+            whiteboard.user_permissions.filter(perm => isValidUserPerm(perm)).map(perm => [
+            perm.user.id, true 
+          ])
+        );
+  
+        if (! (userId.toString() in validUserIdSet)) {
+          return res.status(403).json({
+            message: 'You are not authorized to view this resource'
+          });
+        } else {
+          const wbAttribView = whiteboard.toAttribView();
+  
+          return res.status(200).json(wbAttribView);
+        }
     }
+    default:
+      return res.status(500).json({ message: 'Unexpected error occurred' });
+  }
 };// -- end handleGetWhiteboardById
 
 export const handleCreateWhiteboard = async (

--- a/RestAPI/src/models/User.ts
+++ b/RestAPI/src/models/User.ts
@@ -18,18 +18,12 @@ import type {
 
 export type UserIdType = Types.ObjectId;
 
-export type UserTypeEnum = 
-  | "permanent"
-  | "temp"
-;
-
 // === IUser ========================================================================
 //  
 // Base user model containing fields shared by all user types in the system.
 // 
 // ==================================================================================
 export interface IUserModel {
-  kind: UserTypeEnum;
   username: string;
 }
 
@@ -65,6 +59,7 @@ export type IUser =
 //
 // ==================================================================================
 export interface IPermanentUserModel extends IUserModel{
+  kind: 'permanent';
   email: string;
 
   // -- sensitive fields: ensure they are omitted from public-facing views
@@ -107,6 +102,7 @@ export type IPermanentUser =
 //
 // ==================================================================================
 export interface ITempUserModel extends IUserModel{
+  kind: 'temp';
   tempExpiresAt: Date;
 }
 
@@ -138,6 +134,10 @@ export type ITempUser =
 ;
 // -- End ITempUser
 
+export type IUserType = 
+  | IPermanentUser
+  | ITempUser
+;
 
 // === REST Request Body Definitions ===========================================
 //
@@ -212,7 +212,7 @@ const tempUserToAttribView = tempUserToPublicView;
 // Defines how user objects are stored/interacted with.
 //
 // =============================================================================
-const userSchema = new Schema<IUser, UserModelType, {}, {}, IUserVirtual>(
+const userSchema = new Schema<IUserType, UserModelType, {}, {}, IUserVirtual>(
   // -- fields
   {
     kind: { type: String, enum: ['permanent', 'temp'], required: true },
@@ -340,12 +340,7 @@ userSchema.virtual('id').get(function() {
 });
 
 // -- User Model
-export const User = model<IUser>("User", userSchema, "users");
-
-export type IUserType = 
-  | IPermanentUser
-  | ITempUser
-;
+export const User = model<IUserType>("User", userSchema, "users");
 
 export const isIPermanentUser = (user: IUserType): user is IPermanentUser => {
   return user.kind === 'permanent';

--- a/RestAPI/src/models/User.ts
+++ b/RestAPI/src/models/User.ts
@@ -164,8 +164,7 @@ export type PutPermanentUserRequest = AuthorizedRequestBody & PutPermanentUserDa
 // -- for DELETE
 export interface DeletePermanentUserData {
   // requires additional password confirmation
-  id: Types.ObjectId;
-  password: string;
+  password?: string;
 }
 
 export type DeletePermanentUserRequest = AuthorizedRequestBody & DeletePermanentUserData;

--- a/RestAPI/src/models/Whiteboard.ts
+++ b/RestAPI/src/models/Whiteboard.ts
@@ -538,8 +538,6 @@ sharedUsersArraySchema?.discriminator('user', new Schema<IWhiteboardUserPermissi
           ...fields
         } = obj;
 
-        console.log('!! perm (toAttribView):', this);// TODO: remove debug
-
         return ({
           ...fields,
           user: (this as unknown as IWhiteboardUserPermissionById<IUser>).user.toAttribView(),

--- a/RestAPI/src/models/Whiteboard.ts
+++ b/RestAPI/src/models/Whiteboard.ts
@@ -321,6 +321,7 @@ export interface IWhiteboardUserPermissionBase {
 export interface IWhiteboardUserPermissionById <UserType> extends IWhiteboardUserPermissionBase {
   type: 'user';
   user: UserType;
+  email?: string;
 }
 
 export interface IWhiteboardUserPermissionByEmail extends IWhiteboardUserPermissionBase {
@@ -508,6 +509,7 @@ const sharedUsersArraySchema = whiteboardSchema.path('user_permissions').schema;
 sharedUsersArraySchema?.discriminator('user', new Schema<IWhiteboardUserPermissionById<Types.ObjectId>>(
   {
     user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    email: { type: Schema.Types.String, required: false },
   },
   {
     // -- serialization options

--- a/RestAPI/src/services/userService.ts
+++ b/RestAPI/src/services/userService.ts
@@ -14,6 +14,7 @@ import {
   User,
   PatchPermanentUserData,
   type IUserPublicView,
+  type IPermanentUserPublicView,
   type IUserType,
   IPermanentUser,
 } from "../models/User";
@@ -52,19 +53,19 @@ export const getUserById = async (userId: Types.ObjectId): Promise<GetUserByIdRe
   }
 };// end getUser
 
-export interface PatchUserOkResult {
+export interface PatchPermanentUserOkResult {
   type: 'ok';
-  data: IUserPublicView;
+  data: IPermanentUserPublicView;
 }
 
-export interface PatchUserErrorResult {
+export interface PatchPermanentUserErrorResult {
   type: 'error';
   message: string;
 }
 
-export type PatchUserResult = PatchUserOkResult | PatchUserErrorResult;
+export type PatchPermanentUserResult = PatchPermanentUserOkResult | PatchPermanentUserErrorResult;
 
-export const patchUser = async (user: IPermanentUser, patchData: PatchPermanentUserData): Promise<PatchUserResult> => {
+export const patchUser = async (user: IPermanentUser, patchData: PatchPermanentUserData): Promise<PatchPermanentUserResult> => {
   try {
     const patchDataLocal = { ...patchData };
     const passwordHashed = patchDataLocal.password ? 

--- a/RestAPI/src/services/userService.ts
+++ b/RestAPI/src/services/userService.ts
@@ -139,6 +139,16 @@ export const getSharedWhiteboardsByUser = async (
       });
     }
 
+    const user = await User.findOne({
+      '_id': userId,
+    });
+
+    if (! user) {
+      return {
+        status: 'user_not_found',
+      };
+    }
+
     const permissionsFilter : object = (() => {
       switch (includePermissionOpts.type) {
         case 'all':
@@ -152,14 +162,33 @@ export const getSharedWhiteboardsByUser = async (
       }
     })();
 
-    const query = ({
-      user_permissions: {
+    const userQuery = (user.kind === 'permanent') ?
+      {
+        '$elemMatch': {
+          '$or': [
+            {
+              type: 'user',
+              user: userId,
+              permission: permissionsFilter,
+            },
+            {
+              type: 'email',
+              email: user.email,
+              permission: permissionsFilter,
+            },
+          ],
+        },
+      }
+      : {
         '$elemMatch': {
           type: 'user',
           user: userId,
           permission: permissionsFilter
         }
-      }
+      };
+
+    const query = ({
+      user_permissions: userQuery,
     });
 
     const whiteboards = await Whiteboard.findAttribs(query);

--- a/RestAPI/src/services/userService.ts
+++ b/RestAPI/src/services/userService.ts
@@ -172,7 +172,6 @@ export const getSharedWhiteboardsByUser = async (
               permission: permissionsFilter,
             },
             {
-              type: 'email',
               email: user.email,
               permission: permissionsFilter,
             },

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -136,10 +136,27 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
 };// -- end getWhiteboardById
 
 export const getWhiteboardsByOwner = async (ownerId: Types.ObjectId): Promise<IWhiteboardAttribView[]> => {
+  const owner = await User.findOne({
+    '_id': ownerId,
+  });
+
+  if (! owner) {
+    return [] as IWhiteboardAttribView[];
+  }
+
+  const userIdQueries = (owner.kind === 'permanent') ?
+    [
+      { user: ownerId, },
+      { email: owner.email, },
+    ]
+    : [
+      { user: ownerId, },
+    ];
+
   const query = {
     user_permissions: {
       '$elemMatch': {
-        user: ownerId,
+        '$or': userIdQueries,
         permission: 'own',
       },
     },

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -64,12 +64,14 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
       // permissions
       let haveSharedUsersChanged = false;
       const sharedUsers: IWhiteboardUserPermissionModel<Types.ObjectId>[] = await Promise.all(whiteboard.user_permissions
-          .filter(perm => (perm.type !== 'user') || ((!! perm.user) && ((!! perm.user._id) || (!! perm.email))))
+          .filter(perm => (perm.email) || (perm.type === 'user' && perm.user && perm.user._id))
           .map(async perm => {
         switch (perm.type) {
           case 'user':
             if (((! perm.user) || (! perm.user._id)) && perm.email) {
               // transform back into an email-type permission
+              haveSharedUsersChanged = true;
+
               return ({
                   type: 'email',
                   email: perm.email,

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -64,15 +64,25 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
       // permissions
       let haveSharedUsersChanged = false;
       const sharedUsers: IWhiteboardUserPermissionModel<Types.ObjectId>[] = await Promise.all(whiteboard.user_permissions
-          .filter(perm => (perm.type !== 'user') || ((!! perm.user) && (!! perm.user._id)))
+          .filter(perm => (perm.type !== 'user') || ((!! perm.user) && ((!! perm.user._id) || (!! perm.email))))
           .map(async perm => {
         switch (perm.type) {
           case 'user':
-            return ({
-              type: 'user',
-              user: perm.user._id,
-              permission: perm.permission,
-            }) ;
+            if (((! perm.user) || (! perm.user._id)) && perm.email) {
+              // transform back into an email-type permission
+              return ({
+                  type: 'email',
+                  email: perm.email,
+                  permission: perm.permission,
+              });
+            } else {
+              return ({
+                type: 'user',
+                user: perm.user._id,
+                email: perm.email,
+                permission: perm.permission,
+              }) ;
+            }
           case 'email':
             // check if this email now belongs to a registered user
             const user = await User.findOne({ email: perm.email });
@@ -84,6 +94,7 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
               return ({
                 type: 'user',
                 user: user._id,
+                email: perm.email,
                 permission: perm.permission,
               });
             } else {

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -269,6 +269,7 @@ export const setSharedUsers = async (
       return {
         type: 'user',
         user: user._id,
+        email: user.email,
         permission: emailsToPermissions[user.email].permission,
       }
     });

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -70,6 +70,7 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
           case 'user':
             if (((! perm.user) || (! perm.user._id)) && perm.email) {
               const user = await User.findOne({
+                kind: 'permanent',
                 email: perm.email,
               });
 
@@ -101,8 +102,10 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
             }
           case 'email':
             // check if this email now belongs to a registered user
-            const user = await User.findOne({ email: perm.email });
-            console.log('!! Found email-identified user:', user);
+            const user = await User.findOne({
+              kind: 'permanent',
+              email: perm.email
+            });
 
             if (user) {
               haveSharedUsersChanged = true;

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -69,21 +69,35 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
         switch (perm.type) {
           case 'user':
             if (((! perm.user) || (! perm.user._id)) && perm.email) {
-              // transform back into an email-type permission
+              const user = await User.findOne({
+                email: perm.email,
+              });
+
               haveSharedUsersChanged = true;
 
-              return ({
-                  type: 'email',
+              if (! user) {
+                // transform back into an email-type permission
+                return ({
+                    type: 'email',
+                    email: perm.email,
+                    permission: perm.permission,
+                });
+              } else {
+                // replace with new user document
+                return ({
+                  type: 'user',
+                  user: user._id,
                   email: perm.email,
                   permission: perm.permission,
-              });
+                });
+              }
             } else {
               return ({
                 type: 'user',
                 user: perm.user._id,
                 email: perm.email,
                 permission: perm.permission,
-              }) ;
+              });
             }
           case 'email':
             // check if this email now belongs to a registered user

--- a/RestAPI/tests/users.test.ts
+++ b/RestAPI/tests/users.test.ts
@@ -1,8 +1,22 @@
 import request from "supertest";
 import app from "../src/app";
-import mongoose from 'mongoose';
+import {
+  type IWhiteboard,
+} from '../src/models/Whiteboard';
+import mongoose, {
+  Types,
+} from 'mongoose';
+import jwt from "jsonwebtoken";
 
 const MONGO_URI = 'mongodb://test_db:27017/testdb';
+
+const {
+  JWT_SECRET,
+} = process.env;
+
+if (! JWT_SECRET) {
+  throw new Error('JWT_SECRET not defined in process environment');
+}
 
 // handle database connection
 const connectToDatabase = async () => {
@@ -74,4 +88,105 @@ describe("Users API", () => {
     expect(new Date (res.body.user.tempExpiresAt) >= minExpirationDTime).toBe(true);
     expect(new Date (res.body.user.tempExpiresAt) <= maxExpirationDTime).toBe(true);
   });
+
+  // Update whiteboard permissions when a user's email is changed by a PATCH
+  // request
+  it(
+    "should update the email address in a user's whiteboard permissions if their email address is updated by a PATCH request",
+    async () => {
+      const userCollection = mongoose.connection.collection('users');
+      const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+      const username = 'frank';
+      const user = await userCollection.findOne({
+        username,
+      });
+
+      // to please TypeScript
+      if (! user) {
+        throw new Error('Expected to fetch test user');
+      }
+
+      const whiteboardsOrigCursor = whiteboardCollection.find({
+        'user_permissions.user': user._id
+      });
+
+      if (! whiteboardsOrigCursor) {
+        throw new Error('No (unpatched) whiteboards could be fetched from database');
+      }
+
+      const whiteboardsOrig = await whiteboardsOrigCursor.toArray();
+
+      if (whiteboardsOrig.length < 1) {
+        throw new Error('No (unpatched) whiteboards were fetched from database');
+      }
+
+      // Generate signed JWT
+      const authToken = jwt.sign(
+        { sub: user._id.toHexString() },   // sub = subject claim
+        JWT_SECRET,
+        { expiresIn: 999999999 }
+      );
+
+      const targetUrl = `/api/v1/users/me`;
+      const newEmail = "newfrank@example.edu";
+      const patchData = {
+        password: "weakpassword",
+        email: newEmail,
+      };
+
+      // -- Perform patch
+      const resp = await request(app)
+        .patch(targetUrl)
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(patchData)
+        .expect(201);
+
+      expect(resp.body).toHaveProperty('email');
+      expect(resp.body.email).toBe(newEmail);
+
+      // Ensure user was properly updated by patch
+      const userPatched = await userCollection.findOne({
+        username,
+      });
+      expect(userPatched).not.toBeNull();
+      // to please TypeScript
+      if (! userPatched) {
+        throw new Error('Patched user expected to have email');
+      }
+      expect(userPatched.email).toBe(newEmail);
+
+      // Ensure all the user's whiteboard permissions have had their permissions
+      // updated
+      const whiteboardsPatchedCursor = whiteboardCollection.find({
+        'user_permissions.user': user._id
+      });
+
+      if (! whiteboardsPatchedCursor) {
+        throw new Error('No (patched) whiteboards fetched from database');
+      }
+
+      const whiteboardsPatched = await whiteboardsPatchedCursor.toArray() as IWhiteboard<Types.ObjectId, Types.ObjectId>[];
+
+      if (whiteboardsPatched.length < 1) {
+        throw new Error('No (patched) whiteboards were fetched from database');
+      }
+
+      console.log('!! WHITEBOARDS ORIG:', JSON.stringify(whiteboardsOrig, null, 2));// TODO: remove debug
+      console.log('!! WHITEBOARDS PATCHED:', JSON.stringify(whiteboardsPatched, null, 2));// TODO: remove debug
+      expect(whiteboardsPatched.length).toBe(whiteboardsOrig.length);
+
+      for (const whiteboard of whiteboardsPatched) {
+        const userPerm = whiteboard.user_permissions.find(perm => perm.type === 'user' && perm.user.equals(user._id));
+
+        if (! userPerm) {
+          throw new Error(
+            `Could not find user permission for user ${user._id} on whiteboard ${whiteboard._id}`
+          );
+        }
+
+        expect(userPerm.email).toBe(newEmail);
+      }// -- end for whiteboard
+    }
+  );
 });

--- a/RestAPI/tests/whiteboards.test.ts
+++ b/RestAPI/tests/whiteboards.test.ts
@@ -1,17 +1,20 @@
 import request from "supertest";
 import app from "../src/app";
-import mongoose from 'mongoose';
+import mongoose, {
+  Types,
+} from 'mongoose';
 import jwt from "jsonwebtoken";
 
 // -- imports from models
-import type {
-  IUser,
+import {
+  type IUser,
 } from '../src/models/User';
 
-import type {
-  IWhiteboardAttribView,
-  IWhiteboardUserPermission,
-  IWhiteboardUserPermissionModel,
+import {
+  type IWhiteboard,
+  type IWhiteboardAttribView,
+  type IWhiteboardUserPermission,
+  type IWhiteboardUserPermissionModel,
 } from '../src/models/Whiteboard';
 
 const MONGO_URI = 'mongodb://test_db:27017/testdb';
@@ -884,4 +887,79 @@ describe("Whiteboards API", () => {
     // Ensure the deletion didn't propagate to the database
     expect(await whiteboardCollection.findOne({ _id: whiteboardId })).not.toBeNull();
   });// -- end test case
+
+  it(
+    'should transform user-type permissions back into email-type permissions if the referenced user cannot be found in the database',
+    async () => {
+      const userCollection = mongoose.connection.collection('users');
+      const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+      const ownerName = 'eve';
+      const owner = await userCollection.findOne({
+        username: ownerName,
+      });
+
+      if (! owner) {
+        throw new Error(`Could not find owner named "${ownerName}"`);
+      }
+
+      const whiteboardName = "Project Theta";
+      const whiteboardOrig = await whiteboardCollection.findOne({
+        name: whiteboardName,
+      }) as IWhiteboard<Types.ObjectId, Types.ObjectId>;
+
+      if (! whiteboardOrig) {
+        throw new Error(`Could not find whiteboard "${whiteboardName}"`);
+      }
+
+      const deletedUserEmail = 'substitute@example.com';
+
+      // ensure that we start with two user-type permissions
+      expect(whiteboardOrig.user_permissions.filter(perm => perm.type === 'user').length)
+        .toBe(2);
+
+      // perform GET /whiteboards/:id
+
+      // Generate signed JWT
+      const authToken = jwt.sign(
+        { sub: owner._id.toHexString() },   // sub = subject claim
+        JWT_SECRET,
+        { expiresIn: 999999999 }
+      );
+
+      const resp = await request(app)
+        .get(`/api/v1/whiteboards/${whiteboardOrig._id.toHexString()}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .send()
+        .expect(200);
+
+      // ensure permissions are set correctly in the response body
+      expect(resp.body).toHaveProperty('user_permissions');
+      expect(resp.body.user_permissions.length).toBe(2);
+      expect(resp.body.user_permissions
+        .filter((perm: IWhiteboardUserPermission<Types.ObjectId>) => perm.type === 'email').length)
+        .toBe(1);
+
+      // ensure permissions were properly written back to database
+      const whiteboardUpdated = await whiteboardCollection.findOne({
+        name: whiteboardName,
+      }) as IWhiteboard<Types.ObjectId, Types.ObjectId>;
+
+      if (! whiteboardUpdated) {
+        throw new Error(`Could not find whiteboard "${whiteboardName}"`);
+      }
+
+      expect(whiteboardUpdated).toHaveProperty('user_permissions');
+      expect(whiteboardUpdated.user_permissions.length).toBe(2);
+      expect(whiteboardUpdated.user_permissions
+        .filter((perm: IWhiteboardUserPermission<Types.ObjectId>) => perm.type === 'email').length)
+        .toBe(1);
+      expect(whiteboardUpdated.user_permissions
+        .find((perm: IWhiteboardUserPermission<Types.ObjectId>) => perm.type === 'email'))
+        .not.toBeNull();
+      expect(whiteboardUpdated.user_permissions
+        .find((perm: IWhiteboardUserPermission<Types.ObjectId>) => perm.type === 'email')?.email)
+        .toBe(deletedUserEmail);
+    }
+  );
 });

--- a/TestDatabase/init-db.js
+++ b/TestDatabase/init-db.js
@@ -217,6 +217,7 @@ const whiteboards = [
       {
         type: 'user',
         user: new ObjectId('68d5e8cf829da666aece0101'),  // Alice
+        email: "alice@example.com",
         permission: 'own',
       }
     ],
@@ -230,6 +231,7 @@ const whiteboards = [
       {
         type: 'user',
         user: new ObjectId('68d5e8d4829da666aece0102'), // Bob
+        email: "bob@example.com",
         permission: 'own',
       }
     ],
@@ -243,11 +245,13 @@ const whiteboards = [
       {
         type: 'user',
         user: new ObjectId('68d5e8d4829da666aece0103'), // Carol
+        email: "carol@example.com",
         permission: 'own',
       },
       {
         type: 'user',
         user: new ObjectId('68d5e8cf829da666aece0101'),  // Alice
+        email: "alice@example.com",
         permission: 'edit',
       },
     ],
@@ -261,11 +265,13 @@ const whiteboards = [
       {
         type: 'user',
         user: new ObjectId('68d5e8d4829da666aece0103'), // Carol
+        email: "carol@example.com",
         permission: 'own',
       },
       {
         type: 'user',
         user: new ObjectId('68d5e8cf829da666aece01ff'),  // Non-existent user
+        email: "nobody@example.com",
         permission: 'edit',
       },
     ],

--- a/TestDatabase/init-db.js
+++ b/TestDatabase/init-db.js
@@ -202,6 +202,16 @@ const canvases = [
     // null allowed_users = all users allowed
     // allowed_users: [],
   },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece020b'),
+    width: 3000,
+    height: 3000,
+    name: "Canvas Theta",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+  },
 ];
 
 db.canvases.insertMany(canvases);
@@ -309,7 +319,6 @@ const whiteboards = [
       {
         type: 'user',
         user: new ObjectId('68d5e8cf829da666aece01ff'),  // Non-existent user
-        email: "nobody@example.com",
         permission: 'edit',
       },
     ],
@@ -365,6 +374,26 @@ const whiteboards = [
         user: new ObjectId('68d5e8d4829da666aece0106'), // Frank
         email: "frank@example.com",
         permission: 'view',
+      },
+    ],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0407'),
+    name: "Project Theta",
+    time_created: new Date("2025-08-02T12:10:00.000Z"),
+    root_canvas: new ObjectId('68d5e8d4829da666aece020b'),
+    user_permissions: [
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0105'), // Eve
+        email: "eve@example.com",
+        permission: 'own',
+      },
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aeceeeee'), // Non-existent (i.e. deleted) user
+        email: "substitute@example.com",
+        permission: 'edit',
       },
     ],
   },

--- a/TestDatabase/init-db.js
+++ b/TestDatabase/init-db.js
@@ -51,6 +51,14 @@ const users = [
     // password: weakpassword
     passwordHashed: "$2b$10$ihPYYk6dgK/OwTMkBOnlXe9UDcSHNvYSWQe5N0oM11TPwle7EJrH2",
   },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0106'),
+    kind: "permanent",
+    username: "frank",
+    email: "frank@example.com",
+    // password: weakpassword
+    passwordHashed: "$2b$10$ihPYYk6dgK/OwTMkBOnlXe9UDcSHNvYSWQe5N0oM11TPwle7EJrH2",
+  },
 ];
 
 db.users.insertMany(users);
@@ -159,6 +167,36 @@ const canvases = [
     width: 3000,
     height: 3000,
     name: "Canvas Delta",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0208'),
+    width: 3000,
+    height: 3000,
+    name: "Canvas Epsilon",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0209'),
+    width: 3000,
+    height: 3000,
+    name: "Canvas Zeta",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece020a'),
+    width: 3000,
+    height: 3000,
+    name: "Canvas Eta",
     time_created: new Date("2025-08-01T12:10:00.000Z"),
     time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
     // null allowed_users = all users allowed
@@ -273,6 +311,60 @@ const whiteboards = [
         user: new ObjectId('68d5e8cf829da666aece01ff'),  // Non-existent user
         email: "nobody@example.com",
         permission: 'edit',
+      },
+    ],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0404'),
+    name: "Project Epsilon",
+    time_created: new Date("2025-08-02T12:10:00.000Z"),
+    root_canvas: new ObjectId('68d5e8d4829da666aece0208'),
+    user_permissions: [
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0106'), // Frank
+        email: "frank@example.com",
+        permission: 'own',
+      },
+    ],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0405'),
+    name: "Project Zeta",
+    time_created: new Date("2025-08-02T12:10:00.000Z"),
+    root_canvas: new ObjectId('68d5e8d4829da666aece0209'),
+    user_permissions: [
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0105'), // Eve
+        email: "eve@example.com",
+        permission: 'own',
+      },
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0106'), // Frank
+        email: "frank@example.com",
+        permission: 'edit',
+      },
+    ],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0406'),
+    name: "Project Eta",
+    time_created: new Date("2025-08-02T12:10:00.000Z"),
+    root_canvas: new ObjectId('68d5e8d4829da666aece020a'),
+    user_permissions: [
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0105'), // Eve
+        email: "eve@example.com",
+        permission: 'own',
+      },
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0106'), // Frank
+        email: "frank@example.com",
+        permission: 'view',
       },
     ],
   },

--- a/WebSocketServer/src/lib.rs
+++ b/WebSocketServer/src/lib.rs
@@ -559,8 +559,13 @@ pub enum WhiteboardPermissionEnum {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase", rename_all_fields = "snake_case")]
 pub enum WhiteboardPermissionType {
-    User { user: ObjectId },
-    Email { email: String },
+    User {
+        user: ObjectId,
+        email: Option<String>,
+    },
+    Email {
+        email: String,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -712,7 +717,7 @@ impl WhiteboardMetadataMongoDBView {
             user_permissions: self.user_permissions.clone(),
             permissions_by_user_id: self.user_permissions.iter()
                 .map(|wb_perm| match wb_perm.permission_type {
-                    WhiteboardPermissionType::User { ref user} => Some((user.to_string(), wb_perm.permission)),
+                    WhiteboardPermissionType::User { ref user, .. } => Some((user.to_string(), wb_perm.permission)),
                     _ => None
                 })
                 .filter(|x| x.is_some())

--- a/WebSocketServer/src/unit_tests.rs
+++ b/WebSocketServer/src/unit_tests.rs
@@ -573,6 +573,7 @@ mod unit_tests {
                     WhiteboardPermission {
                         permission_type: WhiteboardPermissionType::User {
                             user: target_uid,
+                            email: Some(String::from("bob@example.com")),
                         },
                         permission: WhiteboardPermissionEnum::Edit,
                     },
@@ -722,6 +723,7 @@ mod unit_tests {
                     WhiteboardPermission {
                         permission_type: WhiteboardPermissionType::User {
                             user: test_user_id,
+                            email: None,
                         },
                         permission: WhiteboardPermissionEnum::Edit,
                     },


### PR DESCRIPTION
Implemented redundantly storing email addresses in user permissions so they can be recovered if a user's account is deleted.

To test this functionality:
- Create a new user account
- Log into an older account, give the new account some permissions on a
whiteboard
- Log into the new account, make sure the whiteboard is accessible
- Delete the new account
- Recreate the new account using the same email address
- Make sure the whiteboard is still accessible and visible on the dashboard

- **Added optional email (string) field to user id-type whiteboard permissions.**
- **GET /whiteboards/:id endpoint controller turns user id-type whiteboard permissions back into email-type permissions if the associated user has been deleted and an email address is attached to the permission.**
- **PATCH /users/:id endpoint updates user's whiteboard permissions if their email address changes.**
- **Misc bugfixes in transformation of user permissions in PATCH /users/:id controller. Function also waits for each whiteboard to save before returning.**
- **Added RestAPI test case to ensure PATCH /users/:id correctly updates emails in user permissions.**
- **Fixed transformation of user permissions back into email permissions in getWhiteboardById service function.**
- **getSharedWhiteboardsByUser, getWhiteboardsByOwner service functions in RestAPI refactored to query for permissions using email as well as the user's object ID.**
- **Properly implemented DELETE /users/me endpoing, as well as the call to it from the AccountSettings form.**
