### PR TITLE
feat/real time cursor

### DIFF
--- a/Frontend/src/components/CanvasCard.tsx
+++ b/Frontend/src/components/CanvasCard.tsx
@@ -206,7 +206,7 @@ const CanvasCard = ({
       const timeoutId = window.setInterval(
         () => {
           if (stageRef.current) {
-            const pos = stageRef.current.getPointerPosition();
+            const pos = stageRef.current.getRelativePointerPosition();
 
             if (pos) {
               const { x, y } = pos;
@@ -393,7 +393,7 @@ const CanvasCard = ({
             {Object.values(activeUsers).map(u => u.cursorPos && (
               <Circle
                 x={u.cursorPos.x}
-                y={u.cursorPos.x}
+                y={u.cursorPos.y}
                 width={10}
                 height={10}
                 fill={u.color}

--- a/Frontend/src/components/CanvasCard.tsx
+++ b/Frontend/src/components/CanvasCard.tsx
@@ -223,7 +223,7 @@ const CanvasCard = ({
             }
           }
         },
-        1000
+        50
       );
 
       return () => {

--- a/Frontend/src/components/CanvasCard.tsx
+++ b/Frontend/src/components/CanvasCard.tsx
@@ -21,9 +21,12 @@ import {
   type AxiosError,
 } from 'axios';
 
+import Konva from 'konva';
+
 import {
   Stage,
   Layer,
+  Circle,
 } from 'react-konva';
 
 import Canvas from "./Canvas";
@@ -35,6 +38,10 @@ import {
   type CanvasIdType,
   type CanvasAttribs,
 } from "@/types/WebSocketProtocol";
+
+import {
+  type ClientSummary,
+} from '@/types/ClientSummary';
 
 import {
   type User,
@@ -53,6 +60,10 @@ import {
 import {
   type RootState,
 } from '@/store';
+
+import {
+  selectActiveUsersByWhiteboard,
+} from '@/store/activeUsers/activeUsersSelectors';
 
 import {
   selectClientId,
@@ -135,6 +146,10 @@ const CanvasCard = ({
     lodash.isEqual
   );
 
+  const activeUsers : Record<ClientIdType, ClientSummary> = useSelector(
+    (state: RootState) => selectActiveUsersByWhiteboard(state, whiteboardId)
+  );
+
   const clientMessengerContext = useContext(ClientMessengerContext);
 
   if (! clientMessengerContext) {
@@ -181,6 +196,35 @@ const CanvasCard = ({
       state, whiteboardId, clientId
     ),
     lodash.isEqual
+  );
+
+  // -- set up interval to broadcast cursor position
+  const stageRef = useRef<Konva.Stage | null>(null);
+
+  useEffect(
+    () => {
+      const timeoutId = window.setInterval(
+        () => {
+          if (stageRef.current) {
+            const pos = stageRef.current.getPointerPosition();
+
+            if (pos) {
+              const { x, y } = pos;
+
+              clientMessenger?.sendSetCursorPos({
+                type: 'set_cursor_pos', x, y
+              });
+            }
+          }
+        },
+        1000
+      );
+
+      return () => {
+        window.clearTimeout(timeoutId);
+      };
+    },
+    [stageRef, clientMessenger]
   );
 
   useEffect(
@@ -327,6 +371,7 @@ const CanvasCard = ({
         }}
       >
         <Stage
+          ref={stageRef}
           width={width}
           height={height}
           onClick={handleUnselect}
@@ -341,6 +386,19 @@ const CanvasCard = ({
                 onSelectCanvasDimensions,
               }}
             />
+          </Layer>
+
+          {/** Display other users' cursors **/}
+          <Layer>
+            {Object.values(activeUsers).map(u => u.cursorPos && (
+              <Circle
+                x={u.cursorPos.x}
+                y={u.cursorPos.x}
+                width={10}
+                height={10}
+                fill={u.color}
+              />
+            ) || null)}
           </Layer>
         </Stage>
       </div>

--- a/Frontend/src/components/CanvasCard.tsx
+++ b/Frontend/src/components/CanvasCard.tsx
@@ -41,6 +41,7 @@ import {
 
 import {
   type ClientSummary,
+  type CursorPosition,
 } from '@/types/ClientSummary';
 
 import {
@@ -63,6 +64,7 @@ import {
 
 import {
   selectActiveUsersByWhiteboard,
+  selectCursorPositionsByClients,
 } from '@/store/activeUsers/activeUsersSelectors';
 
 import {
@@ -148,6 +150,10 @@ const CanvasCard = ({
 
   const activeUsers : Record<ClientIdType, ClientSummary> = useSelector(
     (state: RootState) => selectActiveUsersByWhiteboard(state, whiteboardId)
+  );
+
+  const cursorPositionsByClient : Record<ClientIdType, CursorPosition> = useSelector(
+    (state: RootState) => selectCursorPositionsByClients(state, Object.keys(activeUsers))
   );
 
   const clientMessengerContext = useContext(ClientMessengerContext);
@@ -390,15 +396,15 @@ const CanvasCard = ({
 
           {/** Display other users' cursors **/}
           <Layer>
-            {Object.values(activeUsers).map(u => u.cursorPos && (
+            {Object.entries(cursorPositionsByClient).map(([clientId, cursorPos]) => (
               <Circle
-                x={u.cursorPos.x}
-                y={u.cursorPos.y}
+                x={cursorPos.x}
+                y={cursorPos.y}
                 width={10}
                 height={10}
-                fill={u.color}
+                fill={activeUsers[clientId].color}
               />
-            ) || null)}
+            ))}
           </Layer>
         </Stage>
       </div>

--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -76,6 +76,7 @@ import {
 
 import {
   setClientId,
+  setClientCursorPos,
   addWhiteboard,
   deleteWhiteboard,
   setWhiteboardStatus,
@@ -385,6 +386,18 @@ const WebSocketClientMessengerProvider = ({
                 },
                 WHITEBOARD_DELETED_NOTIFICATION_NUM_MILLIS
               );
+          }
+          break;
+          case 'set_cursor_pos':
+          {
+            const {
+              clientId,
+              x,
+              y,
+            } = msg;
+
+            // -- update cursor in state store
+            setClientCursorPos(dispatch, clientId, x, y);
           }
           break;
           case 'error':

--- a/Frontend/src/controllers/activeUsers.ts
+++ b/Frontend/src/controllers/activeUsers.ts
@@ -18,6 +18,7 @@ import {
 
 import {
   setActiveUsers,
+  setClientCursorPos as reducerSetClientCursorPos,
 } from '@/store/activeUsers/activeUsersSlice';
 
 import {
@@ -80,4 +81,15 @@ export const removeCanvasObjectsBySelector = (
   selectors: ClientIdType[],
 ) => {
   dispatch(reducerRemoveCanvasObjectsBySelector(selectors));
+};
+
+export const setClientCursorPos = (
+  dispatch: AppDispatch,
+  clientId: ClientIdType,
+  x: number,
+  y: number,
+) => {
+  dispatch(reducerSetClientCursorPos({
+    [clientId]: { x, y },
+  }));
 };

--- a/Frontend/src/controllers/activeUsers.ts
+++ b/Frontend/src/controllers/activeUsers.ts
@@ -18,8 +18,12 @@ import {
 
 import {
   setActiveUsers,
-  setClientCursorPos as reducerSetClientCursorPos,
 } from '@/store/activeUsers/activeUsersSlice';
+
+import {
+  setCursorPosByClient,
+  unsetCursorPosByClient,
+} from '@/store/activeUsers/cursorPositionsByActiveUserSlice';
 
 import {
   setSelectorsByCanvasObject as reducerSetSelectorsByCanvasObject,
@@ -60,6 +64,7 @@ export const removeActiveUsers = (
   userClientIds: ClientIdType[]
 ) => {
   dispatch(removeActiveUsersReducer(userClientIds));
+  dispatch(unsetCursorPosByClient(userClientIds));
 };
 
 export const setSelectorsByCanvasObject = (
@@ -89,7 +94,14 @@ export const setClientCursorPos = (
   x: number,
   y: number,
 ) => {
-  dispatch(reducerSetClientCursorPos({
+  dispatch(setCursorPosByClient({
     [clientId]: { x, y },
   }));
+};
+
+export const unsetClientCursorPos = (
+  dispatch: AppDispatch,
+  clientId: ClientIdType,
+) => {
+  dispatch(unsetCursorPosByClient([clientId]));
 };

--- a/Frontend/src/controllers/index.ts
+++ b/Frontend/src/controllers/index.ts
@@ -31,6 +31,7 @@ import {
   setSelectorsByCanvasObject,
   removeSelectorsByCanvasObject,
   removeCanvasObjectsBySelector,
+  setClientCursorPos,
 } from './activeUsers';
 
 import {
@@ -41,6 +42,7 @@ import {
 export {
   setClientId,
   unsetClientId,
+  setClientCursorPos,
   setCanvasObjects,
   removeCanvasObjects,
   addCanvas,

--- a/Frontend/src/services/whiteboardSocketMessenger.ts
+++ b/Frontend/src/services/whiteboardSocketMessenger.ts
@@ -4,6 +4,7 @@
 
 // -- local imports
 import {
+  type ClientMessageSetCursorPos,
   type ClientMessageLogin,
   type ClientMessageEditingCanvas,
   type ClientMessageSelectedCanvasObject,
@@ -27,6 +28,10 @@ class WhiteboardSocketMessenger {
   #sendMessage(msg: object) {
     this.#socket.send(JSON.stringify(msg));
   }// -- end sendMessage
+
+  sendSetCursorPos(msg: ClientMessageSetCursorPos) {
+    this.#sendMessage(msg);
+  }// -- end sendSetCursorPos
 
   sendUpdateCanvasAllowedUsers(msg: ClientMessageUpdateAllowedUsers) {
     this.#sendMessage(msg);

--- a/Frontend/src/store/activeUsers/activeUsersSelectors.ts
+++ b/Frontend/src/store/activeUsers/activeUsersSelectors.ts
@@ -14,6 +14,7 @@ import {
 
 import {
   type ClientSummary,
+  type CursorPosition,
 } from '@/types/ClientSummary';
 
 export const selectActiveUsersByWhiteboard = (
@@ -44,4 +45,18 @@ export const selectSelectorByCanvasObject = (
   } else {
     return state.activeUsers[clientId];
   }
+};
+
+export const selectCursorPositionsByClients = (
+  state: RootState,
+  clientIds: ClientIdType[],
+): Record<ClientIdType, CursorPosition> => {
+  const cursorPositionsByClient = state.cursorPositionsByClient;
+
+  return Object.fromEntries(
+    clientIds.map(clientId => clientId in cursorPositionsByClient ?
+      [clientId, cursorPositionsByClient[clientId]]
+      : null)
+    .filter(entry => entry !== null)
+  );
 };

--- a/Frontend/src/store/activeUsers/activeUsersSlice.ts
+++ b/Frontend/src/store/activeUsers/activeUsersSlice.ts
@@ -45,37 +45,17 @@ const activeUsersSlice = createSlice({
 
       return newState;
     },
-    setClientCursorPos(state, action: PayloadAction<Record<ClientIdType, { x: number; y: number; }>>) {
-      for (const [clientId, cursorPos] of Object.entries(action.payload)) {
-        if (clientId in state) {
-          state[clientId].cursorPos = cursorPos;
-        }
-      }// -- end for clientId, cursorPos
-
-      return state;
-    },
-    unsetClientCursorPos(state, action: PayloadAction<ClientIdType[]>) {
-      for (const clientId of action.payload) {
-        delete state[clientId];
-      }// -- end for clientId
-
-      return state;
-    },
   },
 });// -- end activeUsersSlice
 
 export const {
   setActiveUsers,
   removeActiveUsers,
-  setClientCursorPos,
-  unsetClientCursorPos,
 } = activeUsersSlice.actions;
 
 export type ActiveUsersActions =
   | ReturnType<typeof setActiveUsers>
   | ReturnType<typeof removeActiveUsers>
-  | ReturnType<typeof setClientCursorPos>
-  | ReturnType<typeof unsetClientCursorPos>
 ;
 
 export default activeUsersSlice.reducer;

--- a/Frontend/src/store/activeUsers/activeUsersSlice.ts
+++ b/Frontend/src/store/activeUsers/activeUsersSlice.ts
@@ -45,17 +45,37 @@ const activeUsersSlice = createSlice({
 
       return newState;
     },
+    setClientCursorPos(state, action: PayloadAction<Record<ClientIdType, { x: number; y: number; }>>) {
+      for (const [clientId, cursorPos] of Object.entries(action.payload)) {
+        if (clientId in state) {
+          state[clientId].cursorPos = cursorPos;
+        }
+      }// -- end for clientId, cursorPos
+
+      return state;
+    },
+    unsetClientCursorPos(state, action: PayloadAction<ClientIdType[]>) {
+      for (const clientId of action.payload) {
+        delete state[clientId];
+      }// -- end for clientId
+
+      return state;
+    },
   },
 });// -- end activeUsersSlice
 
 export const {
   setActiveUsers,
   removeActiveUsers,
+  setClientCursorPos,
+  unsetClientCursorPos,
 } = activeUsersSlice.actions;
 
 export type ActiveUsersActions =
   | ReturnType<typeof setActiveUsers>
   | ReturnType<typeof removeActiveUsers>
+  | ReturnType<typeof setClientCursorPos>
+  | ReturnType<typeof unsetClientCursorPos>
 ;
 
 export default activeUsersSlice.reducer;

--- a/Frontend/src/store/activeUsers/cursorPositionsByActiveUserSlice.ts
+++ b/Frontend/src/store/activeUsers/cursorPositionsByActiveUserSlice.ts
@@ -1,0 +1,48 @@
+import {
+  createSlice,
+  type PayloadAction,
+} from '@reduxjs/toolkit';
+
+import {
+  type ClientIdType,
+} from '@/types/WebSocketProtocol';
+
+import {
+  type CursorPosition
+} from '@/types/ClientSummary';
+
+type CursorPositionsByClientState = Record<ClientIdType, CursorPosition>;
+
+const initialState : CursorPositionsByClientState = {};
+
+export const cursorPositionsByClientSlice = createSlice({
+  name: 'cursorPositionsByClient',
+  initialState,
+  reducers: {
+    setCursorPosByClient(state, action: PayloadAction<Record<ClientIdType, CursorPosition>>) {
+      return {
+        ...state,
+        ...action.payload,
+      };
+    },
+    unsetCursorPosByClient(state, action: PayloadAction<ClientIdType[]>) {
+      for (const clientId of action.payload) {
+        delete state[clientId];
+      }// -- end for clientId
+
+      return state;
+    },
+  },
+});// -- end cursorPositionsByClientSlice
+
+export const {
+    setCursorPosByClient,
+    unsetCursorPosByClient,
+} = cursorPositionsByClientSlice.actions;
+
+export type CursorPositionsByClientActions =
+  | ReturnType<typeof setCursorPosByClient>
+  | ReturnType<typeof unsetCursorPosByClient>
+;
+
+export default cursorPositionsByClientSlice.reducer;

--- a/Frontend/src/store/index.ts
+++ b/Frontend/src/store/index.ts
@@ -18,6 +18,9 @@ import selectorsByCanvasObjectReducer, {
 import currentEditorsByCanvasReducer, {
   type CurrentEditorsByCanvasActions,
 } from './activeUsers/currentEditorsByCanvasSlice';
+import cursorPositionsByClientReducer, {
+  type CursorPositionsByClientActions,
+} from './activeUsers/cursorPositionsByActiveUserSlice';
 import canvasObjectsReducer, {
   type CanvasObjectsActions,
 } from './canvasObjects/canvasObjectsSlice';
@@ -65,6 +68,7 @@ const rootReducer = combineReducers({
   activeUsersByWhiteboard: activeUsersByWhiteboardReducer,
   selectorsByCanvasObject: selectorsByCanvasObjectReducer,
   currentEditorsByCanvas: currentEditorsByCanvasReducer,
+  cursorPositionsByClient: cursorPositionsByClientReducer,
   canvasObjects: canvasObjectsReducer,
   canvasObjectsByCanvas: canvasObjectsByCanvasReducer,
   allowedUsersByCanvas: allowedUsersByCanvasReducer,
@@ -82,6 +86,7 @@ type ActionType =
   | ActiveUsersByWhiteboardActions
   | SelectorsByCanvasObjectActions
   | CurrentEditorsByCanvasActions
+  | CursorPositionsByClientActions
   | CanvasObjectsActions
   | AllowedUsersByCanvasActions
   | CanvasObjectsByCanvasActions

--- a/Frontend/src/types/ClientSummary.ts
+++ b/Frontend/src/types/ClientSummary.ts
@@ -5,8 +5,9 @@ import {
 export interface ClientSummary extends UserSummary {
   // -- color used to indicate when a user is interacting with the interface
   color: string;
-  cursorPos?: {
-    x: number;
-    y: number;
-  };
+}
+
+export interface CursorPosition {
+  x: number;
+  y: number;
 }

--- a/Frontend/src/types/ClientSummary.ts
+++ b/Frontend/src/types/ClientSummary.ts
@@ -5,4 +5,8 @@ import {
 export interface ClientSummary extends UserSummary {
   // -- color used to indicate when a user is interacting with the interface
   color: string;
+  cursorPos?: {
+    x: number;
+    y: number;
+  };
 }

--- a/Frontend/src/types/IWhiteboardClientMessenger.ts
+++ b/Frontend/src/types/IWhiteboardClientMessenger.ts
@@ -9,6 +9,7 @@
 // -- local imports
 
 import {
+  type ClientMessageSetCursorPos,
   type ClientMessageUpdateAllowedUsers,
   type ClientMessageLogin,
   type ClientMessageDeleteCanvases,
@@ -23,6 +24,7 @@ import {
 } from '@/types/WebSocketProtocol';
 
 export interface IWhiteboardClientMessenger {
+  sendSetCursorPos: (msg: ClientMessageSetCursorPos) => unknown;
   sendUpdateCanvasAllowedUsers: (msg: ClientMessageUpdateAllowedUsers) => unknown;
   sendLogin: (msg: ClientMessageLogin) => unknown;
   sendDeleteCanvases: (msg: ClientMessageDeleteCanvases) => unknown;

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -261,6 +261,13 @@ export interface ServerMessageDeleteWhiteboard {
   type: 'delete_whiteboard';
 }
 
+export interface ServerMessageSetCursorPos {
+  type: 'set_cursor_pos';
+  clientId: ClientIdType;
+  x: number;
+  y: number;
+}
+
 export interface ServerMessageError {
   type: 'error';
   error: ClientError;
@@ -282,6 +289,7 @@ export type SocketServerMessage =
   | ServerMessageDeleteCanvasObjects
   | ServerMessageMergeCanvas
   | ServerMessageDeleteWhiteboard
+  | ServerMessageSetCursorPos
   | ServerMessageError
 ;
 
@@ -366,6 +374,12 @@ export interface ClientMessageMergeCanvas {
   canvasId: CanvasIdType;
 }
 
+export interface ClientMessageSetCursorPos {
+  type: 'set_cursor_pos';
+  x: number;
+  y: number;
+}
+
 // Tagged union of all possible client-server messages
 export type SocketClientMessage =
   | ClientMessageLogin
@@ -379,4 +393,5 @@ export type SocketClientMessage =
   | ClientMessageUpdateAllowedUsers
   | ClientMessageDeleteCanvasObjects
   | ClientMessageMergeCanvas
+  | ClientMessageSetCursorPos
 ;

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -321,6 +321,14 @@ async fn handle_connection(
                             break;
                         }
                     },
+                    BroadcastRest { ref src_client_id, ref msg } => {
+                        if ! matches!(src_client_id.cmp(&current_client_id), Ordering::Equal) {
+                            let json = serde_json::to_string(&msg).unwrap();
+                            if user_ws_tx.send(Message::text(json)).await.is_err() {
+                                break;
+                            }
+                        }
+                    },
                 };// -- end match msg
             }
         })

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -176,8 +176,8 @@ pub enum ServerSocketBroadcastMessage {
 pub enum ServerSocketBroadcastRestMessage {
     SetCursorPos {
         client_id: ClientIdType,
-        x: usize,
-        y: usize,
+        x: f64,
+        y: f64,
     },
 }// -- end pub enum ServerSocketBroadcastRestMessage
 
@@ -250,7 +250,7 @@ pub enum ClientSocketMessage {
         canvas_id: CanvasIdType,
     },
     SetCursorPos {
-        x: usize,
-        y: usize,
+        x: f64,
+        y: f64,
     },
 } // -- end pub enum ClientSocketMessage

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -160,7 +160,26 @@ pub enum ServerSocketBroadcastMessage {
     Error {
         error: ClientError,
     },
-}// -- end pub enum ServerSocketMessage
+}// -- end pub enum ServerSocketBroadcastMessage
+
+// === enum ServerSocketBroadcastRestMessage =======================================================
+//
+// Broadcasts a message to all clients except the source client.
+//
+// =================================================================================================
+#[derive(Debug, Clone, Serialize)]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum ServerSocketBroadcastRestMessage {
+    SetCursorPos {
+        client_id: ClientIdType,
+        x: usize,
+        y: usize,
+    },
+}// -- end pub enum ServerSocketBroadcastRestMessage
 
 #[derive(Debug, Clone)]
 pub enum ServerSocketMessage {
@@ -171,6 +190,10 @@ pub enum ServerSocketMessage {
     },
     Broadcast {
         msg: ServerSocketBroadcastMessage,
+    },
+    BroadcastRest {
+        src_client_id: ClientIdType,
+        msg: ServerSocketBroadcastRestMessage,
     },
 }// -- end pub enum ServerSocketMessage
 
@@ -225,5 +248,9 @@ pub enum ClientSocketMessage {
     },
     MergeCanvas {
         canvas_id: CanvasIdType,
+    },
+    SetCursorPos {
+        x: usize,
+        y: usize,
     },
 } // -- end pub enum ClientSocketMessage

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -214,6 +214,18 @@ pub async fn handle_authenticated_client_message(
                         },
                     }// -- end match
                 }
+                SetCursorPos {
+                    x,
+                    y,
+                } => {
+                    // -- UI-only feature; just relay the message to the other clients
+                    vec![ServerSocketMessage::BroadcastRest {
+                        src_client_id: client_state.client_id.clone(),
+                        msg: ServerSocketBroadcastRestMessage::SetCursorPos {
+                            client_id: client_state.client_id.clone(), x, y,
+                        },
+                    }]
+                }
                 CreateShapes {
                     canvas_id,
                     ref shapes,


### PR DESCRIPTION
Implemented a real-time cursor, which shows the location of all other clients' cursors. Cursor positions update at a rate of 20 frames per second.

- **Basic proof of concept for broadcasting cursor positions at a one-second interval (cursor positions aren't yet accurate).**
- **Correct cursor position by using stage.getRelativePointerPosition, using y position instead of two x positions (oops). Now need to separate cursorPosition from activeUsers in order to prevent other components dependent on activeUsers from re-rendering unnecessarily.**
- **Separated cursor position from activeUsers slice.**
- **Increased granularity of client cursor messages from one update per second to 20 updates per second.**
