### PR TITLE
Refactor/debounce color selection

### DIFF
--- a/Frontend/src/app.config.ts
+++ b/Frontend/src/app.config.ts
@@ -38,3 +38,5 @@ export const WHITEBOARD_DELETED_NOTIFICATION_NUM_MILLIS = 5000;
 // header.
 export const ACTIVE_USERS_DISPLAY_LIMIT = 3;
 
+// -- Milliseconds to wait between throttled function execuations
+export const THROTTLE_INTERVAL = 100;

--- a/Frontend/src/components/AttributeFillColor.tsx
+++ b/Frontend/src/components/AttributeFillColor.tsx
@@ -1,7 +1,6 @@
 // -- std imports
 import {
   useContext,
-  useCallback,
 } from 'react';
 
 import {
@@ -33,6 +32,8 @@ import {
 
 import AttributeMenuItem from "./AttributeMenuItem";
 
+import { THROTTLE_INTERVAL, useThrottledCallback } from '@/hooks/useThrottledCallback';
+
 const FillColorComponent = ({
   selectedShapeIds, 
   dispatch, 
@@ -54,14 +55,10 @@ const FillColorComponent = ({
     lodash.isEqual
   );
 
-  const onChangeFillColor = useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement>) => {
-      ev.preventDefault();
+  const throttledUpdate = useThrottledCallback(
+    (color: string) => {
+      dispatch({ type: 'SET_FILL_COLOR', payload: color});
 
-      const color = ev.target.value;
-    
-      dispatch({ type: 'SET_FILL_COLOR', payload: color });
-    
       if (canvasObjectsById) {
         handleUpdateShapes(
           canvasId,
@@ -70,8 +67,12 @@ const FillColorComponent = ({
         );
       }
     },
-    [dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
+    THROTTLE_INTERVAL
   );
+
+  const onChangeFillColor = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    throttledUpdate(ev.target.value);
+  }
  
   return (
     <AttributeMenuItem title="Fill Color">

--- a/Frontend/src/components/AttributeFillColor.tsx
+++ b/Frontend/src/components/AttributeFillColor.tsx
@@ -23,6 +23,10 @@ import {
 import WhiteboardContext from '@/context/WhiteboardContext';
 
 import {
+  THROTTLE_INTERVAL,
+} from '@/app.config';
+
+import {
   type RootState,
 } from '@/store';
 
@@ -32,7 +36,7 @@ import {
 
 import AttributeMenuItem from "./AttributeMenuItem";
 
-import { THROTTLE_INTERVAL, useThrottledCallback } from '@/hooks/useThrottledCallback';
+import { useThrottledCallback } from '@/hooks/useThrottledCallback';
 
 const FillColorComponent = ({
   selectedShapeIds, 

--- a/Frontend/src/components/AttributeFontColor.tsx
+++ b/Frontend/src/components/AttributeFontColor.tsx
@@ -10,12 +10,15 @@ import {
 } from '@/store';
 
 import {
+  THROTTLE_INTERVAL,
+} from '@/app.config';
+import {
   selectCanvasObjectsByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
-import { THROTTLE_INTERVAL, useThrottledCallback } from '@/hooks/useThrottledCallback';
+import { useThrottledCallback } from '@/hooks/useThrottledCallback';
 
 const FontColorComponent = ({
   selectedShapeIds, 

--- a/Frontend/src/components/AttributeFontColor.tsx
+++ b/Frontend/src/components/AttributeFontColor.tsx
@@ -1,8 +1,4 @@
 import {
-  useCallback,
-} from 'react';
-
-import {
   useSelector,
 } from 'react-redux';
 
@@ -19,6 +15,7 @@ import {
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
+import { THROTTLE_INTERVAL, useThrottledCallback } from '@/hooks/useThrottledCallback';
 
 const FontColorComponent = ({
   selectedShapeIds, 
@@ -32,24 +29,25 @@ const FontColorComponent = ({
     lodash.isEqual
   );
 
-  const onChangeFontColor = useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement>) => {
-      ev.preventDefault();
-      const color = ev.target.value;
-    
-      dispatch({ type: 'SET_FONT_COLOR', payload: color });
-    
+  const throttledUpdate = useThrottledCallback(
+    (color: string) => {
+      dispatch({ type: 'SET_FONT_COLOR', payload: color});
+
       if (canvasObjectsById) {
         handleUpdateShapes(
           canvasId,
           canvasObjectsById,
           Object.fromEntries(selectedShapeIds.map(id => [id, { color: color }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
-        );  
+        );
       }
     },
-    [dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
-  );// -- end onChangeFontColor
- 
+    THROTTLE_INTERVAL
+  );
+
+  const onChangeFontColor = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    throttledUpdate(ev.target.value);
+  }
+  
   return (
     <div>
       <AttributeMenuItem title="Font Color">

--- a/Frontend/src/components/AttributeStrokeColor.tsx
+++ b/Frontend/src/components/AttributeStrokeColor.tsx
@@ -15,6 +15,7 @@ import {
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
+import { THROTTLE_INTERVAL, useThrottledCallback } from '@/hooks/useThrottledCallback';
 
 const StrokeColorComponent = ({
   selectedShapeIds, 
@@ -28,19 +29,23 @@ const StrokeColorComponent = ({
     lodash.isEqual
   );
 
+  const throttledUpdate = useThrottledCallback(
+    (color: string) => {
+      dispatch({ type: 'SET_STROKE_COLOR', payload: color});
+
+      if (canvasObjectsById) {
+        handleUpdateShapes(
+          canvasId,
+          canvasObjectsById,
+          Object.fromEntries(selectedShapeIds.map(id => [id, { strokeColor: color }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+        );
+      }
+    },
+    THROTTLE_INTERVAL
+  );
+
   const onChangeStrokeColor = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    ev.preventDefault();
-    const color = ev.target.value;
-  
-    dispatch({ type: 'SET_STROKE_COLOR', payload: color });
-  
-    if (canvasObjectsById) {
-      handleUpdateShapes(
-        canvasId,
-        canvasObjectsById,
-        Object.fromEntries(selectedShapeIds.map(id => [id, { strokeColor: color }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
-      );
-    }
+    throttledUpdate(ev.target.value);
   };
  
   return (

--- a/Frontend/src/components/AttributeStrokeColor.tsx
+++ b/Frontend/src/components/AttributeStrokeColor.tsx
@@ -5,6 +5,10 @@ import {
 import lodash from 'lodash';
 
 import {
+  THROTTLE_INTERVAL,
+} from '@/app.config';
+
+import {
   type RootState,
 } from '@/store';
 
@@ -15,7 +19,7 @@ import {
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
-import { THROTTLE_INTERVAL, useThrottledCallback } from '@/hooks/useThrottledCallback';
+import { useThrottledCallback } from '@/hooks/useThrottledCallback';
 
 const StrokeColorComponent = ({
   selectedShapeIds, 

--- a/Frontend/src/hooks/useThrottledCallback.ts
+++ b/Frontend/src/hooks/useThrottledCallback.ts
@@ -3,7 +3,7 @@ import lodash from 'lodash';
 
 export const THROTTLE_INTERVAL = 100; // ms between updates
 
-export function useThrottledCallback<T extends (...args: any[]) => any>(
+export function useThrottledCallback<T extends (...args: unknown[]) => unknown>(
   callback: T,
   interval: number
 ): T {

--- a/Frontend/src/hooks/useThrottledCallback.ts
+++ b/Frontend/src/hooks/useThrottledCallback.ts
@@ -1,0 +1,26 @@
+import { useRef, useEffect } from 'react';
+import lodash from 'lodash';
+
+export const THROTTLE_INTERVAL = 100; // ms between updates
+
+export function useThrottledCallback<T extends (...args: any[]) => any>(
+  callback: T,
+  interval: number
+): T {
+  const latestCallback = useRef(callback);
+  latestCallback.current = callback;
+
+  const throttledFn = useRef(
+    lodash.throttle(
+      (...args: Parameters<T>) => {
+        latestCallback.current(...args);
+      }, 
+      interval,
+      { leading: true, trailing: true }
+    )
+  ).current;
+
+  useEffect(() => () => throttledFn.cancel(), [throttledFn]);
+
+  return throttledFn as unknown as T;
+}

--- a/Frontend/src/hooks/useThrottledCallback.ts
+++ b/Frontend/src/hooks/useThrottledCallback.ts
@@ -3,18 +3,18 @@ import lodash from 'lodash';
 
 export const THROTTLE_INTERVAL = 100; // ms between updates
 
-export function useThrottledCallback<T extends (...args: unknown[]) => unknown>(
-  callback: T,
+export function useThrottledCallback<TArgs extends unknown[], TReturn>(
+  callback: (...args: TArgs) => TReturn,
   interval: number
-): T {
+): (...args: TArgs) => TReturn {
   const latestCallback = useRef(callback);
   latestCallback.current = callback;
 
   const throttledFn = useRef(
     lodash.throttle(
-      (...args: Parameters<T>) => {
+      (...args: TArgs) => {
         latestCallback.current(...args);
-      }, 
+      },
       interval,
       { leading: true, trailing: true }
     )
@@ -22,5 +22,5 @@ export function useThrottledCallback<T extends (...args: unknown[]) => unknown>(
 
   useEffect(() => () => throttledFn.cancel(), [throttledFn]);
 
-  return throttledFn as unknown as T;
+  return throttledFn as unknown as (...args: TArgs) => TReturn;
 }

--- a/Frontend/src/hooks/useThrottledCallback.ts
+++ b/Frontend/src/hooks/useThrottledCallback.ts
@@ -1,8 +1,6 @@
 import { useRef, useEffect } from 'react';
 import lodash from 'lodash';
 
-export const THROTTLE_INTERVAL = 100; // ms between updates
-
 export function useThrottledCallback<TArgs extends unknown[], TReturn>(
   callback: (...args: TArgs) => TReturn,
   interval: number


### PR DESCRIPTION
The color pickers now use a function throttler to limit the color change dispatches when using the color input selector tool. We initially called this 'debouncing' and I implemented that but discovered that debouncing would only limit the number of updates by waiting for a pause in activity and then firing the last queued call. In this case, that meant the color was only updating once the user stopped moving the cursor or released their click. I think that showing the gradual color changes as the user clicks and drags across the palette is better UX. This is achieved by 'throttling' which only calls the update once per defined interval. 