### PR TITLE
bugfix/draw vectors on deeply nested canvases

### DIFF
--- a/Frontend/src/dispatchers/useVectorDispatcher.tsx
+++ b/Frontend/src/dispatchers/useVectorDispatcher.tsx
@@ -36,46 +36,41 @@ const useVectorDispatcher = ({
   const [mouseCoords, setMouseCoords] = useState<EventCoords | null>(null);
 
   const handlePointerDown = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    const { x: targetX, y: targetY } = ev.currentTarget.getPosition();
-    const { offsetX, offsetY } = ev.evt;
+    const pos = ev.currentTarget.getRelativePointerPosition();
 
-    setMouseDownCoords({
-      x: offsetX - targetX,
-      y: offsetY - targetY
-    });
-    setMouseCoords({
-      x: offsetX - targetX,
-      y: offsetY - targetY
-    });
+    if (pos) {
+      const { x, y } = pos;
 
-    if (onStartEditing) {
-      onStartEditing();
+      setMouseDownCoords({ x, y });
+      setMouseCoords({ x, y });
+
+      if (onStartEditing) {
+        onStartEditing();
+      }
     }
   };
 
   const handlePointerMove = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    const { x: targetX, y: targetY } = ev.currentTarget.getPosition();
-    const { offsetX, offsetY } = ev.evt;
+    const pos = ev.currentTarget.getRelativePointerPosition();
 
-    setMouseCoords({
-      x: offsetX - targetX,
-      y: offsetY - targetY
-    });
+    if (pos) {
+      const { x, y } = pos;
+
+      setMouseCoords({ x, y });
+    }
   };
 
   const handlePointerUp = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    if (mouseDownCoords !== null) {
-      const { x: targetX, y: targetY } = ev.currentTarget.getPosition();
-      const { offsetX, offsetY } = ev.evt;
-      const { x: xB, y: yB } = mouseDownCoords;
+    const pos = ev.currentTarget.getRelativePointerPosition();
 
-      const xA = offsetX - targetX;
-      const yA = offsetY - targetY;
+    if (pos && mouseDownCoords) {
+      const { x: xA, y: yA } = pos;
+      const { x: xB, y: yB } = mouseDownCoords;
 
       addShapes([{
         type: 'vector',
         ...shapeAttributes,
-        points: [xB, yB, xA, yA]
+        points: [xA, yA, xB, yB]
       }]);
       setMouseDownCoords(null);
     }

--- a/WebSocketServer/Dockerfile
+++ b/WebSocketServer/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_DIR=/build
 ARG DEST_DIR=/app
 
 # ---- Stage 1: Dependency planner (cargo-chef) ----
-FROM rust:1.88 AS planner
+FROM rust:1.95 AS planner
 
 ARG BUILD_DIR
 ARG DEST_DIR
@@ -31,7 +31,7 @@ RUN \
   cargo chef prepare --recipe-path recipe.json
 
 # ---- Stage: Test Builder ----
-FROM rust:1.88 AS build_tests
+FROM rust:1.95 AS build_tests
 
 ARG BUILD_DIR
 ARG DEST_DIR
@@ -87,7 +87,7 @@ cargo test --no-run
 _EOF_
 
 # ---- Stage: Prepare Test Runtime Environment ----
-FROM rust:1.88 AS test_runtime
+FROM rust:1.95 AS test_runtime
 
 ARG BUILD_DIR
 ARG DEST_DIR
@@ -113,7 +113,7 @@ EOF
 ENTRYPOINT ["cargo", "test"]
 
 # ---- Stage: Build Release Binary ----
-FROM rust:1.88 AS build_release
+FROM rust:1.95 AS build_release
 
 ARG BUILD_DIR
 ARG DEST_DIR


### PR DESCRIPTION
Fixed bug preventing drawing vectors on deeply nested canvases by using relative
positions in the event handlers in the Vector dispatcher.

- **Updated rust version to 1.95 from 1.88 in WebSocketServer Dockerfile.**
- **Fixed bug preventing drawing vectors on deeply nested canvases by using relative positions in Vector dispatcher.**
