### PR TITLE
Only allow whiteboard owners to change canvas allowed users

### DIFF
--- a/Frontend/src/components/CanvasMenu.tsx
+++ b/Frontend/src/components/CanvasMenu.tsx
@@ -217,7 +217,9 @@ const CanvasMenu = ({
         <DropdownMenuContent className="w-48">
         
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger
+              className="hover:cursor-pointer"
+            >
               Allowed Users
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>

--- a/Frontend/src/components/CanvasMenu.tsx
+++ b/Frontend/src/components/CanvasMenu.tsx
@@ -83,7 +83,7 @@ const CanvasMenu = ({
   whiteboardId,
   allowedUsernames,
 }: CanvasMenuProps) => {
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [allowedUsersMenuOpen, setAllowedUsersMenuOpen] = useState(false);
   const allowedUsers = useSelector((state: RootState) =>
     selectAllowedUsersByCanvas(state, canvasId)
   ) ?? [];
@@ -97,6 +97,7 @@ const CanvasMenu = ({
   }
 
   const { 
+    ownPermission,
     canvasGroupRefsByIdRef,
   } = whiteboardContext;
 
@@ -220,14 +221,20 @@ const CanvasMenu = ({
               Allowed Users
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
-              <DropdownMenuItem 
-                className="flex justify-center" 
-                onSelect={() => setDialogOpen(true)}
-              >
-                Edit
-                <SquarePen/>
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
+              {
+                (ownPermission === 'own') && (
+                  <>
+                    <DropdownMenuItem 
+                      className="flex justify-center" 
+                      onSelect={() => setAllowedUsersMenuOpen(true)}
+                    >
+                      Edit
+                      <SquarePen/>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                )
+              }
               {allowedUsernames.map((u) => (
                 <DropdownMenuLabel key={u}>
                   {u}
@@ -260,7 +267,7 @@ const CanvasMenu = ({
       </DropdownMenu>
 
       {/* Edit Users Modal */}
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog open={allowedUsersMenuOpen} onOpenChange={setAllowedUsersMenuOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Edit Allowed Users</DialogTitle>
@@ -274,13 +281,13 @@ const CanvasMenu = ({
           <div className="flex justify-end gap-2 pt-4">
             <Button variant="secondary" onClick={() => {
               setSelectedUsers(allowedUsers); // Reset to original selection
-              setDialogOpen(false);
+              setAllowedUsersMenuOpen(false);
             }}>
               Cancel
             </Button>
             <Button onClick={() => {
               handleUpdateAllowedUsers(selectedUsers);
-              setDialogOpen(false);
+              setAllowedUsersMenuOpen(false);
             }}>
               Save
             </Button>

--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -19,6 +19,11 @@ import {
   useParams,
 } from 'react-router-dom';
 
+import {
+  Bounce,
+  toast,
+} from 'react-toastify';
+
 // -- local imports
 import {
   CURRENT_EDITOR_NUM_MILLIS,
@@ -304,45 +309,78 @@ const WebSocketClientMessengerProvider = ({
           case 'individual_error':
           case 'broadcast_error':
             {
-              const { error } = msg;
+              const {
+                error,
+              } = msg;
+
+              // -- A user-friendly error message to display in a popup
+              // notification
+              let popupErrorMsg : string;
 
               switch (error.type) {
                 case 'invalid_message':
                   console.error('Socket error: invalid message:', error.clientMessageRaw);
+                  // This is a low-level error, which implies that the client
+                  // was programmed incorrectly (i.e. programmer error, not user
+                  // error). We should indicate to the user that the app
+                  // encountered an error and direct them to the information they
+                  // need to submit an error report.
+                  popupErrorMsg = 'ERROR: app sent an invalid message to the server. See console logs for details';
                   break;
                 case 'unauthorized':
                   console.error('Socket error: not authorized to view this whiteboard');
+                  popupErrorMsg = 'You are not authorized to view this whiteboard';
                   break;
                 case 'not_authenticated':
                   console.error('Socket error: client not authenticated');
+                  popupErrorMsg = 'You are not currently logged in';
                   break;
                 case 'already_authorized':
                   console.error('Socket error: client cannot authenticate again');
+                  popupErrorMsg = 'You are already logged in';
                   break;
                 case 'invalid_auth':
                   console.error('Socket error: auth token invalid');
+                  popupErrorMsg = 'Your authentication token is invalid';
                   break;
                 case 'auth_token_expired':
                   console.error('Socket error: auth token expired');
+                  popupErrorMsg = 'Your login session has expired';
                   break;
                 case 'user_not_found':
                   console.error(`Socket error: user ${error.userId} not found`);
+                  popupErrorMsg = `User ${error.userId} not found`;
                   break;
                 case 'whiteboard_not_found':
                   console.error(`Socket error: whiteboard ${error.whiteboardId} not found`);
+                  popupErrorMsg = `Whiteboard ${error.whiteboardId} not found`;
                   break;
                 case 'canvas_not_found':
                   console.error(`Socket error: canvas ${error.canvasId} not found`);
+                  popupErrorMsg = `Canvas ${error.canvasId} not found`;
                   break;
                 case 'action_forbidden':
                   console.error(`Socket error: action ${error.action} not permitted`);
+                  popupErrorMsg = `You are not authorized to ${error.action}`;
                   break;
                 case 'other':
                   console.error('Socket error:', error.message);
+                  popupErrorMsg = error.message;
                   break;
                 default:
                   throw new Error(`Unrecognized error: ${JSON.stringify(error, null, 2)}`);
               }// -- end switch (error.type)
+
+              toast.error(popupErrorMsg, {
+                position: "bottom-center",
+                hideProgressBar: true,
+                closeOnClick: true,
+                pauseOnHover: true,
+                draggable: true,
+                progress: undefined,
+                theme: "colored",
+                transition: Bounce,
+              });
             }
             break;
           default:

--- a/WebSocketServer/src/lib.rs
+++ b/WebSocketServer/src/lib.rs
@@ -1242,7 +1242,9 @@ pub async fn handle_authenticated_client_message(
                                     return Some(ServerSocketMessage::IndividualError {
                                         client_id: client_state.client_id.clone(),
                                         error: ClientError::Other {
-                                            message: format!("User {} is not an owner", user_id),
+                                            message: String::from(
+                                                "You cannot change a canvas' allowed users as a non-owner"
+                                            ),
                                         }
                                     });
                                 },

--- a/WebSocketServer/src/lib.rs
+++ b/WebSocketServer/src/lib.rs
@@ -1237,15 +1237,15 @@ pub async fn handle_authenticated_client_message(
                                 });
                             },
                             Some(perm) => match perm {
-                                WhiteboardPermissionEnum::View => {
+                                WhiteboardPermissionEnum::Own => {},
+                                _  => {
                                     return Some(ServerSocketMessage::IndividualError {
                                         client_id: client_state.client_id.clone(),
                                         error: ClientError::Other {
-                                            message: format!("User {} does not have edit permission", user_id),
+                                            message: format!("User {} is not an owner", user_id),
                                         }
                                     });
                                 },
-                                WhiteboardPermissionEnum::Edit | WhiteboardPermissionEnum::Own => {},
                             },
                         };
                     }// -- end for user_id in allowed_users.iter()


### PR DESCRIPTION
Previously, editors were allowed to change the allowed users on a canvas. This changes it so only whiteboard owners can change the allowed users, as we agreed on.

While I was at it, I alwso implemented various UI improvements, namely displaying a popup notification when the web socket server sends an error message to the client and hiding the "edit allowed users" menu from non-owners.

- **WebSocketServer only allows whiteboard owners to edit allowed users on cavnases.**
- **Web socket server gives user individualized error message when they attempt to edit a canvas' allowed users as a non-owner.**
- **WebSocketClientMessengerProvider displays a toast error notification on receiving an error message from the web socket server.**
- **Whiteboard editor only display menu for editing allowed users if the authenticated user is an owner.**
- **Set cursor to hover over "Allowed Users" button in canvas menu.**
