### PR TITLE
Bumped test database mongo version down to 7.0 from 8.0 in order to enable compatibility with Linux kernel 6.19.

### DIFF
--- a/TestDatabase/Dockerfile
+++ b/TestDatabase/Dockerfile
@@ -1,7 +1,10 @@
 # Just mirrors the default Mongo image.
 # Allows the image to be easily cached locally.
 
-FROM mongo:8.0 AS release
+# Mongo <8.0 required for compatibility with Linux kernel 6.19+.
+# Details: https://www.mongodb.com/community/forums/t/mongodb-8-x-and-linux-kernel-6-19/337547
+# Should be bumped to latest stable release on resolution of the issue.
+FROM mongo:7.0 AS release
 
 # No other build steps.
 


### PR DESCRIPTION
MongoDB 8.0+, which we were using for our test database, is incompatible with the latest versions of the Linux kernel. This means our Rest API and Web Socket Server tests will fail on updated Linux computers. As a workaround, I downgraded the Mongo version used by the test database to 7.0. This will only affect our tests, not our production database, which is of course hosted separately.

Here's some more information about the issue: https://www.mongodb.com/community/forums/t/mongodb-8-x-and-linux-kernel-6-19/337547
