### PR TITLE
Bugfix: web socket server can load empty canvases

### DIFF
--- a/TestDatabase/init-db.js
+++ b/TestDatabase/init-db.js
@@ -472,3 +472,127 @@ db.whiteboards.insertMany(whiteboards);
 const insertedWhiteboards = db.whiteboards.find().toArray();
 
 print("Database initialized with test users and whiteboards.");
+
+// === wss_fetch_canvas_with_no_objects ========================================
+//
+// Used to test loading a whiteboard containing a canvas with no objects.
+//
+// =============================================================================
+(() => {
+  const dbName = "wss_fetch_canvas_with_no_objects";
+  const testDb = db.getSiblingDB(dbName);
+
+  // -- Single test user (owner)
+  const userOwner = {
+    _id: new ObjectId(),
+    kind: "permanent",
+    username: "alice",
+    email: "alice@example.com",
+    // password: password123
+    passwordHashed: "$2b$10$lE4PvWzGiI.hKlq98/EFW.9QSKDDkq.O/WHvMjeMvheUiDxE2pzgW",
+  };// -- end const userOwner
+
+  testDb.users.insertOne(userOwner);
+
+  // -- Single whiteboard named containing a root canvas with canvas objects,
+  // plus a child canvas with no canvas objects
+  const rootCanvas = {
+    _id: new ObjectId(),
+    width: 3000,
+    height: 3000,
+    name: "Canvas Alpha",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+  };// -- end const rootCanvas
+
+  const childCanvas = {
+    _id: new ObjectId(),
+    width: 600,
+    height: 600,
+    name: "Canvas Beta",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+    parent_canvas: {
+      // Canvas Alpha
+      canvas_id: rootCanvas._id,
+      origin_x: 1000,
+      origin_y: 1000,
+    },
+  };// -- end const childCanvas
+
+  const grandchildCanvas = {
+    _id: new ObjectId(),
+    width: 600,
+    height: 600,
+    name: "Canvas Gamma",
+    time_created: new Date("2025-08-01T12:10:00.000Z"),
+    time_last_modified: new Date("2025-08-10T12:10:00.000Z"),
+    // null allowed_users = all users allowed
+    // allowed_users: [],
+    parent_canvas: {
+      // Canvas Alpha
+      canvas_id: childCanvas._id,
+      origin_x: 50,
+      origin_y: 50,
+    },
+  };// -- end const grandchildCanvas
+
+  testDb.canvases.insertMany([rootCanvas, childCanvas, grandchildCanvas]);
+
+  // -- All canvas objects belong to root canvas
+  const canvasObjects = [
+    {
+      _id: new ObjectId(),
+      canvas_id: rootCanvas._id,
+      type: 'rect',
+      width: 10,
+      height: 10,
+      x: 20,
+      y: 20,
+      rotation: 0,
+      fillColor: "red",
+      strokeColor: "black",
+      strokeWidth: 1.0,
+    },
+    {
+      _id: new ObjectId(),
+      canvas_id: rootCanvas._id,
+      type: 'rect',
+      width: 10,
+      height: 10,
+      x: 30,
+      y: 30,
+      rotation: 0,
+      fillColor: "red",
+      strokeColor: "black",
+      strokeWidth: 1.0,
+    },
+  ];// -- end const canvasObjects
+
+  testDb.shapes.insertMany(canvasObjects);
+
+  const whiteboard = {
+    _id: new ObjectId('68d5e8d4829da666aece0400'),
+    name: "Whiteboard Alpha",
+    kind: "permanent_whiteboard",
+    visibility: "private",
+    time_created: new Date("2025-08-01T12:00:00.000Z"),
+    root_canvas: rootCanvas._id,
+    user_permissions: [
+      {
+        type: 'user',
+        user: userOwner._id,  // Alice
+        email: userOwner.email,
+        permission: 'own',
+      }
+    ],
+  };// -- end const whiteboard
+
+  testDb.whiteboards.insertOne(whiteboard);
+})();// -- end wss_fetch_canvas_with_no_objects
+
+

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -1075,7 +1075,7 @@ pub struct CanvasMongoDBView {
     #[serde(skip_serializing)]
     pub canvas_hierarchy: Option<Vec<CanvasMongoDBView>>,
     // virtual field - don't serialize
-    #[serde(skip_serializing)]
+    #[serde(default,skip_serializing)]
     pub canvas_objects: Vec<CanvasObjectMongoDBView>,
     pub allowed_users: Option<Vec<ObjectId>>,
 }

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -2794,4 +2794,39 @@ mod unit_tests {
             }
         };// -- end server_msg
     } // -- end test_reverse_edit_after_other_user_edit
+
+    // === fetch_canvas_with_no_objects ============================================================
+    //
+    // Tests loading a whiteboard containing a canvas which has no canvas objects.
+    //
+    // See TestDatabase/init-db.js for the sample data.
+    //
+    // ============================================================================================
+    #[tokio::test]
+    async fn fetch_canvas_with_no_objects() {
+        // -- try fetching Project Alpha and its constituent components (see
+        // TestDatabase/init-db.js for document definitions)
+        use crate::bson::oid::ObjectId;
+        use db::{connect_mongodb, get_whiteboard_by_id};
+
+        // -- initialize database connection
+        let mongo_uri = "mongodb://test_db:27017/wss_fetch_canvas_with_no_objects";
+        let mongo_client = connect_mongodb(&mongo_uri).await.unwrap();
+        let db = mongo_client.default_database().unwrap();
+
+        let whiteboard_id_s = "68d5e8d4829da666aece0400";
+        let whiteboard_id = ObjectId::parse_str(&whiteboard_id_s).unwrap();
+
+        let whiteboard = get_whiteboard_by_id(&db, &whiteboard_id)
+            .await
+            .unwrap()
+            .unwrap();
+
+        println!("Whiteboard Received: {:?}", whiteboard);
+
+        assert!(*whiteboard.id() == whiteboard_id);
+        assert!(whiteboard.metadata().name() == "Whiteboard Alpha");
+        assert!(whiteboard.metadata().user_permissions().len() == 1);
+        assert!(whiteboard.canvases().len() == 3);
+    } // -- end fn fetch_canvas_with_no_objects()
 }


### PR DESCRIPTION
Fixed the bug that prevented whiteboards containing empty canvases from loading by having the canvas_objects field of CanvasObjectMongoDBView default to an empty vector if the canvas_objects field is missing in the query result.

- **Added fetch_canvas_with_no_objects test case to WebSocketServer, in server.rs.**
- **Modified canvas_objects fields of CanvasMongoDBView to default to an empty vector if the field is missing in the query result.**
