### PR TITLE
Bugfix/text entry fix

### DIFF
--- a/Frontend/src/components/CanvasCard.tsx
+++ b/Frontend/src/components/CanvasCard.tsx
@@ -262,14 +262,14 @@ const CanvasCard = ({
         // ensure container receives focus while objects within are being
         // manipulated
         const handlePointerEvent = () => {
-          container.focus({
-            preventScroll: true,
-          });
+          const active = document.activeElement;
+          if (active instanceof HTMLTextAreaElement || active instanceof HTMLInputElement) {
+            return;
+          }
+          container.focus({ preventScroll: true });
         };// -- end handlePointerEvent
 
         container.addEventListener('pointerdown', handlePointerEvent);
-        // We need to ensure focus remains after pointerup
-        container.addEventListener('pointermove', handlePointerEvent);
         container.addEventListener('pointerup', handlePointerEvent);
 
         // handle keypresses within container
@@ -293,7 +293,6 @@ const CanvasCard = ({
 
         return () => {
           container.removeEventListener('pointerdown', handlePointerEvent);
-          container.removeEventListener('pointermove', handlePointerEvent);
           container.removeEventListener('pointerup', handlePointerEvent);
           container.removeEventListener('keydown', handleKeyDown);
         };

--- a/Frontend/src/components/TextEditor.tsx
+++ b/Frontend/src/components/TextEditor.tsx
@@ -1,3 +1,4 @@
+import { useRef, useCallback } from "react";
 import { Html } from "react-konva-utils";
 import Konva from "konva";
 
@@ -12,7 +13,7 @@ interface TextEditorProps {
 }
 
 const TextEditor = ({ textNode, onClose }: TextEditorProps) => {
-  const textareaRef = { current: null as (HTMLTextAreaElement | null) };
+  const textareaRef = useRef<TAWithClose | null>(null);
 
   const initTextArea = (textarea: TAWithClose) => {
     const textPosition = textNode.position();
@@ -108,27 +109,29 @@ const TextEditor = ({ textNode, onClose }: TextEditorProps) => {
     return close;
   };
 
+  // Stable ref callback — useCallback with [] prevents React from treating it
+  // as a new function on every parent re-render, which would otherwise call the
+  // old cleanup (null) and new init (element) on every re-render, resetting
+  // textarea.value to the stale textNode.text() and jumping the cursor.
+  const handleRef = useCallback((elem: HTMLTextAreaElement | null) => {
+    if (elem) {
+      const e = elem as TAWithClose;
+      textareaRef.current = e;
+      if (!e.__konvaInit) {
+        initTextArea(e);
+      }
+    } else {
+      const prev = textareaRef.current;
+      if (prev?.__konvaClose) prev.__konvaClose();
+      textareaRef.current = null;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <Html>
       <textarea
         placeholder="Enter text here"
-        ref={(elem) => {
-          if (elem) {
-            const e = elem as TAWithClose;
-            textareaRef.current = elem;
-            // Prevent double-init (React can call ref callback multiple times)
-            if (!e.__konvaInit) {
-              initTextArea(e);
-              // IMPORTANT: do NOT call the returned close() here.
-              // Instead it's stored on the element as __konvaClose.
-            }
-          } else {
-            // ref cleared -> component unmount. cleanup if we have a stored close.
-            const prev = textareaRef.current as TAWithClose | null;
-            if (prev && prev.__konvaClose) prev.__konvaClose();
-            textareaRef.current = null;
-          }
-        }}
+        ref={handleRef}
         style={{
           minHeight: "1rem",
           position: "absolute",

--- a/Frontend/src/components/TextEditor.tsx
+++ b/Frontend/src/components/TextEditor.tsx
@@ -80,6 +80,11 @@ const TextEditor = ({ textNode, onClose }: TextEditorProps) => {
       textarea.style.height = `${textarea.scrollHeight + textNode.fontSize()}px`;
     };
 
+    const handleBlur = () => {
+      performClose(textarea.value);
+    }
+    
+    textarea.addEventListener("blur", handleBlur);
     textarea.addEventListener("keydown", handleKeyDown);
     textarea.addEventListener("input", handleInput);
     window.addEventListener("click", handleOutsideClick);
@@ -88,6 +93,7 @@ const TextEditor = ({ textNode, onClose }: TextEditorProps) => {
       try {
         textarea.removeEventListener("keydown", handleKeyDown);
         textarea.removeEventListener("input", handleInput);
+        textarea.removeEventListener("blur", handleBlur);
         window.removeEventListener("click", handleOutsideClick);
       } finally {
         textarea.__konvaInit = false;


### PR DESCRIPTION
Text entry issues with re-renders and destructive listeners fixed. Text area now utilized useRef and useCallback, and there is no longer a mouse move listener in CanvasCard overtaking cursor control.