### PR TITLE
Feat/icons active users

### DIFF
--- a/Frontend/src/app.config.ts
+++ b/Frontend/src/app.config.ts
@@ -36,5 +36,5 @@ export const WHITEBOARD_DELETED_NOTIFICATION_NUM_MILLIS = 5000;
 
 // -- Number of active users to display outside dropdown menu on Whiteboard page
 // header.
-export const ACTIVE_USERS_DISPLAY_LIMIT = 1;
+export const ACTIVE_USERS_DISPLAY_LIMIT = 3;
 

--- a/Frontend/src/app.config.ts
+++ b/Frontend/src/app.config.ts
@@ -33,3 +33,8 @@ export const DEFAULT_CLIENT_COLORS = [
 // -- Number of milliseconds to display a notification when a whiteboard is
 // deleted, before redirecting the user to their dashboard.
 export const WHITEBOARD_DELETED_NOTIFICATION_NUM_MILLIS = 5000;
+
+// -- Number of active users to display outside dropdown menu on Whiteboard page
+// header.
+export const ACTIVE_USERS_DISPLAY_LIMIT = 1;
+

--- a/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
+++ b/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
@@ -1,5 +1,5 @@
 import {
-  useState,
+  // useState,
   useContext,
 } from 'react';
 
@@ -9,10 +9,10 @@ import {
   useSelector,
 } from 'react-redux';
 
-import {
-  ChevronDown,
-  Circle,
-} from 'lucide-react';
+// import {
+//   ChevronDown,
+//   Circle,
+// } from 'lucide-react';
 
 import {
   type ClientIdType,
@@ -32,12 +32,12 @@ import {
 
 import WhiteboardContext from '@/context/WhiteboardContext';
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+// import {
+//   DropdownMenu,
+//   DropdownMenuContent,
+//   DropdownMenuLabel,
+//   DropdownMenuTrigger,
+// } from '@/components/ui/dropdown-menu';
 
 export const ActiveUsersHeaderDropdown = () => {
   // TODO: Abstract out a generic dropdown menu
@@ -52,7 +52,7 @@ export const ActiveUsersHeaderDropdown = () => {
     whiteboardId,
   } = whiteboardContext;
 
-  const [isActiveUsersOpen, setIsActiveUsersOpen] = useState<boolean>(false);
+  // const [isActiveUsersOpen, setIsActiveUsersOpen] = useState<boolean>(false);
 
   const activeUsers : Record<ClientIdType, ClientSummary> = useSelector(
     (state: RootState) => selectActiveUsersByWhiteboard(state, whiteboardId) || null,
@@ -60,34 +60,47 @@ export const ActiveUsersHeaderDropdown = () => {
   );
 
   return (
-    <DropdownMenu
-      key="active-users"
-      open={isActiveUsersOpen}
-      onOpenChange={setIsActiveUsersOpen}
-    >
-      <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-4 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap">
-        Active Users
-        <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <div className="flex flex-col">
-          {activeUsers && Object.values(activeUsers).map((u) => (
-            <DropdownMenuLabel
-              key={u.clientId}
-              className="flex flex-row content-center"
-            >
-              <Circle
-                size={20}
-                stroke={u.color}
-                strokeWidth={4}
-              />
-              <span className="pl-2">
-                {u.username}
-              </span>
-            </DropdownMenuLabel>
-          ))}
+    <div className="flex items-center gap-1">
+      {activeUsers && Object.values(activeUsers).map((u) => (
+        <div
+          key={u.clientId}
+          className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
+          style={{ backgroundColor: u.color }}
+          title={u.username}
+        >
+          {u.username[0].toUpperCase()}
         </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      ))}
+    </div>
+
+    // <DropdownMenu
+    //   key="active-users"
+    //   open={isActiveUsersOpen}
+    //   onOpenChange={setIsActiveUsersOpen}
+    // >
+    //   <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-4 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap">
+    //     Active Users
+    //     <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
+    //   </DropdownMenuTrigger>
+    //   <DropdownMenuContent>
+    //     <div className="flex flex-col">
+    //       {activeUsers && Object.values(activeUsers).map((u) => (
+    //         <DropdownMenuLabel
+    //           key={u.clientId}
+    //           className="flex flex-row content-center"
+    //         >
+    //           <Circle
+    //             size={20}
+    //             stroke={u.color}
+    //             strokeWidth={4}
+    //           />
+    //           <span className="pl-2">
+    //             {u.username}
+    //           </span>
+    //         </DropdownMenuLabel>
+    //       ))}
+    //     </div>
+    //   </DropdownMenuContent>
+    // </DropdownMenu>
   );
 };// -- end ActiveUsersHeaderDropdown

--- a/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
+++ b/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
@@ -39,7 +39,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-const ACTIVE_USERS_LIMIT = 2;
+const ACTIVE_USERS_LIMIT = 1;
 
 export const ActiveUsersHeaderDropdown = () => {
   // TODO: Abstract out a generic dropdown menu
@@ -64,7 +64,7 @@ export const ActiveUsersHeaderDropdown = () => {
   const activeUsersLength =  Object.keys(activeUsers).length;
 
   return (
-    activeUsersLength < ACTIVE_USERS_LIMIT
+    activeUsersLength <= ACTIVE_USERS_LIMIT
       ? 
       // Display all user icons side-by-side on header
       <div className="flex items-center gap-1">
@@ -72,7 +72,7 @@ export const ActiveUsersHeaderDropdown = () => {
           <div
             key={u.clientId}
             className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
-            style={{ backgroundColor: u.color }}
+            style={{ border: `2px solid ${u.color}` }}
             title={u.username}
           >
             {u.username[0].toUpperCase()}
@@ -87,18 +87,18 @@ export const ActiveUsersHeaderDropdown = () => {
         onOpenChange={setIsActiveUsersOpen}
       >
         <div className='flex justify-center items-center gap-2'>
-          {activeUsers && Object.values(activeUsers).slice(0, ACTIVE_USERS_LIMIT - 1).map((u) => (
+          {activeUsers && Object.values(activeUsers).slice(0, ACTIVE_USERS_LIMIT).map((u) => (
             <div
               key={u.clientId}
               className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
-              style={{ backgroundColor: u.color }}
+              style={{ border: `2px solid ${u.color}` }}
               title={u.username}
             >
               {u.username[0].toUpperCase()}
             </div>
           ))}
-          <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-0 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap">
-            ...
+          <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-0 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap" title="View all active users">
+            {`... +${activeUsersLength - ACTIVE_USERS_LIMIT}`}
             <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
@@ -111,7 +111,7 @@ export const ActiveUsersHeaderDropdown = () => {
                   <Circle
                     size={20}
                     stroke={u.color}
-                    strokeWidth={4}
+                    strokeWidth={2}
                   />
                   <span className="pl-2">
                     {u.username}

--- a/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
+++ b/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
@@ -15,6 +15,10 @@ import {
 } from 'lucide-react';
 
 import {
+  ACTIVE_USERS_DISPLAY_LIMIT,
+} from '@/app.config';
+
+import {
   type ClientIdType,
 } from '@/types/WebSocketProtocol';
 
@@ -39,8 +43,6 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-const ACTIVE_USERS_LIMIT = 1;
-
 export const ActiveUsersHeaderDropdown = () => {
   // TODO: Abstract out a generic dropdown menu
   // Active Users
@@ -57,14 +59,14 @@ export const ActiveUsersHeaderDropdown = () => {
   const [isActiveUsersOpen, setIsActiveUsersOpen] = useState<boolean>(false);
 
   const activeUsers : Record<ClientIdType, ClientSummary> = useSelector(
-    (state: RootState) => selectActiveUsersByWhiteboard(state, whiteboardId) || null,
+    (state: RootState) => selectActiveUsersByWhiteboard(state, whiteboardId) || {},
     lodash.isEqual
   );
 
   const activeUsersLength =  Object.keys(activeUsers).length;
 
   return (
-    activeUsersLength <= ACTIVE_USERS_LIMIT
+    activeUsersLength <= ACTIVE_USERS_DISPLAY_LIMIT
       ? 
       // Display all user icons side-by-side on header
       <div className="flex items-center gap-1">
@@ -80,14 +82,14 @@ export const ActiveUsersHeaderDropdown = () => {
         ))}
       </div>
       : 
-      // Display first <ACTIVE_USERS_LIMIT> user icons on header with dropdown option to see all
+      // Display first <ACTIVE_USERS_DISPLAY_LIMIT> user icons on header with dropdown option to see all
       <DropdownMenu
         key="active-users"
         open={isActiveUsersOpen}
         onOpenChange={setIsActiveUsersOpen}
       >
         <div className='flex justify-center items-center gap-2'>
-          {activeUsers && Object.values(activeUsers).slice(0, ACTIVE_USERS_LIMIT).map((u) => (
+          {activeUsers && Object.values(activeUsers).slice(0, ACTIVE_USERS_DISPLAY_LIMIT).map((u) => (
             <div
               key={u.clientId}
               className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
@@ -98,7 +100,7 @@ export const ActiveUsersHeaderDropdown = () => {
             </div>
           ))}
           <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-0 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap" title="View all active users">
-            {`... +${activeUsersLength - ACTIVE_USERS_LIMIT}`}
+            {`... +${activeUsersLength - ACTIVE_USERS_DISPLAY_LIMIT}`}
             <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
           </DropdownMenuTrigger>
           <DropdownMenuContent>

--- a/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
+++ b/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
@@ -61,7 +61,7 @@ export const ActiveUsersHeaderDropdown = () => {
     lodash.isEqual
   );
 
-  let activeUsersLength =  Object.keys(activeUsers).length;
+  const activeUsersLength =  Object.keys(activeUsers).length;
 
   return (
     activeUsersLength < ACTIVE_USERS_LIMIT

--- a/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
+++ b/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
@@ -65,10 +65,9 @@ export const ActiveUsersHeaderDropdown = () => {
 
   const activeUsersLength =  Object.keys(activeUsers).length;
 
-  return (
-    activeUsersLength <= ACTIVE_USERS_DISPLAY_LIMIT
-      ? 
-      // Display all user icons side-by-side on header
+  if (activeUsersLength <= ACTIVE_USERS_DISPLAY_LIMIT) {
+    // -- Display all user icons side-by-side on header
+    return (
       <div className="flex items-center gap-1">
         {activeUsers && Object.values(activeUsers).map((u) => (
           <div
@@ -81,10 +80,11 @@ export const ActiveUsersHeaderDropdown = () => {
           </div>
         ))}
       </div>
-      : 
-      // Display first <ACTIVE_USERS_DISPLAY_LIMIT> user icons on header with dropdown option to see all
+    );
+  } else {
+    // -- Display first <ACTIVE_USERS_DISPLAY_LIMIT> user icons on header with dropdown option to see all
+    return (
       <DropdownMenu
-        key="active-users"
         open={isActiveUsersOpen}
         onOpenChange={setIsActiveUsersOpen}
       >
@@ -124,5 +124,6 @@ export const ActiveUsersHeaderDropdown = () => {
           </DropdownMenuContent>
         </div>
       </DropdownMenu>
-  );
+    );
+  }
 };// -- end ActiveUsersHeaderDropdown

--- a/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
+++ b/Frontend/src/components/ActiveUsersHeaderDropdown.tsx
@@ -1,5 +1,5 @@
 import {
-  // useState,
+  useState,
   useContext,
 } from 'react';
 
@@ -9,10 +9,10 @@ import {
   useSelector,
 } from 'react-redux';
 
-// import {
-//   ChevronDown,
-//   Circle,
-// } from 'lucide-react';
+import {
+  ChevronDown,
+  Circle,
+} from 'lucide-react';
 
 import {
   type ClientIdType,
@@ -32,12 +32,14 @@ import {
 
 import WhiteboardContext from '@/context/WhiteboardContext';
 
-// import {
-//   DropdownMenu,
-//   DropdownMenuContent,
-//   DropdownMenuLabel,
-//   DropdownMenuTrigger,
-// } from '@/components/ui/dropdown-menu';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+const ACTIVE_USERS_LIMIT = 2;
 
 export const ActiveUsersHeaderDropdown = () => {
   // TODO: Abstract out a generic dropdown menu
@@ -52,55 +54,73 @@ export const ActiveUsersHeaderDropdown = () => {
     whiteboardId,
   } = whiteboardContext;
 
-  // const [isActiveUsersOpen, setIsActiveUsersOpen] = useState<boolean>(false);
+  const [isActiveUsersOpen, setIsActiveUsersOpen] = useState<boolean>(false);
 
   const activeUsers : Record<ClientIdType, ClientSummary> = useSelector(
     (state: RootState) => selectActiveUsersByWhiteboard(state, whiteboardId) || null,
     lodash.isEqual
   );
 
-  return (
-    <div className="flex items-center gap-1">
-      {activeUsers && Object.values(activeUsers).map((u) => (
-        <div
-          key={u.clientId}
-          className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
-          style={{ backgroundColor: u.color }}
-          title={u.username}
-        >
-          {u.username[0].toUpperCase()}
-        </div>
-      ))}
-    </div>
+  let activeUsersLength =  Object.keys(activeUsers).length;
 
-    // <DropdownMenu
-    //   key="active-users"
-    //   open={isActiveUsersOpen}
-    //   onOpenChange={setIsActiveUsersOpen}
-    // >
-    //   <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-4 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap">
-    //     Active Users
-    //     <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
-    //   </DropdownMenuTrigger>
-    //   <DropdownMenuContent>
-    //     <div className="flex flex-col">
-    //       {activeUsers && Object.values(activeUsers).map((u) => (
-    //         <DropdownMenuLabel
-    //           key={u.clientId}
-    //           className="flex flex-row content-center"
-    //         >
-    //           <Circle
-    //             size={20}
-    //             stroke={u.color}
-    //             strokeWidth={4}
-    //           />
-    //           <span className="pl-2">
-    //             {u.username}
-    //           </span>
-    //         </DropdownMenuLabel>
-    //       ))}
-    //     </div>
-    //   </DropdownMenuContent>
-    // </DropdownMenu>
+  return (
+    activeUsersLength < ACTIVE_USERS_LIMIT
+      ? 
+      // Display all user icons side-by-side on header
+      <div className="flex items-center gap-1">
+        {activeUsers && Object.values(activeUsers).map((u) => (
+          <div
+            key={u.clientId}
+            className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
+            style={{ backgroundColor: u.color }}
+            title={u.username}
+          >
+            {u.username[0].toUpperCase()}
+          </div>
+        ))}
+      </div>
+      : 
+      // Display first <ACTIVE_USERS_LIMIT> user icons on header with dropdown option to see all
+      <DropdownMenu
+        key="active-users"
+        open={isActiveUsersOpen}
+        onOpenChange={setIsActiveUsersOpen}
+      >
+        <div className='flex justify-center items-center gap-2'>
+          {activeUsers && Object.values(activeUsers).slice(0, ACTIVE_USERS_LIMIT - 1).map((u) => (
+            <div
+              key={u.clientId}
+              className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white select-none"
+              style={{ backgroundColor: u.color }}
+              title={u.username}
+            >
+              {u.username[0].toUpperCase()}
+            </div>
+          ))}
+          <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-0 py-2 rounded-lg hover:cursor-pointer hover:text-header-button-text-hover whitespace-nowrap">
+            ...
+            <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <div className="flex flex-col">
+              {activeUsers && Object.values(activeUsers).map((u) => (
+                <DropdownMenuLabel
+                  key={u.clientId}
+                  className="flex flex-row content-center"
+                >
+                  <Circle
+                    size={20}
+                    stroke={u.color}
+                    strokeWidth={4}
+                  />
+                  <span className="pl-2">
+                    {u.username}
+                  </span>
+                </DropdownMenuLabel>
+              ))}
+            </div>
+          </DropdownMenuContent>
+        </div>
+      </DropdownMenu>
   );
 };// -- end ActiveUsersHeaderDropdown

--- a/Frontend/src/components/CanvasMenu.tsx
+++ b/Frontend/src/components/CanvasMenu.tsx
@@ -225,7 +225,7 @@ const CanvasMenu = ({
     <div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <div className="rounded-lg shadow-2xl backdrop-blur-md bg-bar-background/80 border-1 border-border">
+          <div className="px-4 py-2 rounded-lg shadow-2xl backdrop-blur-md bg-bar-background/80 border-1 border-border">
             <HeaderButton
               title={
                 <div className="flex items-center gap-2">

--- a/Frontend/src/components/Header.tsx
+++ b/Frontend/src/components/Header.tsx
@@ -23,9 +23,9 @@ export interface HeaderProps {
   title: string;
   zIndex?: number;
   // Buttons and other elements to display on left side of header
-  toolbarElemsLeft?: React.JSX.Element[];
+  toolbarElemsLeft?: React.ReactNode[];
   // Buttons and other elements to display on right side of header
-  toolbarElemsRight?: React.JSX.Element[];
+  toolbarElemsRight?: React.ReactNode[];
   noMarginTop?: boolean;
 }
 

--- a/Frontend/src/components/Header.tsx
+++ b/Frontend/src/components/Header.tsx
@@ -40,7 +40,7 @@ const Header = ({
     <>
       {/** Floating header **/}
       <div
-        className="fixed top-1 left-0 right-0 max-h-15 backdrop-blur-md shadow-2xl rounded-lg border-border border-1 mx-5 lg:mx-30 m-1 px-3 py-1 bg-bar-background/80"
+        className="fixed top-1 left-0 right-0 max-h-15 backdrop-blur-md shadow-2xl rounded-lg border-border border-1 mx-5 lg:mx-30 m-1 px-3 py-2 bg-bar-background/80"
         style={{ zIndex }}
       > 
         <div className="relative flex items-center justify-between"> 

--- a/Frontend/src/components/Header.tsx
+++ b/Frontend/src/components/Header.tsx
@@ -71,7 +71,7 @@ const Header = ({
           </NavigationMenu>
 
           {/* Left Side Items */}
-          <div className="text-h2-text mx-4 gap-4 hidden md:flex w-60 items-center">
+          <div className="text-h2-text mx-4 gap-4 hidden md:flex items-center">
             {toolbarElemsLeft}
           </div>
 
@@ -81,7 +81,7 @@ const Header = ({
           </h1>
           
           {/* Right Side Items */}
-          <div className="text-h2-text mx-4 gap-4 hidden md:flex w-60 items-center justify-end">
+          <div className="text-h2-text mx-4 gap-4 hidden md:flex items-center justify-end">
             {toolbarElemsRight}
           </div>
         </div>

--- a/Frontend/src/components/HeaderAuthed.tsx
+++ b/Frontend/src/components/HeaderAuthed.tsx
@@ -56,7 +56,7 @@ const HeaderAuthed = ({
         (
           // Profile Dropdown
           <DropdownMenu key="profile">
-            <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 px-4 py-2 text-xl font-bold rounded-md hover:cursor-pointer hover:text-header-button-text-hover">
+            <DropdownMenuTrigger className="text-header-button-text group flex items-center gap-1 text-xl font-bold rounded-md hover:cursor-pointer hover:text-header-button-text-hover">
               {user?.username}
               <ChevronDown className="w-4 h-4 transition-transform duration-300 group-data-[state=open]:rotate-180"/>
             </DropdownMenuTrigger>

--- a/Frontend/src/components/HeaderButton.tsx
+++ b/Frontend/src/components/HeaderButton.tsx
@@ -14,7 +14,7 @@ import {
 import type { ReactNode } from 'react';
 
 const buttonVariants = cva(
-  "px-4 py-2 rounded-lg text-nowrap",
+  "rounded-lg text-nowrap",
   {
     variants: {
       variant: {

--- a/Frontend/src/pages/Whiteboard.tsx
+++ b/Frontend/src/pages/Whiteboard.tsx
@@ -673,6 +673,9 @@ const Whiteboard = ({
                     />
                   ),
                 ]}
+                toolbarElemsRight={[
+                  <ActiveUsersHeaderDropdown />,
+                ]}
                 noMarginTop={true}
               />
             </>}

--- a/Frontend/src/pages/Whiteboard.tsx
+++ b/Frontend/src/pages/Whiteboard.tsx
@@ -631,14 +631,13 @@ const Whiteboard = ({
       );
 
       // Delete whiteboard button (only if the user is an owner)
-      const DeleteWhiteboardButton = (ownPermission === 'own') ?
-        () => (
-          <HeaderButton
-            onClick={openDeleteWhiteboardModal}
-            title="Delete"
-          />
-        )
-        : () => null;
+      const DeleteWhiteboardButton = () => (
+        <HeaderButton
+          onClick={openDeleteWhiteboardModal}
+          title="Delete"
+          disabled={ownPermission !== 'own'}
+        />
+      );
       
       const pageTitle = `${title} | ${APP_NAME}`;
 
@@ -653,8 +652,8 @@ const Whiteboard = ({
                 title={title}
                 zIndex={10}
                 toolbarElemsLeft={[
-                  <ShareWhiteboardButton />,
-                  <DeleteWhiteboardButton />,
+                  ((ownPermission === 'own') && <ShareWhiteboardButton />),
+                  ((ownPermission === 'own') && <DeleteWhiteboardButton />),
                 ]}
                 toolbarElemsRight={[
                   <ActiveUsersHeaderDropdown />,


### PR DESCRIPTION
Active users are now listed as color-coded circle icons with the first initial of their username along the header. If the number of active users surpasses the limit, the number up to the limit will be displayed on the header and the all of them will be listed in a dropdown. The styling of everything is open to adjustment and can be refined in the upcoming UI updates. 

To test, open a whiteboard on an authed user account, the user's Initial should appear in the header. Then copy and paste that url in a private window. The limit is currently set to 1 active user, so both of these windows should now show a single user icon in the header along with the active users list. 