### PR TITLE
Feat/temp to perm create account

### DIFF
--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -9,11 +9,10 @@ COPY . .
 # Install dependencies and build.
 # Cache node_modules for future builds.
 RUN \
-  --mount=type=cache,id=frontend.npm_home,target=${HOME}/.npm \
-  --mount=type=cache,id=frontend.node_modules,target=/app/node_modules \
-  npm install --prefer-offline && \
-  npm ci && \
-  npm run build
+  --mount=type=cache,id=frontend_yarn_home,target=${HOME}/.yarn \
+  --mount=type=cache,id=frontend_node_modules,target=/app/node_modules \
+  yarn install --prefer-offline && \
+  yarn build
 
 # ---- Stage 2: Serve with a static web server ----
 FROM nginx:stable-alpine AS release

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "npx": "^10.2.2",
+    "tsc": "^2.0.4",
     "tw-animate-css": "^1.3.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",

--- a/Frontend/src/components/AuthForm.tsx
+++ b/Frontend/src/components/AuthForm.tsx
@@ -66,7 +66,9 @@ const AuthForm = ({
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const navigate = useNavigate();
-  const { setUser } = useUser();
+  const { user, setUser } = useUser();
+  const tempUser = user?.kind === 'temp' ? user : null;
+  const tempUserId = tempUser ? { id: tempUser.id } : null;
   const action = initialAction;
   const redirectUrl = searchParams.has('redirect') ?
     decodeURIComponent(searchParams.get('redirect') || '')
@@ -89,7 +91,7 @@ const AuthForm = ({
   const [submitButtonStatus, setSubmitButtonStatus] = useState<ButtonStatus>('enabled');
 
   // -- derived state
-  const endpoint = (action === "login") ? "/auth/login" : "/users";
+  let endpoint = (action === "login") ? "/auth/login" : "/users";
 
   // TODO: Make this dynamic to handle either email or username
   const authSource = "email";
@@ -103,21 +105,43 @@ const AuthForm = ({
 
       setSubmitButtonStatus('pending');
 
-    const payload = 
+    type LoginPayload = { 
+      authSource: string; 
+      email: string; 
+      password: string; 
+      transferWhiteboardId: string | null; 
+    };
+    type SignupPayload = { 
+      email: string; 
+      username: string; 
+      password: string; 
+      authUser?: { id: string } | null;
+    };
+
+    let payload: LoginPayload | SignupPayload = 
       action === "login"
       ? { authSource, email, password, transferWhiteboardId: tempWhiteboardId }
       : { email, username, password };
 
     try {
+      const tempWhiteboardId = searchParams.get('transfer_temp_whiteboard');
+      
+      if (tempWhiteboardId && action === "signup" && tempUser !== null) {
+        endpoint = "/users/convert_temp";
+        payload = {
+          ...payload,
+          authUser: tempUserId
+        }
+      }
+      
       const res : AxiosResponse<AuthLoginSuccessResponse> = await api.post(endpoint, payload);
-
+      
       const {
         user,
         token,
       } = res.data;
 
       // -- Attempt to transfer temp whiteboard if applicable
-      const tempWhiteboardId = searchParams.get('transfer_temp_whiteboard');
       if (tempWhiteboardId) {
         try {
           await api.post(`/whiteboards/${tempWhiteboardId}/convert_temp_to_perm`, {

--- a/Frontend/src/components/AuthForm.tsx
+++ b/Frontend/src/components/AuthForm.tsx
@@ -94,8 +94,8 @@ const AuthForm = ({
   // TODO: Make this dynamic to handle either email or username
   const authSource = "email";
 
-    const tempWhiteboardId = searchParams.get('tempWhiteboardId');
-    let isTransferring = false;
+  const tempWhiteboardId = searchParams.get('tempWhiteboardId');
+  let isTransferring = false;
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -108,13 +108,13 @@ const AuthForm = ({
       ? { authSource, email, password, transferWhiteboardId: tempWhiteboardId }
       : { email, username, password };
 
-      try {
-        const res : AxiosResponse<AuthLoginSuccessResponse> = await api.post(endpoint, payload);
+    try {
+      const res : AxiosResponse<AuthLoginSuccessResponse> = await api.post(endpoint, payload);
 
-        const {
-          user,
-          token,
-        } = res.data;
+      const {
+        user,
+        token,
+      } = res.data;
 
       // -- Attempt to transfer temp whiteboard if applicable
       const tempWhiteboardId = searchParams.get('transfer_temp_whiteboard');

--- a/Frontend/src/components/AuthForm.tsx
+++ b/Frontend/src/components/AuthForm.tsx
@@ -47,7 +47,7 @@ import {
 import ChangeNameTrialWhiteboard from "./ChangeNameTrialWhiteboard";
 
 interface AuthFormProps {
-  initialAction: "login" | "signup";
+    initialAction: "login" | "signup";
 }
 
 const AuthForm = ({
@@ -64,15 +64,10 @@ const AuthForm = ({
   const [uiStatus, setUiStatus] = useState<'ok' | 'err_user' | 'err_system'>('ok');
 
   const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
   const navigate = useNavigate();
   const { user, setUser } = useUser();
   const tempUser = user?.kind === 'temp' ? user : null;
-  const tempUserId = tempUser ? { id: tempUser.id } : null;
   const action = initialAction;
-  const redirectUrl = searchParams.has('redirect') ?
-    decodeURIComponent(searchParams.get('redirect') || '')
-    : '/dashboard';
   const authContext = useContext(AuthContext);
   const {
     Modal: ChangeNameModal,
@@ -90,18 +85,21 @@ const AuthForm = ({
 
   const [submitButtonStatus, setSubmitButtonStatus] = useState<ButtonStatus>('enabled');
 
-  // -- derived state
-  let endpoint = (action === "login") ? "/auth/login" : "/users";
-
   // TODO: Make this dynamic to handle either email or username
   const authSource = "email";
-
-  const tempWhiteboardId = searchParams.get('tempWhiteboardId');
-  let isTransferring = false;
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
+
+      // -- derived state
+      const searchParams = new URLSearchParams(location.search);
+      const tempWhiteboardId = searchParams.get('tempWhiteboardId');
+      const redirectUrl = searchParams.has('redirect') ?
+        decodeURIComponent(searchParams.get('redirect') || '')
+        : '/dashboard';
+      const tempUserId = tempUser ? { id: tempUser.id } : null;
+      let endpoint = (action === "login") ? "/auth/login" : "/users";
 
       setSubmitButtonStatus('pending');
 
@@ -124,6 +122,7 @@ const AuthForm = ({
       : { email, username, password };
 
     try {
+      let isTransferring = false;
       const tempWhiteboardId = searchParams.get('transfer_temp_whiteboard');
       
       if (tempWhiteboardId && action === "signup" && tempUser !== null) {
@@ -228,44 +227,69 @@ const AuthForm = ({
     },
     [
       action,
-      endpoint,
       email,
       navigate,
       password,
-      redirectUrl,
       setAuthToken,
       setUser,
       username,
       setSubmitButtonStatus,
+      openChangeNameModal,
+      tempUser,
+      location.search,
     ]
   );// -- end const handleSubmit
 
-  const handleToggle = () => {
-    // -- remove highlighting
-    setUiStatus('ok');
+  const handleToggle = useCallback(
+      () => {
+        // -- remove highlighting
+        setUiStatus('ok');
 
-    navigate(action === "login" ? "/signup" : "/login");
-  }
+        navigate(action === "login" ? "/signup" : "/login");
+      },
+      [setUiStatus, navigate, action]
+  );// -- end handleToggle
 
-  const handleConfirmNameChange = async (nameFromModal: string) => {
-    if (transferringWhiteboardId) {
-      try {
-        await api.put(`/whiteboards/${transferringWhiteboardId}/newName`, {
-          newName: nameFromModal,
-        });
+  const handleConfirmNameChange = useCallback(
+    async (nameFromModal: string) => {
+      const searchParams = new URLSearchParams(location.search);
+      const redirectUrl = searchParams.has('redirect') ?
+        decodeURIComponent(searchParams.get('redirect') || '')
+        : '/dashboard';
 
-        toast.success("Whiteboard name updated!");
-      } catch (err) {
-        console.error('Error changing whiteboard name:', err);
+      if (transferringWhiteboardId) {
+        try {
+          await api.put(`/whiteboards/${transferringWhiteboardId}/newName`, {
+            newName: nameFromModal,
+          });
 
-        const toastMessage = "Whiteboard added to your account, but there was an error updating its name.";
-        toast.warn(toastMessage);
+          toast.success("Whiteboard name updated!");
+        } catch (err) {
+          console.error('Error changing whiteboard name:', err);
+
+          const toastMessage = "Whiteboard added to your account, but there was an error updating its name.";
+          toast.warn(toastMessage);
+        }
       }
-    }
 
-    closeChangeNameModal();
-    navigate(redirectUrl);
-  }
+      closeChangeNameModal();
+      navigate(redirectUrl);
+    },
+    [location.search, closeChangeNameModal, navigate, transferringWhiteboardId]
+  );// -- end handleConfirmNameChange
+  
+  const handleSkipNameChange = useCallback(
+    () => {
+      const searchParams = new URLSearchParams(location.search);
+      const redirectUrl = searchParams.has('redirect') ?
+        decodeURIComponent(searchParams.get('redirect') || '')
+        : '/dashboard';
+
+      closeChangeNameModal();
+      navigate(redirectUrl);
+    },
+    [location.search, closeChangeNameModal, navigate]
+  );// -- end handleSkipNameChange
 
   return (
     <div className="flex flex-col w-75 sm:w-95 md:w-120">
@@ -342,10 +366,7 @@ const AuthForm = ({
         className='p-8 rounded-sm'>
           <ChangeNameTrialWhiteboard
             onConfirm={handleConfirmNameChange}
-            onSkip={() => {
-              closeChangeNameModal();
-              navigate(redirectUrl);
-            }}
+            onSkip={handleSkipNameChange}
           />
       </ChangeNameModal>
     </div>

--- a/Frontend/src/components/ConfirmTempToPerm.tsx
+++ b/Frontend/src/components/ConfirmTempToPerm.tsx
@@ -2,30 +2,57 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
 
 export interface ConfirmTempToPermProps {
-  onCancel: () => void
+  onCancel: () => void,
+  action: "login" | "signup",
 }
 
 const ConfirmTempToPerm = ({
-  onCancel
+  onCancel,
+  action
 }: ConfirmTempToPermProps) => {
+  let message : string = "";
+  let handleSubmit : (event: React.FormEvent<HTMLFormElement>) => void;
+
   const navigate = useNavigate();
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const url = new URL(window.location.href);
+  const segments = url.pathname.split('/');
+  const whiteboardId = segments.pop() || segments.pop();
+  
+  if (!whiteboardId) {
+    console.error("No whiteboardId found in URL");
+    return;
+  }
+
+  const encodedWhiteboardUrl = encodeURIComponent(`/whiteboard/${whiteboardId}`);
+
+  const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const url = new URL(window.location.href);
-    const segments = url.pathname.split('/');
-    const whiteboardId = segments.pop() || segments.pop();
-    
-    if (!whiteboardId) {
-      console.error("No whiteboardId found in URL");
-      return;
-    }
-
-    const encodedWhiteboardUrl = encodeURIComponent(`/whiteboard/${whiteboardId}`);
     const redirectUrl = `/login/?transfer_temp_whiteboard=${whiteboardId}&redirect=${encodedWhiteboardUrl}`;
 
     navigate(redirectUrl);
+  }
+
+  const handleSingup = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const redirectUrl = `/signup/?transfer_temp_whiteboard=${whiteboardId}&redirect=${encodedWhiteboardUrl}`;
+
+    navigate(redirectUrl);
+  }
+
+  switch (action) {
+    case 'login':
+      message = "Logging in will transfer ownership of this whiteboard to your permanent account.";
+      handleSubmit = handleLogin;
+      break;
+    case 'signup':
+      message = "Signing up will transfer ownership of this whiteboard to your new account.";
+      handleSubmit = handleSingup;
+      break;
+    default:
+      throw new Error(`unrecognized action: ${action}`);
   }
   
   return (
@@ -33,7 +60,7 @@ const ConfirmTempToPerm = ({
       <form
         onSubmit={handleSubmit}
       >
-        <h1>Logging in will transfer ownership of this whiteboard to your permanent account.</h1>
+        <h1>{message}</h1>
         <div className="flex flex-row justify-center pt-2 gap-2">
           <Button
             type="submit"

--- a/Frontend/src/components/ConfirmTempToPerm.tsx
+++ b/Frontend/src/components/ConfirmTempToPerm.tsx
@@ -20,9 +20,8 @@ const ConfirmTempToPerm = ({
   const segments = url.pathname.split('/');
   const whiteboardId = segments.pop() || segments.pop();
   
-  if (!whiteboardId) {
-    console.error("No whiteboardId found in URL");
-    return;
+  if (! whiteboardId) {
+    throw new Error('No whiteboardId found in URL');
   }
 
   const encodedWhiteboardUrl = encodeURIComponent(`/whiteboard/${whiteboardId}`);

--- a/Frontend/src/components/ConfirmTempToPerm.tsx
+++ b/Frontend/src/components/ConfirmTempToPerm.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
+import { useCallback } from "react";
 
 export interface ConfirmTempToPermProps {
   onCancel: () => void,
@@ -26,21 +27,21 @@ const ConfirmTempToPerm = ({
 
   const encodedWhiteboardUrl = encodeURIComponent(`/whiteboard/${whiteboardId}`);
 
-  const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleLogin = useCallback((event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const redirectUrl = `/login/?transfer_temp_whiteboard=${whiteboardId}&redirect=${encodedWhiteboardUrl}`;
 
     navigate(redirectUrl);
-  }
+  }, [navigate, whiteboardId, encodedWhiteboardUrl]);
 
-  const handleSingup = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSingup = useCallback((event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     const redirectUrl = `/signup/?transfer_temp_whiteboard=${whiteboardId}&redirect=${encodedWhiteboardUrl}`;
 
     navigate(redirectUrl);
-  }
+  }, [navigate, whiteboardId, encodedWhiteboardUrl]);
 
   switch (action) {
     case 'login':

--- a/Frontend/src/components/HeaderUnauthed.tsx
+++ b/Frontend/src/components/HeaderUnauthed.tsx
@@ -15,7 +15,7 @@ import Header, {
 
 import HeaderButton from '@/components/HeaderButton';
 import ConfirmTempToPerm from './ConfirmTempToPerm';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export type HeaderUnauthedProps = HeaderProps;
 
@@ -35,7 +35,7 @@ const HeaderUnauthed = ({
   const pathname = location.pathname;
   const [action, setAction] = useState<"login" | "signup">("login");
   
-  const handleLogin = () => {
+  const handleLogin = useCallback(() => {
     if (pathname.startsWith("/login")) {
       console.log("from login");
       navigate("/login");
@@ -44,9 +44,9 @@ const HeaderUnauthed = ({
       console.log("log in from whiteboard, open modal");
       openConfirmationModal();
     }
-  };
+  }, [pathname, navigate, openConfirmationModal]);
 
-  const handleSignup = () => {
+  const handleSignup = useCallback(() => {
     if (pathname.startsWith("/signup")) {
       console.log("from signup");
       navigate("/signup");
@@ -58,11 +58,11 @@ const HeaderUnauthed = ({
       console.log("action after setAction: ", action);
       openConfirmationModal();
     }
-  };
+  }, [pathname, navigate, openConfirmationModal, setAction]);
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     closeConfirmationModal();
-  }
+  }, [closeConfirmationModal]);
 
   return (
     <div>

--- a/Frontend/src/components/HeaderUnauthed.tsx
+++ b/Frontend/src/components/HeaderUnauthed.tsx
@@ -15,6 +15,7 @@ import Header, {
 
 import HeaderButton from '@/components/HeaderButton';
 import ConfirmTempToPerm from './ConfirmTempToPerm';
+import { useState } from 'react';
 
 export type HeaderUnauthedProps = HeaderProps;
 
@@ -30,15 +31,31 @@ const HeaderUnauthed = ({
       openModal: openConfirmationModal,
       closeModal: closeConfirmationModal,
     } = useModal();
+
+  const pathname = location.pathname;
+  const [action, setAction] = useState<"login" | "signup">("login");
   
   const handleLogin = () => {
-    if (location.pathname.startsWith("/login")) {
+    if (pathname.startsWith("/login")) {
       console.log("from login");
       navigate("/login");
     } 
-    else if (location.pathname.startsWith("/whiteboard")) {
-      console.log("from whiteboard, open modal");
+    else if (pathname.startsWith("/whiteboard")) {
+      console.log("log in from whiteboard, open modal");
+      openConfirmationModal();
+    }
+  };
 
+  const handleSignup = () => {
+    if (pathname.startsWith("/signup")) {
+      console.log("from signup");
+      navigate("/signup");
+    } 
+    else if (pathname.startsWith("/whiteboard")) {
+      console.log("action: ", action);
+      console.log("create account from whiteboard, open modal");
+      setAction("signup");
+      console.log("action after setAction: ", action);
       openConfirmationModal();
     }
   };
@@ -62,7 +79,7 @@ const HeaderUnauthed = ({
           ),
           (
             <HeaderButton 
-              to="/signup"
+              onClick={handleSignup}
               title="Create Account"
             />
           ),
@@ -75,6 +92,7 @@ const HeaderUnauthed = ({
         className='p-8 rounded-sm'>
           <ConfirmTempToPerm
             onCancel={handleCancel}
+            action={action}
           />
       </ConfirmationModal>
     </div>

--- a/Frontend/yarn.lock
+++ b/Frontend/yarn.lock
@@ -5515,6 +5515,11 @@ ts-api-utils@^2.1.0:
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz"
   integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
+tsc@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/tsc/-/tsc-2.0.4.tgz#5f6499146abea5dca4420b451fa4f2f9345238f5"
+  integrity sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==
+
 tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -131,7 +131,9 @@ export const handleConvertTempUser = async (
     );
 
     const user = await User.findOne({
-      '_id': tempUserId,
+      '_id': {
+        "$eq": tempUserId
+      },
       'kind': 'permanent',
     });
 

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -38,6 +38,7 @@ import {
   type CreatePermanentUserRequest,
   type DeletePermanentUserRequest,
   isIPermanentUser,
+  ConvertTempUserRequest,
 } from "../models/User";
 
 import {
@@ -70,8 +71,7 @@ export const handleCreateUser = async (
 
     // --- Hash password ---
     const hashed = await bcrypt.hash(password, 10);
-
-    // --- Create user ---
+    
     const user = new User({
       username,
       email,
@@ -99,7 +99,67 @@ export const handleCreateUser = async (
   }
 };
 
-// === POST /users/temp ======================================================
+// === POST /users/convert_temp ================================================
+//
+// Convert a temporary user account to permanent.
+//
+// =============================================================================
+export const handleConvertTempUser = async (
+  req: Request<{}, {}, ConvertTempUserRequest>,
+  res: Response
+) => {
+  try {
+    const { email, username, password, authUser } = req.body;
+    const tempUserId = authUser.id;
+    
+    // --- Hash password ---
+    const hashed = await bcrypt.hash(password, 10);
+
+    User.collection.updateOne(
+      { _id: tempUserId },
+      { 
+        $set: {
+          username,
+          email,
+          kind: 'permanent',
+          passwordHashed: hashed,
+        },
+        $unset: {
+          createdAt: ""
+        }
+      }
+    );
+
+    const user = await User.findOne({
+      '_id': tempUserId,
+      'kind': 'permanent',
+    });
+
+    if (! user) {
+      return res.status(400).json({ error: "Could not find temp user to convert." });
+    }
+    
+    const userFinal = await user.save();
+
+    // --- Automatically log in user via service ---
+    try {
+      const loginResult = await permanentUserLoginService("username", username, password);
+      return res.status(201).json({
+        user: userFinal.toPublicView(),
+        token: loginResult.token
+      });
+    } catch (err: any) {
+      console.error("Login after signup failed: ", err);   
+      return res.status(500).json({ message: 'Unexpected login failure' })   
+    }
+    
+  } catch (err: any) {
+    console.error("Create temp user failed: ", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+// === POST /users/temp ========================================================
 //
 // Create a temporary user account for trial whiteboard use.
 //

--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -110,7 +110,11 @@ export const handleConvertTempUser = async (
 ) => {
   try {
     const { email, username, password, authUser } = req.body;
-    const tempUserId = authUser.id;
+    const tempUserIdRaw = authUser?.id;
+    if (!Types.ObjectId.isValid(tempUserIdRaw)) {
+      return res.status(400).json({ error: "Invalid user id." });
+    }
+    const tempUserId = new Types.ObjectId(tempUserIdRaw);
     
     // --- Hash password ---
     const hashed = await bcrypt.hash(password, 10);

--- a/RestAPI/src/models/User.ts
+++ b/RestAPI/src/models/User.ts
@@ -162,6 +162,10 @@ export interface CreatePermanentUserRequest extends IPermanentUserModel {
   password: string;
 }
 
+export interface ConvertTempUserRequest extends IPermanentUserModel, AuthorizedRequestBody {
+  password: string;
+}
+
 // -- for PATCH
 export type PatchPermanentUserData = Partial<CreatePermanentUserRequest>;
 

--- a/RestAPI/src/routes/users.ts
+++ b/RestAPI/src/routes/users.ts
@@ -1,5 +1,6 @@
 // -- std imports
 import { Request, Response, Router } from "express";
+import rateLimit from "express-rate-limit";
 
 // -- local imports
 import {
@@ -21,6 +22,13 @@ import type {
 } from "../models/User";
 
 const router = Router();
+
+const convertTempRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit convert attempts per IP per window
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 router.post("/", async (
   req: Request<{}, {}, CreatePermanentUserRequest>,
@@ -44,7 +52,7 @@ router.use(authenticateJWT);
 // Converts a temporary user account to a permanent one.
 //
 // =============================================================================
-router.post("/convert_temp", handleConvertTempUser);
+router.post("/convert_temp", convertTempRateLimiter, handleConvertTempUser);
 
 // === GET /users/:userId ======================================================
 //

--- a/RestAPI/src/routes/users.ts
+++ b/RestAPI/src/routes/users.ts
@@ -9,6 +9,7 @@ import {
   handleDeleteOwnUser,
   handleGetSharedWhiteboardsByUser,
   handleCreateTempUser,
+  handleConvertTempUser,
 } from "../controllers/users";
 
 import {
@@ -25,12 +26,10 @@ router.post("/", async (
   req: Request<{}, {}, CreatePermanentUserRequest>,
   res: Response
 ) => {
-    // TODO: secure logging to scrub credentials
-    console.log('Received POST /users:', req.body);
     await handleCreateUser(req, res);
 });
 
-// === POST /users/temp ======================================================
+// === POST /users/temp ========================================================
 //
 // Create a temporary user account for trial whiteboard use.
 //
@@ -39,6 +38,13 @@ router.post("/temp", handleCreateTempUser);
 
 // --- Routes below are authenticated
 router.use(authenticateJWT);
+
+// === POST /users/convert_temp ================================================
+//
+// Converts a temporary user account to a permanent one.
+//
+// =============================================================================
+router.post("/convert_temp", handleConvertTempUser);
 
 // === GET /users/:userId ======================================================
 //

--- a/RestAPI/src/services/loginService.ts
+++ b/RestAPI/src/services/loginService.ts
@@ -33,9 +33,9 @@ export const permanentUserLoginService = async (
   const user: IUserType | null = await (async () => {
     switch (authSource) {
       case 'email':
-        return await User.findOne({ email: identifier });
+        return await User.findOne({ email: { '$eq': identifier } });
       case 'username':
-        return await User.findOne({ username: identifier });
+        return await User.findOne({ username: { '$eq': identifier } });
       default:
         return null;
     }

--- a/RestAPI/tests/whiteboards.test.ts
+++ b/RestAPI/tests/whiteboards.test.ts
@@ -1020,7 +1020,7 @@ describe("Whiteboards API", () => {
     const whiteboardCollection = mongoose.connection.collection('whiteboards');
     const userCollection = mongoose.connection.collection('users');
 
-    let tempWhiteboard = await whiteboardCollection.findOne({ name: "Temp Whiteboard"});
+    let tempWhiteboard = await whiteboardCollection.findOne({ name: "Temp Whiteboard 1"});
     let user = await userCollection.findOne({ username: 'alice' });
     
     expect(tempWhiteboard).not.toBeNull();
@@ -1032,6 +1032,7 @@ describe("Whiteboards API", () => {
     
     expect(tempWhiteboard).toHaveProperty('createdAt');
     expect(tempWhiteboard).not.toHaveProperty('time_created');
+    expect(tempWhiteboard.kind).toBe('temp_whiteboard');
 
     // get the temp user that owns the temp whiteboard
     let tempUser = tempWhiteboard.user_permissions.find((perm: any) => perm.permission === 'own' && perm.type === 'user')?.user;
@@ -1060,12 +1061,58 @@ describe("Whiteboards API", () => {
 
     expect(updatedBoard).not.toHaveProperty('createdAt');
     expect(updatedBoard).toHaveProperty('time_created');
+    expect(updatedBoard.kind).toBe('permanent_whiteboard');
 
     let ownerPerm = updatedBoard.user_permissions.find((perm: any) => perm.permission === 'own' && perm.type === 'user');
     
     expect(ownerPerm).not.toBeNull();
     expect(ownerPerm.user.toString()).toBe(user._id.toString());
   });
+  
+  // Also add check for different user than temp owner trying to convert
+  it('should not allow a user that is not the temp owner to convert a temporary whiteboard to a permanent whiteboard', async () => {
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+    const userCollection = mongoose.connection.collection('users');
+
+    let tempWhiteboard = await whiteboardCollection.findOne({ name: "Temp Whiteboard 2"});
+    let user = await userCollection.findOne({ username: 'alice' });
+    
+    expect(tempWhiteboard).not.toBeNull();
+    expect(user).not.toBeNull();
+    
+    if ((! tempWhiteboard) || (! user)) {
+      return;
+    }
+
+    expect(tempWhiteboard).toHaveProperty('createdAt');
+    expect(tempWhiteboard).not.toHaveProperty('time_created');
+    expect(tempWhiteboard.kind).toBe('temp_whiteboard');
+
+    const authToken = jwt.sign(
+      { sub: user._id.toString() },
+      JWT_SECRET!,
+      { expiresIn: '1h' }
+    );
+
+    await request(app)
+      .post(`/api/v1/whiteboards/${tempWhiteboard._id}/convert_temp_to_perm`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        user: { _id: user._id }
+      })
+      .expect(403);
+
+    let updatedWhiteboard = await whiteboardCollection.findOne({ _id: tempWhiteboard._id });
+
+    expect(updatedWhiteboard).not.toBeNull();
+
+    if (! updatedWhiteboard) {
+      return;
+    }
+
+    expect(updatedWhiteboard).toHaveProperty('createdAt');
+    expect(updatedWhiteboard).not.toHaveProperty('time_created');
+    expect(updatedWhiteboard.kind).toBe('temp_whiteboard');
+  });
 });
 
-// Also add check for unauthed user trying to convert, should fail and keep board as temp

--- a/RestAPI/tests/whiteboards.test.ts
+++ b/RestAPI/tests/whiteboards.test.ts
@@ -1015,4 +1015,57 @@ describe("Whiteboards API", () => {
         .toBe(deletedUserEmail);
     }
   );
+
+  it('should convert a temporary whiteboard to a permanent whiteboard', async () => {
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+    const userCollection = mongoose.connection.collection('users');
+
+    let tempWhiteboard = await whiteboardCollection.findOne({ name: "Temp Whiteboard"});
+    let user = await userCollection.findOne({ username: 'alice' });
+    
+    expect(tempWhiteboard).not.toBeNull();
+    expect(user).not.toBeNull();
+    
+    if ((! tempWhiteboard) || (! user)) {
+      return;
+    }
+    
+    expect(tempWhiteboard).toHaveProperty('createdAt');
+    expect(tempWhiteboard).not.toHaveProperty('time_created');
+
+    // get the temp user that owns the temp whiteboard
+    let tempUser = tempWhiteboard.user_permissions.find((perm: any) => perm.permission === 'own' && perm.type === 'user')?.user;
+
+    const authToken = jwt.sign(
+      { sub: tempUser!._id.toString(), isTemp: true },
+      JWT_SECRET!,
+      { expiresIn: '1h' }
+    );
+
+    await request(app)
+      .post(`/api/v1/whiteboards/${tempWhiteboard._id}/convert_temp_to_perm`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        user: { _id: user._id }
+      })
+      .expect(200);
+
+    const updatedBoard = await whiteboardCollection.findOne({ _id: tempWhiteboard._id });
+
+    expect(updatedBoard).not.toBeNull();
+
+    if (! updatedBoard) {
+      return;
+    }
+
+    expect(updatedBoard).not.toHaveProperty('createdAt');
+    expect(updatedBoard).toHaveProperty('time_created');
+
+    let ownerPerm = updatedBoard.user_permissions.find((perm: any) => perm.permission === 'own' && perm.type === 'user');
+    
+    expect(ownerPerm).not.toBeNull();
+    expect(ownerPerm.user.toString()).toBe(user._id.toString());
+  });
 });
+
+// Also add check for unauthed user trying to convert, should fail and keep board as temp

--- a/TestDatabase/init-db.js
+++ b/TestDatabase/init-db.js
@@ -407,6 +407,20 @@ const whiteboards = [
       },
     ],
   },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0408'),
+    name: "Temp Whiteboard",
+    kind: "temp_whiteboard",
+    createdAt: new Date("2025-08-02T12:10:00.000Z"),
+    root_canvas: new ObjectId('68d5e8d4829da666aece020c'),
+    user_permissions: [
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0107'), // TempUser68d5e8d4829da666aece0107
+        permission: 'own',
+      },
+    ],
+  },
 ];
 
 db.whiteboards.insertMany(whiteboards);

--- a/TestDatabase/init-db.js
+++ b/TestDatabase/init-db.js
@@ -409,7 +409,21 @@ const whiteboards = [
   },
   {
     _id: new ObjectId('68d5e8d4829da666aece0408'),
-    name: "Temp Whiteboard",
+    name: "Temp Whiteboard 1",
+    kind: "temp_whiteboard",
+    createdAt: new Date("2025-08-02T12:10:00.000Z"),
+    root_canvas: new ObjectId('68d5e8d4829da666aece020c'),
+    user_permissions: [
+      {
+        type: 'user',
+        user: new ObjectId('68d5e8d4829da666aece0107'), // TempUser68d5e8d4829da666aece0107
+        permission: 'own',
+      },
+    ],
+  },
+  {
+    _id: new ObjectId('68d5e8d4829da666aece0409'),
+    name: "Temp Whiteboard 2",
     kind: "temp_whiteboard",
     createdAt: new Date("2025-08-02T12:10:00.000Z"),
     root_canvas: new ObjectId('68d5e8d4829da666aece020c'),


### PR DESCRIPTION
Temp users can create an account from their trial whiteboard page. That temp whiteboard will be converted to permanent and added to the account of the newly created user, with that user as the owner. It uses the same controller for handling whiteboard temp to perm conversion as the login flow, with the permanent user passed in the req body set to the newly created user object. 

Tests were also added for testing the whiteboard conversion route as well as checking that a different user from the temp user owner of the temp whiteboard cannot perform the conversion by stealing the url.