### PR TITLE
Create minimal age gate for NPM dependencies

### DIFF
--- a/Frontend/.yarnrc.yml
+++ b/Frontend/.yarnrc.yml
@@ -1,0 +1,4 @@
+# -- Ensure all dependencies releases are at least one week old, to decrease
+# likelihood of being compromised by a zero-day exploit.
+
+npmMinimalAgeGate: 10080  # minimum release age in minutes

--- a/RestAPI/.yarnrc.yml
+++ b/RestAPI/.yarnrc.yml
@@ -1,0 +1,4 @@
+# -- Ensure all dependencies releases are at least one week old, to decrease
+# likelihood of being compromised by a zero-day exploit.
+
+npmMinimalAgeGate: 10080  # minimum release age in minutes


### PR DESCRIPTION
Due to an increase in npm supply chain attacks, I decided to add dependency release age gates for the Frontend and RestAPI services. The age gate instructs yarn to only use versions of the dependencies that are at least one week old. This gives the dependency maintainers time to find vulnerabilities in their releases and unpublish them, reducing the likelihood of us being affected by a supply chain attack. More information can be found [here](https://medium.com/@roman_fedyskyi/yarn-4-10-adds-a-release-age-gate-for-safer-dependency-management-765c2d18149a).

- **Set npmMinimalAgeGate to 10080 (7 days) for RestAPI.**
- **Set npmMinimalAgeGate to 10080 (7 days) for Frontend.**
