### PR TITLE
Fixed Share Whiteboard Form and Fully Implemented User Permission Change handling in the Web Socket Server

### DIFF
--- a/Frontend/src/components/ShareWhiteboardForm.tsx
+++ b/Frontend/src/components/ShareWhiteboardForm.tsx
@@ -184,7 +184,7 @@ const ShareWhiteboardForm = ({
   );
 
   // -- derived state
-  const permissionsSorted : UserPermission[] = useMemo(
+  const userIdPermissionsSorted : UserPermission[] = useMemo(
     () => {
       const userIdPermissions = Object.values(permissionsByUserId);
 
@@ -198,6 +198,13 @@ const ShareWhiteboardForm = ({
         }
       });
 
+      return userIdPermissions;
+    },
+    [permissionsByUserId]
+  );// -- end const userIdPermissionsSorted
+  
+  const emailPermissionsSorted : UserPermission[] = useMemo(
+    () => {
       const emailPermissions = Object.values(permissionsByEmail);
 
       emailPermissions.sort((a, b) => {
@@ -210,10 +217,10 @@ const ShareWhiteboardForm = ({
         }
       });
 
-      return [...userIdPermissions, ...emailPermissions];
+      return emailPermissions;
     },
-    [permissionsByUserId, permissionsByEmail]
-  );// -- end const permissionsSorted
+    [permissionsByEmail]
+  );// -- end emailPermissionsSorted
 
   const handleChangeNewEmail = useCallback(
     (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -221,14 +228,14 @@ const ShareWhiteboardForm = ({
       setNewEmail(ev.target.value);
     },
     [setNewEmail]
-  );
+  );// -- end handleChangeNewEmail
 
   const handleChangePermType = useCallback(
     (value: UserPermissionEnum) => {
       setNewUserPermType(value);
     },
     [setNewUserPermType]
-  );
+  );// -- end handleChangePermType
 
   const handleAddNewEmail = useCallback(
     (ev: React.MouseEvent<HTMLButtonElement>) => {
@@ -252,7 +259,7 @@ const ShareWhiteboardForm = ({
       });
     },
     [setNewEmail, setPermissionsByEmail, newUserPermType]
-  );
+  );// -- end handleAddNewEmail
 
   const removePermission = useCallback(
     (perm: UserPermission) => {
@@ -285,7 +292,7 @@ const ShareWhiteboardForm = ({
   const handleSubmit = useCallback(
     () => {
       const data: ShareWhiteboardFormData = ({
-        userPermissions: permissionsSorted,
+        userPermissions: [...userIdPermissionsSorted, ...emailPermissionsSorted],
       });
 
       setButtonStatus('pending');
@@ -294,7 +301,7 @@ const ShareWhiteboardForm = ({
           setButtonStatus('enabled');
         });
     },
-    [onSubmit, setButtonStatus, permissionsSorted]
+    [onSubmit, setButtonStatus, userIdPermissionsSorted, emailPermissionsSorted]
   );// -- end handleSubmit
 
   return (
@@ -367,7 +374,16 @@ const ShareWhiteboardForm = ({
             </thead>
             <tbody>
               {
-                permissionsSorted.map(perm => (
+                userIdPermissionsSorted.map(perm => (
+                  <RemovablePermission
+                    key={getKeyForPermission(perm)}
+                    perm={perm}
+                    onRemove={removePermission}
+                  />
+                ))
+              }
+              {
+                emailPermissionsSorted.map(perm => (
                   <RemovablePermission
                     key={getKeyForPermission(perm)}
                     perm={perm}
@@ -378,7 +394,7 @@ const ShareWhiteboardForm = ({
             </tbody>
           </table>
           {
-            permissionsSorted.length < 1 && (
+            (userIdPermissionsSorted.length + emailPermissionsSorted.length) < 1 && (
               <span>No user permissions created</span>
             )
           }

--- a/Frontend/src/components/ShareWhiteboardForm.tsx
+++ b/Frontend/src/components/ShareWhiteboardForm.tsx
@@ -2,6 +2,8 @@
 import {
   useState,
   useCallback,
+  useEffect,
+  useMemo,
 } from 'react';
 
 // -- third-party imports
@@ -10,11 +12,16 @@ import {
 } from 'lucide-react';
 
 // -- local imports
+import {
+  type UserIdType,
+} from '@/types/WebSocketProtocol';
 
 import {
   USER_PERMISSION_TYPES,
   type UserPermission,
   type UserPermissionEnum,
+  type UserPermissionByUser,
+  type UserPermissionByEmail,
 } from '@/types/UserPermission';
 
 import {
@@ -39,52 +46,117 @@ export interface ShareWhiteboardFormData {
 }
 
 export interface ShareWhiteboardFormProps {
-  initUserPermissions: UserPermission[];
+  isActive: boolean;
+  initPermissionsByUserId: Record<UserIdType, UserPermissionByUser>;
+  initPermissionsByEmail: Record<string, UserPermissionByEmail>;
   onSubmit: (data: ShareWhiteboardFormData) => Promise<unknown>;
 }
 
+const getKeyForPermission = (perm: UserPermission): string => {
+  let email : string | null;
+
+  switch (perm.type) {
+    case 'user':
+      switch (perm.user.kind) {
+        case 'temp':
+          email = null;
+          break;
+        case 'permanent':
+          email = perm.user.email;
+          break;
+        default:
+          throw new Error(`Unrecognized user format: ${perm.user}`);
+      }
+      break;
+    case 'email':
+      email = perm.email;
+      break;
+    default:
+      throw new Error(`Unrecognized permission type: ${perm}`);
+  }// -- end switch (perm.type)
+
+  const username: string | null = perm.type === 'user' ? perm.user.username : null;
+
+  if (email) {
+    return `email:${email}`;
+  } else if (username) {
+    return `username:${username}`;
+  } else {
+    throw new Error(
+      `Either email or username must be present on permission in order to form unique ID`
+    );
+  }
+};// -- end getKeyForPermission
+
+interface RemovablePermissionProps {
+  perm: UserPermission;
+  onRemove: (perm: UserPermission) => unknown;
+}// -- end interface RemovablePermissionProps
+
+const RemovablePermission = ({
+  perm,
+  onRemove,
+}: RemovablePermissionProps): React.JSX.Element => {
+  // as an entry in a table
+  const FIELD_UNAVAILABLE = '-';
+
+  let email : string | null;
+  switch (perm.type) {
+    case 'user':
+      switch (perm.user.kind) {
+        case 'temp':
+          email = null;
+          break;
+        case 'permanent':
+          email = perm.user.email;
+          break;
+        default:
+          throw new Error(`Unrecognized user format: ${perm.user}`);
+      }
+      break;
+    case 'email':
+      email = perm.email;
+      break;
+    default:
+      throw new Error(`Unrecognized permission type: ${perm}`);
+  }// -- end switch (perm.type)
+
+  const username: string | null = perm.type === 'user' ? perm.user.username : null;
+
+  const {
+    permission,
+  } = perm;
+
+  return (
+    <tr>
+      <td className="text-center">{email || FIELD_UNAVAILABLE}</td>
+      <td className="text-center">{username || FIELD_UNAVAILABLE}</td>
+      <td className="text-center">{permission}</td>
+      <td className="text-center">
+        <button
+          disabled={false}
+          onClick={() => onRemove(perm)}
+          className="hover:cursor-pointer hover:bg-gray-600 p-1 inline-block align-middle rounded-md"
+        >
+          <X size={18} />
+        </button>
+      </td>
+    </tr>
+  );
+};// -- end RemovablePermission
+
 const ShareWhiteboardForm = ({
-  initUserPermissions,
+  isActive,
+  initPermissionsByUserId,
+  initPermissionsByEmail,
   onSubmit,
 }: ShareWhiteboardFormProps): React.JSX.Element => {
-  // -- prop-derived state
-  const initPermissionsByKey: Record<string, UserPermission> = Object.fromEntries(
-    initUserPermissions.map(perm => {
-      switch (perm.type) {
-        case 'email':
-        {
-            const key = `email:${perm.email}`;
-
-            return [key, perm];
-        }
-        case 'user':
-        {
-            switch (perm.user.kind) {
-              case 'permanent':
-              {
-                  const key = `email:${perm.user.email}`;
-
-                  return [key, perm];
-              }
-              case 'temp':
-              {
-                  const key = `username:${perm.user.username}`;
-
-                  return [key, perm];
-              }
-              default:
-                throw new Error(`Unrecognized user type: ${perm.user}`);
-            }// -- end switch (perm.user.kind)
-        }
-        default:
-          throw new Error(`Unrecognized permission type: ${perm}`);
-      }
-    })
-  );
-
   // -- managed state
-  const [permissionsByKey, setPermissionsByKey] = useState<Record<string, UserPermission>>(
-    initPermissionsByKey
+  const [permissionsByUserId, setPermissionsByUserId] = useState<Record<UserIdType, UserPermissionByUser>>(
+    initPermissionsByUserId
+  );
+  const [permissionsByEmail, setPermissionsByEmail] = useState<Record<string, UserPermissionByEmail>>(
+    initPermissionsByEmail
   );
   const [newEmail, setNewEmail] = useState<string>("");
   const [newUserPermType, setNewUserPermType] = useState<UserPermissionEnum>(
@@ -92,8 +164,54 @@ const ShareWhiteboardForm = ({
   );
   const [buttonStatus, setButtonStatus] = useState<ButtonStatus>('enabled');
 
+  // -- reset permissions to init permissions when set from inactive to active
+  useEffect(
+    () => {
+      if (isActive) {
+        setPermissionsByUserId(initPermissionsByUserId);
+        setPermissionsByEmail(initPermissionsByEmail);
+      }
+    },
+    [
+      isActive,
+      setPermissionsByUserId,
+      setPermissionsByEmail,
+      initPermissionsByUserId,
+      initPermissionsByEmail,
+    ]
+  );
+
   // -- derived state
-  const permissions: UserPermission[] = Object.values(permissionsByKey);
+  const permissionsSorted : UserPermission[] = useMemo(
+    () => {
+      const userIdPermissions = Object.values(permissionsByUserId);
+
+      userIdPermissions.sort((a, b) => {
+        if (a.user.username < b.user.username) {
+          return -1;
+        } else if (a.user.username === b.user.username) {
+          return 0;
+        } else {
+          return 1;
+        }
+      });
+
+      const emailPermissions = Object.values(permissionsByEmail);
+
+      emailPermissions.sort((a, b) => {
+        if (a.email < b.email) {
+          return -1;
+        } else if (a.email === b.email) {
+          return 0;
+        } else {
+          return 1;
+        }
+      });
+
+      return [...userIdPermissions, ...emailPermissions];
+    },
+    [permissionsByUserId, permissionsByEmail]
+  );// -- end const permissionsSorted
 
   const handleChangeNewEmail = useCallback(
     (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -104,8 +222,8 @@ const ShareWhiteboardForm = ({
   );
 
   const handleChangePermType = useCallback(
-    (value: string) => {
-      setNewUserPermType(value as UserPermissionEnum);
+    (value: UserPermissionEnum) => {
+      setNewUserPermType(value);
     },
     [setNewUserPermType]
   );
@@ -116,98 +234,60 @@ const ShareWhiteboardForm = ({
 
       setNewEmail(newEmail => {
         if (newEmail) {
-          setPermissionsByKey(prev => ({
-            ...prev,
-            [newEmail]: ({
-              type: 'email',
-              email: newEmail,
-              permission: newUserPermType
-            })
-          }));
+          setPermissionsByEmail((oldPerms) => {
+            return {
+              ...oldPerms,
+              [newEmail]: {
+                type: 'email',
+                email: newEmail,
+                permission: newUserPermType,
+              },
+            };
+          });
         }
 
         return "";
       });
     },
-    [setNewEmail, setPermissionsByKey, newUserPermType]
+    [setNewEmail, setPermissionsByEmail, newUserPermType]
   );
 
-  const makeHandleRemoveByKey = (key: string) => () => {
-    setPermissionsByKey(prev => {
-      const {
-        [key]: _removed,
-        ...filtered
-      } = prev;
+  const removePermission = useCallback(
+    (perm: UserPermission) => {
+      console.log('!! removePermission:', perm);
 
-      return filtered;
-    });
-  };
+      switch (perm.type) {
+        case 'user':
+          setPermissionsByUserId((oldPerms) => {
+            const {
+              [perm.user.id]: _removedPerm,
+              ...nextPerms
+            } = oldPerms;
 
-  const RemovablePermission = (perm: UserPermission): React.JSX.Element => {
-    // as an entry in a table
-    const FIELD_UNAVAILABLE = '-';
+            console.log('!! nextPerms:', nextPerms);
+            return nextPerms;
+          });
+          break;
+        case 'email':
+          setPermissionsByEmail((oldPerms) => {
+            const {
+              [perm.email]: _removedPerm,
+              ...nextPerms
+            } = oldPerms;
 
-    let email : string | null;
-    switch (perm.type) {
-      case 'user':
-        switch (perm.user.kind) {
-          case 'temp':
-            email = null;
-            break;
-          case 'permanent':
-            email = perm.user.email;
-            break;
-          default:
-            throw new Error(`Unrecognized user format: ${perm.user}`);
-        }
-        break;
-      case 'email':
-        email = perm.email;
-        break;
-      default:
-        throw new Error(`Unrecognized permission type: ${perm}`);
-    }// -- end switch (perm.type)
-
-    const username: string | null = perm.type === 'user' ? perm.user.username : null;
-
-    const {
-      permission,
-    } = perm;
-
-    let key : string;
-    if (email) {
-      key = `email:${email}`;
-    } else if (username) {
-      key = `username:${username}`;
-    } else {
-      throw new Error(
-        `Either email or username must be present on permission in order to form unique ID`
-      );
-    }
-
-    return (
-      <tr key={key}>
-        <td className="text-center">{email || FIELD_UNAVAILABLE}</td>
-        <td className="text-center">{username || FIELD_UNAVAILABLE}</td>
-        <td className="text-center">{permission}</td>
-        <td className="text-center">
-          <button
-            onClick={makeHandleRemoveByKey(key)}
-            className="hover:cursor-pointer p-1 inline-block align-middle"
-          >
-            <X size={18} />
-          </button>
-        </td>
-      </tr>
-    );
-  };
+            console.log('!! nextPerms:', nextPerms);
+            return nextPerms;
+          });
+          break;
+      }// -- end switch (perm.type)
+    },
+    [setPermissionsByUserId, setPermissionsByEmail]
+  );// -- end removePermission
 
   const handleSubmit = useCallback(
-    (ev: React.FormEvent<HTMLFormElement>) => {
-      ev.preventDefault();
-
+    () => {
       const data: ShareWhiteboardFormData = ({
-        userPermissions: Object.values(permissionsByKey)
+        userPermissions: permissionsSorted,
       });
 
       setButtonStatus('pending');
@@ -216,98 +296,106 @@ const ShareWhiteboardForm = ({
           setButtonStatus('enabled');
         });
     },
-    [onSubmit, setButtonStatus, permissionsByKey]
-  );
+    [onSubmit, setButtonStatus, permissionsSorted]
+  );// -- end handleSubmit
 
   return (
     <div className="w-200 p-0 m-4 mt-0 flex flex-col flex-shrink">
-      <form onSubmit={handleSubmit}>
-        <h2 className="text-center text-2xl font-bold m-2">Update User Permissions</h2>
+      <h2 className="text-center text-2xl font-bold m-2">Update User Permissions</h2>
 
-        <div className="flex flex-col flex-shrink p-4">
-          <h3 className="text-lg font-semibold">
-            Invite collaborators by email
-          </h3>
+      <div className="flex flex-col flex-shrink p-4">
+        <h3 className="text-lg font-semibold">
+          Invite collaborators by email
+        </h3>
 
-          <div
-            className="flex flex-row align-text-bottom w-full"
+        <div
+          className="flex flex-row align-text-bottom w-full"
+        >
+          <Input
+            name="new-email"
+            type="email"
+            placeholder="Email"
+            onChange={handleChangeNewEmail}
+            value={newEmail}
+            className="mr-2 grow"
+          />
+
+          <label
+            htmlFor="permission-type"
+            className="mr-2 grow"
           >
-            <Input
-              name="new-email"
-              type="email"
-              placeholder="Email"
-              onChange={handleChangeNewEmail}
-              value={newEmail}
-              className="mr-2 grow"
-            />
+            Permission:
+          </label>
+          <Select value={newUserPermType} onValueChange={handleChangePermType}>
+            <SelectTrigger id="permission-type" className="hover:cursor-pointer mr-2 w-auto">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {USER_PERMISSION_TYPES.map(perm => (
+                <SelectItem key={perm} value={perm}>{perm}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-            <label
-              htmlFor="permission-type"
-              className="mr-2 grow"
-            >
-              Permission:
-            </label>
-            <Select value={newUserPermType} onValueChange={handleChangePermType}>
-              <SelectTrigger id="permission-type" className="hover:cursor-pointer mr-2 w-auto">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {USER_PERMISSION_TYPES.map(perm => (
-                  <SelectItem key={perm} value={perm}>{perm}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            <Button
-              variant="secondary"
-              onClick={handleAddNewEmail}
-            >
-              + Add Collaborator
-            </Button>
-          </div>
-
-          <div>
-            {/** Display user emails to add, with option to remove **/}
-            <h3 className="text-lg font-semibold my-2">
-              Collaborators to invite:
-            </h3>
-            <table className="w-full">
-              <thead>
-                <tr>
-                  <th>
-                    Email
-                  </th>
-                  <th>
-                    Username
-                  </th>
-                  <th>
-                    Permission
-                  </th>
-                  <th>
-                    Delete
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {permissions.map(perm => RemovablePermission(perm)) }
-              </tbody>
-            </table>
-            {
-              permissions.length < 1 && <span>No user permissions created</span>
-            }
-          </div>
-        </div>
-
-        <div className="flex flex-row justify-center">
           <Button
-            type="submit"
-            status={buttonStatus}
-            className="w-1/2"
+            variant="secondary"
+            onClick={handleAddNewEmail}
           >
-            Update User Permissions
+            + Add Collaborator
           </Button>
         </div>
-      </form>
+
+        <div>
+          {/** Display user emails to add, with option to remove **/}
+          <h3 className="text-lg font-semibold my-2">
+            Collaborators to invite:
+          </h3>
+          <table className="w-full">
+            <thead>
+              <tr>
+                <th>
+                  Email
+                </th>
+                <th>
+                  Username
+                </th>
+                <th>
+                  Permission
+                </th>
+                <th>
+                  Delete
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {
+                permissionsSorted.map(perm => (
+                  <RemovablePermission
+                    key={getKeyForPermission(perm)}
+                    perm={perm}
+                    onRemove={removePermission}
+                  />
+                ))
+              }
+            </tbody>
+          </table>
+          {
+            permissionsSorted.length < 1 && (
+              <span>No user permissions created</span>
+            )
+          }
+        </div>
+      </div>
+
+      <div className="flex flex-row justify-center">
+        <Button
+          status={buttonStatus}
+          className="w-1/2"
+          onClick={handleSubmit}
+        >
+          Update User Permissions
+        </Button>
+      </div>
     </div>
   );
 };

--- a/Frontend/src/components/ShareWhiteboardForm.tsx
+++ b/Frontend/src/components/ShareWhiteboardForm.tsx
@@ -88,20 +88,32 @@ const getKeyForPermission = (perm: UserPermission): string => {
   }
 };// -- end getKeyForPermission
 
-interface RemovablePermissionProps {
+interface EditablePermissionProps {
   perm: UserPermission;
+  onChange: (perm: UserPermission) => unknown;
   onRemove: (perm: UserPermission) => unknown;
-}// -- end interface RemovablePermissionProps
+}// -- end interface EditablePermissionProps
 
-const RemovablePermission = ({
+const EditablePermission = ({
   perm,
+  onChange,
   onRemove,
-}: RemovablePermissionProps): React.JSX.Element => {
+}: EditablePermissionProps): React.JSX.Element => {
   // as an entry in a table
   const FIELD_UNAVAILABLE = '-';
 
   let email : string | null;
   let username : string | null = null;
+
+  const handleChangePermType = useCallback(
+    (newPerm: UserPermissionEnum) => {
+      onChange({
+        ...perm,
+        permission: newPerm,
+      });
+    },
+    [perm, onChange]
+  );// -- end handleChangePermType
 
   switch (perm.type) {
     case 'user':
@@ -133,10 +145,20 @@ const RemovablePermission = ({
     <tr>
       <td className="text-center">{email || FIELD_UNAVAILABLE}</td>
       <td className="text-center">{username || FIELD_UNAVAILABLE}</td>
-      <td className="text-center">{permission}</td>
+      <td className="flex flex-row justify-center">
+        <Select value={permission} onValueChange={handleChangePermType}>
+          <SelectTrigger id="permission-type" className="hover:cursor-pointer mr-2 w-auto">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {USER_PERMISSION_TYPES.map(perm => (
+              <SelectItem key={perm} value={perm}>{perm}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </td>
       <td className="text-center">
         <button
-          disabled={false}
           onClick={() => onRemove(perm)}
           className="hover:cursor-pointer hover:bg-gray-600 p-1 inline-block align-middle rounded-md"
         >
@@ -145,7 +167,7 @@ const RemovablePermission = ({
       </td>
     </tr>
   );
-};// -- end RemovablePermission
+};// -- end EditablePermission
 
 const ShareWhiteboardForm = ({
   isActive,
@@ -289,6 +311,32 @@ const ShareWhiteboardForm = ({
     [setPermissionsByUserId, setPermissionsByEmail]
   );// -- end removePermission
 
+  const handleChangePermission = useCallback(
+    (perm: UserPermission) => {
+      switch (perm.type) {
+        case 'user':
+          setPermissionsByUserId((oldPermissions) => {
+            return {
+              ...oldPermissions,
+              [perm.user.id]: perm,
+            };
+          });
+          break;
+        case 'email':
+          setPermissionsByEmail((oldPermissions) => {
+            return {
+              ...oldPermissions,
+              [perm.email]: perm,
+            };
+          });
+          break;
+        default:
+          throw new Error(`Unrecognized permission: ${perm}`);
+      }// -- end switch (perm.type)
+    },
+    [setPermissionsByUserId, setPermissionsByEmail]
+  );// -- end handleChangePermission
+
   const handleSubmit = useCallback(
     () => {
       const data: ShareWhiteboardFormData = ({
@@ -314,7 +362,7 @@ const ShareWhiteboardForm = ({
         </h3>
 
         <div
-          className="flex flex-row align-text-bottom w-full"
+          className="flex flex-row align-center w-full"
         >
           <Input
             name="new-email"
@@ -331,7 +379,7 @@ const ShareWhiteboardForm = ({
           >
             Permission:
           </label>
-          <Select value={newUserPermType} onValueChange={handleChangePermType}>
+          <Select name="permission-type" value={newUserPermType} onValueChange={handleChangePermType}>
             <SelectTrigger id="permission-type" className="hover:cursor-pointer mr-2 w-auto">
               <SelectValue />
             </SelectTrigger>
@@ -375,18 +423,20 @@ const ShareWhiteboardForm = ({
             <tbody>
               {
                 userIdPermissionsSorted.map(perm => (
-                  <RemovablePermission
+                  <EditablePermission
                     key={getKeyForPermission(perm)}
                     perm={perm}
+                    onChange={handleChangePermission}
                     onRemove={removePermission}
                   />
                 ))
               }
               {
                 emailPermissionsSorted.map(perm => (
-                  <RemovablePermission
+                  <EditablePermission
                     key={getKeyForPermission(perm)}
                     perm={perm}
+                    onChange={handleChangePermission}
                     onRemove={removePermission}
                   />
                 ))

--- a/Frontend/src/components/ShareWhiteboardForm.tsx
+++ b/Frontend/src/components/ShareWhiteboardForm.tsx
@@ -175,13 +175,31 @@ const ShareWhiteboardForm = ({
   initPermissionsByEmail,
   onSubmit,
 }: ShareWhiteboardFormProps): React.JSX.Element => {
-  // -- managed state
+  // -- Existing (but not committed) permissions
   const [permissionsByUserId, setPermissionsByUserId] = useState<Record<UserIdType, UserPermissionByUser>>(
     initPermissionsByUserId
   );
   const [permissionsByEmail, setPermissionsByEmail] = useState<Record<string, UserPermissionByEmail>>(
     initPermissionsByEmail
   );
+
+  const userIdsByEmail : Record<string, UserIdType> = useMemo(
+    () => {
+      return Object.fromEntries(Object.entries(permissionsByUserId).map(([userId, perm]) => {
+        switch (perm.user.kind) {
+          case 'temp':
+            return null;
+          case 'permanent':
+            return [perm.user.email, userId];
+          default:
+            throw new Error(`Unrecognized user type: ${perm.user}`);
+        }// -- end switch (perm.user.kind)
+      }).filter(entry => !!entry));
+    },
+    [permissionsByUserId]
+  );// -- end const userIdsByEmail
+
+  // -- New permission input state
   const [newEmail, setNewEmail] = useState<string>("");
   const [newUserPermType, setNewUserPermType] = useState<UserPermissionEnum>(
     USER_PERMISSION_TYPES[0] as UserPermissionEnum
@@ -265,22 +283,38 @@ const ShareWhiteboardForm = ({
 
       setNewEmail(newEmail => {
         if (newEmail) {
-          setPermissionsByEmail((oldPerms) => {
-            return {
-              ...oldPerms,
-              [newEmail]: {
-                type: 'email',
-                email: newEmail,
+          if (newEmail in userIdsByEmail) {
+            // -- Simply override existing user id permission
+            setPermissionsByUserId((oldPermissions) => {
+              const userId = userIdsByEmail[newEmail];
+              const newPerm : UserPermissionByUser = {
+                ...oldPermissions[userId],
                 permission: newUserPermType,
-              },
-            };
-          });
+              };
+
+              return {
+                ...oldPermissions,
+                [userId]: newPerm,
+              };
+            });
+          } else {
+            setPermissionsByEmail((oldPerms) => {
+              return {
+                ...oldPerms,
+                [newEmail]: {
+                  type: 'email',
+                  email: newEmail,
+                  permission: newUserPermType,
+                },
+              };
+            });
+          }
         }
 
         return "";
       });
     },
-    [setNewEmail, setPermissionsByEmail, newUserPermType]
+    [setNewEmail, setPermissionsByEmail, newUserPermType, userIdsByEmail]
   );// -- end handleAddNewEmail
 
   const removePermission = useCallback(

--- a/Frontend/src/components/ShareWhiteboardForm.tsx
+++ b/Frontend/src/components/ShareWhiteboardForm.tsx
@@ -101,8 +101,12 @@ const RemovablePermission = ({
   const FIELD_UNAVAILABLE = '-';
 
   let email : string | null;
+  let username : string | null = null;
+
   switch (perm.type) {
     case 'user':
+      username = perm.user.username;
+
       switch (perm.user.kind) {
         case 'temp':
           email = null;
@@ -120,8 +124,6 @@ const RemovablePermission = ({
     default:
       throw new Error(`Unrecognized permission type: ${perm}`);
   }// -- end switch (perm.type)
-
-  const username: string | null = perm.type === 'user' ? perm.user.username : null;
 
   const {
     permission,
@@ -254,8 +256,6 @@ const ShareWhiteboardForm = ({
 
   const removePermission = useCallback(
     (perm: UserPermission) => {
-      console.log('!! removePermission:', perm);
-
       switch (perm.type) {
         case 'user':
           setPermissionsByUserId((oldPerms) => {
@@ -264,7 +264,6 @@ const ShareWhiteboardForm = ({
               ...nextPerms
             } = oldPerms;
 
-            console.log('!! nextPerms:', nextPerms);
             return nextPerms;
           });
           break;
@@ -275,7 +274,6 @@ const ShareWhiteboardForm = ({
               ...nextPerms
             } = oldPerms;
 
-            console.log('!! nextPerms:', nextPerms);
             return nextPerms;
           });
           break;

--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -81,6 +81,7 @@ import {
   setClientId,
   setClientCursorPos,
   addWhiteboard,
+  updateWhiteboard,
   deleteWhiteboard,
   setWhiteboardStatus,
   setCanvasObjects,
@@ -234,6 +235,21 @@ const WebSocketClientMessengerProvider = ({
               // -- remove logged out users
               removeActiveUsers(dispatch, clients);
             } 
+            break;
+          case 'set_permissions':
+            {
+              console.log('!! set_permissions:', msg);
+
+              const {
+                permissionsByEmail,
+                permissionsByUserId,
+              } = msg;
+
+              updateWhiteboard(dispatch, whiteboardId, {
+                permissionsByUserId,
+                permissionsByEmail,
+              });
+            }
             break;
           case 'editing_canvas':
             {
@@ -426,6 +442,31 @@ const WebSocketClientMessengerProvider = ({
 
             // -- update cursor in state store
             setClientCursorPos(dispatch, clientId, x, y);
+          }
+          break;
+          case 'evict':
+          {
+            const {
+              reason,
+            } = msg;
+
+            toast.warn(`You have been evicted from this whiteboard: ${reason}`);
+
+            // -- set whiteboard status to "deleting"
+            setWhiteboardStatus(dispatch, whiteboardId, "deleting");
+
+            // -- close connection
+            if (webSocketRef.current) {
+              webSocketRef.current.close();
+            }
+
+            // -- set timeout for changing status from "deleting" to "deleted"
+            window.setTimeout(
+              () => {
+                deleteWhiteboard(dispatch, whiteboardId);
+              },
+              WHITEBOARD_DELETED_NOTIFICATION_NUM_MILLIS
+            );
           }
           break;
           case 'confirm':

--- a/Frontend/src/context/WhiteboardContext.tsx
+++ b/Frontend/src/context/WhiteboardContext.tsx
@@ -20,10 +20,8 @@ import type {
 } from '@/types/WebSocketProtocol';
 
 import {
-  type UserPermission,
-} from '@/types/UserPermission'
-
-import type { OperationDispatcher } from '@/types/OperationDispatcher';
+  type OperationDispatcher,
+} from '@/types/OperationDispatcher';
 
 export interface WhiteboardContextType {
   handleUpdateShapes: (
@@ -32,8 +30,6 @@ export interface WhiteboardContextType {
       updates: Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
   ) => unknown;
   whiteboardId: WhiteboardIdType;
-  userPermissions: UserPermission[];
-  setSharedUsers: React.Dispatch<React.SetStateAction<UserPermission[]>>;
   // -- view/edit/own permission - determines which actions to enable/disable
   currentDispatcherRef: RefObject<OperationDispatcher | null>;
   // -- tracks refs to Canvas groups (Konva Groups serve as frames for each Canvas)
@@ -48,8 +44,6 @@ const WhiteboardProvider = ({
   handleUpdateShapes,
   whiteboardId,
   children,
-  userPermissions,
-  setSharedUsers,
   currentDispatcherRef,
   canvasGroupRefsByIdRef,
 }: PropsWithChildren<WhiteboardProvidersProps>): React.JSX.Element => {
@@ -57,8 +51,6 @@ const WhiteboardProvider = ({
     <WhiteboardContext.Provider value={{
       handleUpdateShapes,
       whiteboardId,
-      userPermissions,
-      setSharedUsers,
       currentDispatcherRef,
       canvasGroupRefsByIdRef,
     }}>

--- a/Frontend/src/pages/Whiteboard/ShareWhiteboardForm.tsx
+++ b/Frontend/src/pages/Whiteboard/ShareWhiteboardForm.tsx
@@ -119,7 +119,7 @@ export const ShareWhiteboardForm = ({
     () => {
       return Object.fromEntries(Object.entries(usersById).map(([userId, user]) => {
         if (! (userId in permissionsByUserId)) {
-          throw new Error(`User id ${userId} not found in permissionsByUserId`);
+          return null;
         }
 
         return [
@@ -130,7 +130,7 @@ export const ShareWhiteboardForm = ({
             permission: permissionsByUserId[userId],
           }
         ];
-      }));
+      }).filter(entry => !!entry));
     },
     [usersById, permissionsByUserId]
   );// -- end const initPermissionsByUserId

--- a/Frontend/src/pages/Whiteboard/ShareWhiteboardForm.tsx
+++ b/Frontend/src/pages/Whiteboard/ShareWhiteboardForm.tsx
@@ -1,0 +1,219 @@
+// -- std imports
+import {
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+} from 'react';
+
+// -- third-party imports
+import lodash from 'lodash';
+
+import {
+  useSelector,
+} from 'react-redux';
+
+import {
+  toast,
+} from 'react-toastify';
+
+import {
+  type AxiosError,
+} from 'axios';
+
+// -- local imports
+import {
+  type UserIdType,
+} from '@/types/WebSocketProtocol';
+
+import {
+  type UserPermissionEnum,
+  type UserPermissionByUser,
+  type UserPermissionByEmail,
+} from '@/types/UserPermission';
+
+import {
+  type User,
+} from '@/types/User';
+
+import api from '@/api/axios';
+
+import {
+  type RootState,
+} from '@/store';
+
+import {
+  selectPermissionsByUserByWhiteboard,
+  selectPermissionsByEmailByWhiteboard,
+} from '@/store/whiteboards/whiteboardsSelectors';
+
+import WhiteboardContext from '@/context/WhiteboardContext';
+import UserCacheContext from '@/context/UserCacheContext';
+
+import ShareWhiteboardFormUI, {
+  type ShareWhiteboardFormData
+} from '@/components/ShareWhiteboardForm';
+
+export interface ShareWhiteboardFormProps {
+  isActive: boolean;
+  onClose: () => unknown;
+}// -- end interface ShareWhiteboardFormProps
+
+export const ShareWhiteboardForm = ({
+  isActive,
+  onClose,
+}: ShareWhiteboardFormProps): React.JSX.Element => {
+  const whiteboardContext = useContext(WhiteboardContext);
+
+  if (! whiteboardContext) {
+    throw new Error('No WhiteboardContext provided');
+  }
+
+  const {
+    whiteboardId,
+  } = whiteboardContext;
+
+  const userCacheContext = useContext(UserCacheContext);
+
+  if (! userCacheContext) {
+    throw new Error('No UserCacheContext provided');
+  }
+
+  const {
+    getUserById,
+  } = userCacheContext;
+
+  const permissionsByUserId : Record<UserIdType, UserPermissionEnum> = useSelector(
+    (state: RootState) => selectPermissionsByUserByWhiteboard(state, whiteboardId) || {},
+    lodash.isEqual
+  );
+
+  const permissionsByEmail : Record<string, UserPermissionEnum> = useSelector(
+    (state: RootState) => selectPermissionsByEmailByWhiteboard(state, whiteboardId) || {},
+    lodash.isEqual
+  );
+
+  const [usersById, setUsersById] = useState<Record<UserIdType, User>>({});
+
+  useEffect(
+    () => {
+      const updateUsersById = async () => {
+        const userIds = Object.keys(permissionsByUserId);
+
+        const nextUsersById : Record<UserIdType, User> = Object.fromEntries(
+          await Promise.all(userIds.map(
+            async (userId) => [userId, await getUserById(userId)]
+          ))
+        );
+
+        setUsersById(nextUsersById);
+      };// -- end updateUsersById
+
+      updateUsersById();
+    },
+    [permissionsByUserId, getUserById]
+  );
+
+  const initPermissionsByUserId: Record<UserIdType, UserPermissionByUser> = useMemo(
+    () => {
+      return Object.fromEntries(Object.entries(usersById).map(([userId, user]) => {
+        if (! (userId in permissionsByUserId)) {
+          throw new Error(`User id ${userId} not found in permissionsByUserId`);
+        }
+
+        return [
+          userId,
+          {
+            type: 'user',
+            user,
+            permission: permissionsByUserId[userId],
+          }
+        ];
+      }));
+    },
+    [usersById, permissionsByUserId]
+  );// -- end const initPermissionsByUserId
+
+  const initPermissionsByEmail : Record<string, UserPermissionByEmail> = useMemo(
+    () => {
+      return Object.fromEntries(
+        Object.entries(permissionsByEmail).map((email, perm) => [
+          email,
+          {
+            type: 'email',
+            email,
+            permission: perm,
+          }
+        ])
+      );
+    },
+    [permissionsByEmail]
+  );// -- end const initPermissionsByEmail
+
+  const handleSubmit = useCallback(
+    async (data: ShareWhiteboardFormData) => {
+      try {
+        const {
+          userPermissions
+        } = data;
+
+        const userPermissionsFinal = userPermissions.map(perm => {
+          if (perm.type === 'user') {
+            if ((typeof perm.user) === 'object') {
+              // extract object id
+              return ({
+                ...perm,
+                user: perm.user.id
+              });
+            } else {
+              // already object id
+              return perm;
+            }
+          } else {
+            return perm;
+          }
+        });
+
+        // -- make sure we have at least one owner
+        if (! userPermissionsFinal.find(perm => perm.permission === 'own')) {
+          // -- display popup alert
+          toast.error('Whiteboard must have at least one owner.');
+
+          return;
+        }
+
+        // No need for AxiosResp<..> type check, as response body
+        // isn't used.
+        await api.post(`/whiteboards/${whiteboardId}/user_permissions`, ({
+          userPermissions: userPermissionsFinal
+        }));
+
+        // -- display popup alert
+        toast.success('User permissions updated successfully');
+
+        onClose();
+      } catch (err: unknown) {
+          const axiosErr = err as AxiosError<{ error: string; }>;
+
+          console.error('POST /whiteboards/:id/user_permissions failed:', axiosErr);
+
+          // -- display popup alert
+          toast.error(`Share request failed: ${axiosErr.response?.data.error}`);
+
+          // -- propagate error to caller
+          throw err;
+      }
+    },
+    [whiteboardId, onClose]
+  );// -- end handleSubmit
+
+  return (
+    <ShareWhiteboardFormUI
+      isActive={isActive}
+      initPermissionsByUserId={initPermissionsByUserId}
+      initPermissionsByEmail={initPermissionsByEmail}
+      onSubmit={handleSubmit}
+    />
+  );
+};// -- end ShareWhiteboardForm

--- a/Frontend/src/pages/Whiteboard/ShareWhiteboardForm.tsx
+++ b/Frontend/src/pages/Whiteboard/ShareWhiteboardForm.tsx
@@ -138,13 +138,13 @@ export const ShareWhiteboardForm = ({
   const initPermissionsByEmail : Record<string, UserPermissionByEmail> = useMemo(
     () => {
       return Object.fromEntries(
-        Object.entries(permissionsByEmail).map((email, perm) => [
+        Object.entries(permissionsByEmail).map(([email, perm]) => [
           email,
-          {
+          ({
             type: 'email',
             email,
             permission: perm,
-          }
+          })
         ])
       );
     },

--- a/Frontend/src/pages/Whiteboard/index.tsx
+++ b/Frontend/src/pages/Whiteboard/index.tsx
@@ -30,7 +30,6 @@ import {
 
 import {
   useQuery,
-  useQueryClient
 } from '@tanstack/react-query';
 
 import {
@@ -109,7 +108,11 @@ import {
   NotificationsHeaderMenu,
 } from '@/pages/Whiteboard/NotificationsHeaderMenu';
 
-// -- ui components
+import {
+  ShareWhiteboardForm,
+} from '@/pages/Whiteboard/ShareWhiteboardForm'
+
+// -- headless components
 import {
   ActiveUsersHeaderDropdown,
 } from '@/components/ActiveUsersHeaderDropdown';
@@ -118,10 +121,6 @@ import type {
   CanvasObjectIdType,
   CanvasObjectModel,
 } from '@/types/CanvasObjectModel';
-
-import ShareWhiteboardForm, {
-  type ShareWhiteboardFormData
-} from '@/components/ShareWhiteboardForm';
 
 import CreateCanvasMenu, {
   type NewCanvas,
@@ -196,7 +195,6 @@ const Whiteboard = ({
   const whiteboardContext = useContext(WhiteboardContext);
   const authContext = useContext(AuthContext);
   const clientMessengerContext = useContext(ClientMessengerContext);
-  const queryClient = useQueryClient();
 
   if (! whiteboardContext) {
     throw new Error('No WhiteboardContext provided to Whiteboard');
@@ -212,7 +210,6 @@ const Whiteboard = ({
 
   const {
     whiteboardId,
-    userPermissions,
   } = whiteboardContext;
 
   const {
@@ -223,9 +220,6 @@ const Whiteboard = ({
     (state: RootState) => selectWhiteboardPermissionByUser(state, whiteboardId, user.id),
     lodash.isEqual
   );
-
-  // -- prop-derived state
-  const whiteboardKey = ['whiteboard', whiteboardId];
 
   // -- managed state
   const {
@@ -339,6 +333,24 @@ const Whiteboard = ({
     openModal: openShareModal,
     closeModal: closeShareModal
   } = useModal();
+
+  const [isShareFormActive, setIsShareFormActive] = useState<boolean>(false);
+
+  const handleOpenShareModal = useCallback(
+    () => {
+      setIsShareFormActive(true);
+      openShareModal();
+    },
+    [openShareModal, setIsShareFormActive]
+  );// -- end handleOpenShareModal
+
+  const handleCloseShareModal = useCallback(
+    () => {
+      setIsShareFormActive(false);
+      closeShareModal();
+    },
+    [closeShareModal, setIsShareFormActive]
+  );// -- end handleCloseShareModal
 
   const {
     Modal: CreateCanvasModal,
@@ -638,7 +650,7 @@ const Whiteboard = ({
       const ShareWhiteboardButton = () => (
         <HeaderButton 
           onClick={() => {
-            openShareModal();
+            handleOpenShareModal();
           }}
           title="Share"
           disabled={ownPermission !== 'own'}
@@ -759,7 +771,7 @@ const Whiteboard = ({
                   className="flex flex-row justify-end"
                 >
                   <button
-                    onClick={closeShareModal}
+                    onClick={handleCloseShareModal}
                     className="hover:cursor-pointer"
                   >
                     <X />
@@ -767,92 +779,8 @@ const Whiteboard = ({
                 </div>
       
                 <ShareWhiteboardForm
-                  initUserPermissions={userPermissions || []}
-                  onSubmit={async (data: ShareWhiteboardFormData) => {
-                    try {
-                      const {
-                        userPermissions
-                      } = data;
-      
-                      const userPermissionsFinal = userPermissions.map(perm => {
-                        if (perm.type === 'user') {
-                          if ((typeof perm.user) === 'object') {
-                            // extract object id
-                            return ({
-                              ...perm,
-                              user: perm.user.id
-                            });
-                          } else {
-                            // already object id
-                            return perm;
-                          }
-                        } else {
-                          return perm;
-                        }
-                      });
-
-                      // -- make sure we have at least one owner
-                      if (! userPermissionsFinal.find(perm => perm.permission === 'own')) {
-                        // -- display popup alert
-                        toast.error('Whiteboard must have at least one owner.', {
-                          position: "bottom-center",
-                          hideProgressBar: true,
-                          closeOnClick: true,
-                          pauseOnHover: true,
-                          draggable: true,
-                          progress: undefined,
-                          theme: "colored",
-                          transition: Bounce,
-                        });
-
-                        return;
-                      }
-      
-                      // No need for AxiosResp<..> type check, as response body
-                      // isn't used.
-                      await api.post(`/whiteboards/${whiteboardId}/user_permissions`, ({
-                        userPermissions: userPermissionsFinal
-                      }));
-
-                      // -- display popup alert
-                      toast.success('User permissions updated successfully', {
-                        position: "bottom-center",
-                        autoClose: 5000,
-                        hideProgressBar: false,
-                        closeOnClick: true,
-                        pauseOnHover: true,
-                        draggable: true,
-                        progress: undefined,
-                        theme: "colored",
-                        transition: Bounce,
-                      });
-
-                      queryClient.invalidateQueries({
-                        queryKey: whiteboardKey
-                      });
-
-                      closeShareModal();
-                    } catch (err: unknown) {
-                        const axiosErr = err as AxiosError<{ error: string; }>;
-
-                        console.error('POST /whiteboards/:id/user_permissions failed:', axiosErr);
-
-                        // -- display popup alert
-                        toast.error(`Share request failed: ${axiosErr.response?.data.error}`, {
-                          position: "bottom-center",
-                          hideProgressBar: true,
-                          closeOnClick: true,
-                          pauseOnHover: true,
-                          draggable: true,
-                          progress: undefined,
-                          theme: "colored",
-                          transition: Bounce,
-                        });
-
-                        // -- propagate error to caller
-                        throw err;
-                    }
-                  }}
+                  isActive={isShareFormActive}
+                  onClose={handleCloseShareModal}
                 />
               </div>
             </ShareModal>
@@ -1053,9 +981,6 @@ const WrappedWhiteboard = () => {
     },
   });
 
-  // update the state of userPermissions whenever whiteboardData changes
-  const [userPermissions, setSharedUsers] = useState<APIWhiteboard['user_permissions']>([]);
-
   // -- track refs to canvas groups (frames)
   const canvasGroupRefsByIdRef: RefObject<Record<CanvasIdType, RefObject<Konva.Group | null>>> = useRef({});
 
@@ -1102,8 +1027,6 @@ const WrappedWhiteboard = () => {
     <WhiteboardProvider
       handleUpdateShapes={handleUpdateShapes}
       whiteboardId={whiteboardId}
-      userPermissions={userPermissions}
-      setSharedUsers={setSharedUsers}
       currentDispatcherRef={currentDispatcherRef}
       canvasGroupRefsByIdRef={canvasGroupRefsByIdRef}
     >

--- a/Frontend/src/store/whiteboards/whiteboardsSelectors.ts
+++ b/Frontend/src/store/whiteboards/whiteboardsSelectors.ts
@@ -55,7 +55,7 @@ export const selectWhiteboardStatus = (
   return state.whiteboardStatus.statusesByWhiteboard[whiteboardId];
 };
 
-export const selectPermissionsByWhiteboard = (
+export const selectPermissionsByUserByWhiteboard = (
   state: RootState,
   whiteboardId: WhiteboardIdType,
 ): Record<UserIdType, UserPermissionEnum> | null => {
@@ -66,7 +66,20 @@ export const selectPermissionsByWhiteboard = (
   const whiteboard = state.whiteboards[whiteboardId];
 
   return whiteboard.permissionsByUserId;
-};// -- end selectPermissionsByWhiteboard
+};// -- end selectPermissionsByUserByWhiteboard
+
+export const selectPermissionsByEmailByWhiteboard = (
+  state: RootState,
+  whiteboardId: WhiteboardIdType,
+): Record<string, UserPermissionEnum> | null => {
+  if (! (whiteboardId in state.whiteboards)) {
+    return null;
+  }
+
+  const whiteboard = state.whiteboards[whiteboardId];
+
+  return whiteboard.permissionsByEmail;
+};// -- end selectPermissionsByEmailByWhiteboard
 
 export const selectWhiteboardPermissionByUser = (
   state: RootState,

--- a/Frontend/src/store/whiteboards/whiteboardsSelectors.ts
+++ b/Frontend/src/store/whiteboards/whiteboardsSelectors.ts
@@ -55,6 +55,19 @@ export const selectWhiteboardStatus = (
   return state.whiteboardStatus.statusesByWhiteboard[whiteboardId];
 };
 
+export const selectPermissionsByWhiteboard = (
+  state: RootState,
+  whiteboardId: WhiteboardIdType,
+): Record<UserIdType, UserPermissionEnum> | null => {
+  if (! (whiteboardId in state.whiteboards)) {
+    return null;
+  }
+
+  const whiteboard = state.whiteboards[whiteboardId];
+
+  return whiteboard.permissionsByUserId;
+};// -- end selectPermissionsByWhiteboard
+
 export const selectWhiteboardPermissionByUser = (
   state: RootState,
   whiteboardId: WhiteboardIdType,
@@ -65,7 +78,7 @@ export const selectWhiteboardPermissionByUser = (
   }
 
   const whiteboard = state.whiteboards[whiteboardId];
-  const explicit = whiteboard.permissionsByUserId[userId]?.permission ?? null;
+  const explicit = whiteboard.permissionsByUserId[userId] || null;
 
   if (explicit !== null) {
     return explicit;

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -16,7 +16,6 @@ import type {
 } from '@/types/CanvasObjectModel';
 
 import {
-  type UserPermission,
   type UserPermissionEnum,
 } from '@/types/UserPermission';
 
@@ -65,10 +64,7 @@ export interface WhiteboardAttribs {
   name: string;
   rootCanvas: CanvasIdType;
   visibility: 'public' | 'private';
-  userPermissions: UserPermission[];
-  permissionsByUserId: Record<UserIdType, {
-    permission: UserPermissionEnum;
-  }>;
+  permissionsByUserId: Record<UserIdType, UserPermissionEnum>;
 }
 
 // Contains nested data

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -65,6 +65,7 @@ export interface WhiteboardAttribs {
   rootCanvas: CanvasIdType;
   visibility: 'public' | 'private';
   permissionsByUserId: Record<UserIdType, UserPermissionEnum>;
+  permissionsByEmail: Record<string, UserPermissionEnum>;
 }
 
 // Contains nested data

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -220,6 +220,12 @@ export interface ServerMessageLogoutUsers {
   clients: ClientIdType[];
 }
 
+export interface ServerMessageSetPermissions {
+  type: 'set_permissions';
+  permissionsByUserId: Record<UserIdType, UserPermissionEnum>;
+  permissionsByEmail: Record<string, UserPermissionEnum>;
+}
+
 // Used to notify clients when a user has started editing a canvas but hasn't
 // performed any edits yet (i.e. when they click and drag to start drawing a
 // shape).
@@ -302,6 +308,11 @@ export interface ServerMessageSetCursorPos {
   y: number;
 }
 
+export interface ServerMessageEvict {
+  type: 'evict';
+  reason: string;
+}// -- end export interface ServerMessageEvict
+
 export interface ServerMessageConfirm {
   type: 'confirm';
   message: string;
@@ -322,6 +333,7 @@ export type SocketServerMessage =
   | ServerMessageInitClient
   | ServerMessageLoginUsers
   | ServerMessageLogoutUsers
+  | ServerMessageSetPermissions
   | ServerMessageEditingCanvas
   | ServerMessageSelectedCanvasObject
   | ServerMessageUnselectedCanvasObject
@@ -334,6 +346,7 @@ export type SocketServerMessage =
   | ServerMessageMergeCanvas
   | ServerMessageDeleteWhiteboard
   | ServerMessageSetCursorPos
+  | ServerMessageEvict
   | ServerMessageConfirm
   | ServerMessageNotify
   | ServerMessageError

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -22,7 +22,7 @@ use mongodb::{
 async fn main() -> process::ExitCode {
     use wss::{
         db::connect_mongodb,
-        models::{WhiteboardIdType, WhiteboardMongoDBView},
+        models::{WhiteboardIdType, WhiteboardMongoDBView, WhiteboardPermissionEnumClientView},
         protocol::{ServerSocketMessage,ServerSocketBroadcastMessage},
         server::{ConnectionState, ProgramState},
     };
@@ -61,7 +61,7 @@ async fn main() -> process::ExitCode {
     });
 
     // -- spawn thread to watch for changes to whiteboards collection
-    let whiteboard_deletion_checker_thread = {
+    let whiteboard_watcher_thread = {
         let connection_state_ref = Arc::clone(&connection_state_ref);
         let db = match mongo_client.default_database() {
             None => {
@@ -76,7 +76,9 @@ async fn main() -> process::ExitCode {
 
         tokio::spawn(async move {
             let whiteboard_coll = db.collection::<WhiteboardMongoDBView>("whiteboards");
-            let mut wb_change_stream = match whiteboard_coll.watch().await {
+            let mut wb_change_stream = match whiteboard_coll.watch()
+                    .full_document(mongodb::options::FullDocumentType::UpdateLookup)
+                    .await {
                 Err(e) => panic!(
                     "Could not subscribe to change stream on whiteboards collection: {}",
                     e
@@ -85,8 +87,84 @@ async fn main() -> process::ExitCode {
             };
 
             // TODO: replace while-let with loop that includes error logging
-            while let Ok(Some(event)) = wb_change_stream.next().await.transpose() {
+            'next_event: while let Ok(Some(event)) = wb_change_stream.next().await.transpose() {
                 match event.operation_type {
+                    // -- check for permission updates
+                    mongodb::change_stream::event::OperationType::Update => {
+                        if let Some(curr_doc) = event.full_document {
+                            let mut whiteboards =
+                                connection_state_ref.program_state.whiteboards.lock().await;
+
+                            if let Some(wb_entry) = whiteboards.get_mut(&curr_doc.id) {
+                                let mut wb = wb_entry.whiteboard_ref.lock().await;
+
+                                // -- check that permissions have changed
+                                'check_perm_change: {
+                                    let wb_meta = wb.metadata();
+                                    let n_prev_perms = wb_meta.permissions_by_user_id().len()
+                                        + wb_meta.permissions_by_email().len();
+
+                                    if n_prev_perms == curr_doc.metadata.user_permissions.len() {
+                                        for perm in curr_doc.metadata.user_permissions.iter() {
+                                            match &perm.permission_type {
+                                                wss::models::WhiteboardPermissionType::User {
+                                                    user: user_id,
+                                                    ..
+                                                } => {
+                                                    if let Some(prev_perm) = wb_meta.permissions_by_user_id().get(&user_id) {
+                                                        if *prev_perm != perm.permission {
+                                                            break 'check_perm_change;
+                                                        }
+                                                    } else {
+                                                        break 'check_perm_change;
+                                                    }
+                                                },
+                                                wss::models::WhiteboardPermissionType::Email {
+                                                    email,
+                                                } => {
+                                                    if let Some(prev_perm) = wb_meta.permissions_by_email().get(email.as_str()) {
+                                                        if *prev_perm != perm.permission {
+                                                            break 'check_perm_change;
+                                                        }
+                                                    } else {
+                                                        break 'check_perm_change;
+                                                    }
+                                                },
+                                            };// -- end match
+                                        }// -- end for perm
+
+                                        continue 'next_event;
+                                    }
+                                }
+
+                                // -- change metadata
+                                wb.set_permissions(curr_doc.metadata.user_permissions.as_slice());
+
+                                let wb_meta = wb.metadata();
+
+                                // -- TODO: iter through key => value pairs: wb_entry.clients_by_user_id.
+
+                                // -- broadcast updated permissions to clients
+                                let _ = wb_entry
+                                    .broadcaster
+                                    .send(ServerSocketMessage::Broadcast {
+                                        msg: ServerSocketBroadcastMessage::SetPermissions {
+                                            permissions_by_user_id: wb_meta.permissions_by_user_id().iter()
+                                                .map(|(uid, perm)| (uid.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm)))
+                                                .collect(),
+                                            permissions_by_email: wb_meta.permissions_by_email().iter()
+                                                .map(|(email, perm)| (email.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm)))
+                                                .collect(),
+                                        },
+                                    });
+
+                                // -- TODO: update permissions in client state
+                                // -- TODO: evict clients whose permissions have been completely
+                                // revoked
+                            }
+                        }
+                    },
+                    // -- whiteboard deleted
                     mongodb::change_stream::event::OperationType::Delete => {
                         if let Some(doc) = event.document_key
                             && let Some(bson::Bson::ObjectId(wb_id)) = doc.get("_id") {
@@ -106,9 +184,6 @@ async fn main() -> process::ExitCode {
                                                 .send(ServerSocketMessage::Broadcast {
                                                     msg: ServerSocketBroadcastMessage::DeleteWhiteboard,
                                                 });
-
-                                            // TODO: end connections
-                                            // whiteboard_entry.broadcaster.closed
                                         }
 
                                         // delete entry
@@ -122,7 +197,7 @@ async fn main() -> process::ExitCode {
                 };
             } // -- end while event
         })
-    }; // -- end let whiteboard_deletion_checker_thread
+    }; // -- end let whiteboard_watcher_thread
 
     let connection_state_ref_filter = warp::any().map({
         let connection_state_ref = Arc::clone(&connection_state_ref);
@@ -142,9 +217,9 @@ async fn main() -> process::ExitCode {
     println!("Rust WebSocket server running at ws://{}", addr);
     warp::serve(ws_route).run(addr).await;
 
-    // -- abort and reap whiteboard deletion checker thread
-    whiteboard_deletion_checker_thread.abort();
-    let _ = whiteboard_deletion_checker_thread.await;
+    // -- abort and reap whiteboard watcher thread
+    whiteboard_watcher_thread.abort();
+    let _ = whiteboard_watcher_thread.await;
 
     process::ExitCode::SUCCESS
 } // end async fn main()
@@ -316,6 +391,7 @@ async fn handle_connection(
                     },
                     Broadcast { msg } => {
                         let json = serde_json::to_string(&msg).unwrap();
+
                         if user_ws_tx.send(Message::text(json)).await.is_err() {
                             break;
                         }
@@ -328,6 +404,20 @@ async fn handle_connection(
                             }
                         }
                     },
+                    Evict {
+                        evicted_client_id,
+                        reason,
+                    } => {
+                        if matches!(evicted_client_id.cmp(&current_client_id), Ordering::Equal) {
+                            // -- send eviction notification and disconnect
+                            let json = serde_json::to_string(&ServerSocketIndividualMessage::Evict {
+                                reason,
+                            }).unwrap();
+
+                            let _ = user_ws_tx.send(Message::text(json)).await;
+                            break;
+                        }
+                    }
                 };// -- end match msg
             }
         })

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -22,7 +22,12 @@ use mongodb::{
 async fn main() -> process::ExitCode {
     use wss::{
         db::connect_mongodb,
-        models::{WhiteboardIdType, WhiteboardMongoDBView, WhiteboardPermissionEnumClientView},
+        models::{
+            WhiteboardIdType,
+            WhiteboardMongoDBView,
+            WhiteboardPermissionEnumClientView,
+            WhiteboardVisibilityEnum,
+        },
         protocol::{ServerSocketMessage,ServerSocketBroadcastMessage},
         server::{ConnectionState, ProgramState},
     };
@@ -142,7 +147,23 @@ async fn main() -> process::ExitCode {
 
                                 let wb_meta = wb.metadata();
 
-                                // -- TODO: iter through key => value pairs: wb_entry.clients_by_user_id.
+                                // -- evict users whose permissions have been revoked if the
+                                // whiteboard is private
+                                if wb_meta.visibility() == WhiteboardVisibilityEnum::Private {
+                                    let clients_by_user_id = wb_entry.clients_by_user_id.lock().await;
+
+                                    // -- evict users whose permissions have been completely removed
+                                    for (user_id, client_id) in clients_by_user_id.iter() {
+                                        if ! wb_meta.permissions_by_user_id().contains_key(user_id) {
+                                            let _ = wb_entry
+                                                .broadcaster
+                                                .send(ServerSocketMessage::Evict {
+                                                    evicted_client_id: client_id.clone(),
+                                                    reason: String::from("Access revoked"),
+                                                });
+                                        }
+                                    }// -- end for
+                                }
 
                                 // -- broadcast updated permissions to clients
                                 let _ = wb_entry
@@ -157,10 +178,6 @@ async fn main() -> process::ExitCode {
                                                 .collect(),
                                         },
                                     });
-
-                                // -- TODO: update permissions in client state
-                                // -- TODO: evict clients whose permissions have been completely
-                                // revoked
                             }
                         }
                     },

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -472,8 +472,8 @@ async fn handle_connection(
             let mongo_interface = MongoDBInterface::new(&db);
 
             async move {
-                // Handle client messages in this loop until user authenticates
-                let client_state_authenticated = 'auth: loop {
+                // Handle client messages in this loop
+                loop {
                     let msg = if let Some(Ok(msg)) = user_ws_rx.next().await {
                         msg
                     } else {
@@ -490,9 +490,13 @@ async fn handle_connection(
                     }
 
                     if let Ok(msg_s) = msg.to_str() {
-                        let resp =
+                        let resp = if let Some(auth_state) = client_state_base.authenticated_state().await {
+                            handle_authenticated_client_message(&auth_state, msg_s).await
+                        } else {
                             handle_unauthenticated_client_message(&client_state_base, &mongo_interface, msg_s)
-                                .await;
+                                .await
+                                .base
+                        };// -- end let resp
 
                         // -- update database, if there are edits
                         {
@@ -509,94 +513,13 @@ async fn handle_connection(
 
 
                         // -- send response to clients, if requested
-                        for r in resp.base.messages.iter() {
+                        for r in resp.messages.iter() {
                            if let Err(e) = tx.send(r.clone()) {
                                eprintln!("ERROR: failed to send message to client: {:?}", e);
                            }
-                        }
-
-                        if let Some(authenticated_state) = resp.authenticated_state {
-                            break 'auth authenticated_state;
-                        }
-                    }
-                };// -- end let client_state_authenticated = 'auth: loop
-
-                // -- Broadcast client login
-               if let Err(e) = tx.send(ServerSocketMessage::Broadcast {
-                    msg: ServerSocketBroadcastMessage::LoginUsers {
-                        users: vec![ client_state_authenticated.user_summary.clone() ],
-                    },
-                }) {
-                    eprintln!("ERROR: failed to send message to client: {:?}", e);
-               }
-
-                // -- Now that client has authenticated, handle client messages in this loop
-                while let Some(Ok(msg)) = user_ws_rx.next().await {
-                    // -- check for whiteboard deletion; if whiteboard deleted, break connection
-                    {
-                        let whiteboard = client_state_base.whiteboard_ref.lock().await;
-
-                        if !whiteboard.is_active() {
-                            return;
-                        }
-                    }
-
-                    if let Ok(msg_s) = msg.to_str() {
-                        let mut resp =
-                            handle_authenticated_client_message(&client_state_authenticated, msg_s).await;
-
-                        // -- send notifications to logged-in users, save notifications to database
-                        // for other users
-                        {
-                            let clients_by_user_ids = client_state_base.clients_by_user_id.lock().await;
-
-                            for nt in resp.notifications.iter_mut() {
-                                // -- If user is currently logged in, send them the notification
-                                // directly
-                                if let Some(client_ids) = clients_by_user_ids
-                                    .get_values_by_key(&nt.recipient) {
-                                        // -- set notification to sent
-                                        // -- TODO: move this logic to individual sender to confirm
-                                        // receipt by client
-                                        nt.is_sent = true;
-
-                                        for client_id in client_ids.iter() {
-                                            resp.messages.push(ServerSocketMessage::Individual {
-                                                target_client_id: client_id.clone(),
-                                                msg: ServerSocketIndividualMessage::Notify {
-                                                    notification: NotificationClientView::from_notification(&nt)
-                                                },
-                                            });
-                                        }// -- end for client_id
-                                }
-
-                                // -- save notification to database
-                                mongo_interface.save_notification(nt).await;
-                            }// -- end for nt
-                        }
-
-                        // -- update database and local edit history, if there are edits
-                        {
-                            let mut edits = client_state_base.edits.lock().await;
-
-                            // -- update local edit history
-                            
-                            for edit in edits.iter() {
-                                // -- don't wait for mongo to finish processing database updates
-                                mongo_interface.process_edit(edit).await;
-                            }// -- end for edit in edits.iter()
-
-                            edits.clear();
-                        }
-
-                        // -- send response to clients, if requested
-                        for r in resp.messages.iter() {
-                            if let Err(e) = tx.send(r.clone()) {
-                                eprintln!("Failed to send message to client: {:?}", e);
-                            }
                         }// -- end for r
                     }
-                } // end while let Some(Ok(msg)) = user_ws_rx.next().await
+                }// -- end loop
             }
         })
     };

--- a/WebSocketServer/src/wss/collections.rs
+++ b/WebSocketServer/src/wss/collections.rs
@@ -5,6 +5,7 @@
 // =================================================================================================
 
 use std::collections::{
+    hash_map,
     HashMap,
     BTreeSet,
 };
@@ -26,6 +27,20 @@ pub struct OneToMany <K, V> {
     keys_by_value: HashMap<V, K>,
 }// -- end pub struct OneToMany
 
+pub struct OneToManyIter <'a, K, V> {
+    keys_by_value_iter: hash_map::Iter<'a, V, K>,
+}// -- end pub struct OneToManyIter
+
+impl <'a, K, V> std::iter::Iterator for OneToManyIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next_vk = self.keys_by_value_iter.next();
+
+        next_vk.map(|(v, k)| (k, v))
+    }// -- end fn next
+}// -- end impl std::iter::Iterator for OneToManyIter
+
 impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToMany <K, V> {
     pub fn new() -> Self {
         Self {
@@ -37,6 +52,12 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToM
     pub fn len(&self) -> usize {
         self.keys_by_value.len()
     }// -- end pub fn len
+
+    pub fn iter(&self) -> OneToManyIter<'_, K, V> {
+        OneToManyIter {
+            keys_by_value_iter: self.keys_by_value.iter(),
+        }
+    }// -- end pub fn iter
 
     pub fn insert(&mut self, key: K, value: V) {
         // -- remove old value => key mapping, if present

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -329,7 +329,7 @@ pub struct WhiteboardClientView {
     pub root_canvas: CanvasIdType,
     pub visibility: WhiteboardVisibilityEnum,
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnum>,
+    pub permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnumClientView>,
 } // -- end struct WhiteboardClientView
 
 // === CanvasParentRef ============================================================================
@@ -550,6 +550,36 @@ pub enum WhiteboardPermissionEnum {
     Own,
 }
 
+#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WhiteboardPermissionEnumClientView {
+    View,
+    Edit,
+    Own,
+}
+
+impl WhiteboardPermissionEnumClientView {
+    pub fn from_permission_enum(perm: &WhiteboardPermissionEnum) -> Self {
+        use WhiteboardPermissionEnum::*;
+
+        match perm {
+            View => Self::View,
+            Edit => Self::Edit,
+            Own => Self::Own,
+        }// -- end match perm
+    }// -- end pub fn from_permission_enum
+
+    pub fn to_permission_enum(&self) -> WhiteboardPermissionEnum {
+        use WhiteboardPermissionEnum::*;
+
+        match self {
+            Self::View => View,
+            Self::Edit => Edit,
+            Self::Own => Own,
+        }// -- end match self
+    }// -- end pub fn to_permission_enum
+}// -- end impl WhiteboardPermissionEnumClientView
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(
     tag = "type",
@@ -589,7 +619,6 @@ pub type WhiteboardPermissionClientView = WhiteboardPermission;
 pub struct WhiteboardMetadata {
     name: String,
     visibility: WhiteboardVisibilityEnum,
-    user_permissions: Vec<WhiteboardPermission>,
     // For permissions attached to an existing account, index by user id, to enable faster
     // retrieval when users log in.
     permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnum>,
@@ -599,13 +628,11 @@ impl WhiteboardMetadata {
     pub fn new(
         name: String,
         visibility: WhiteboardVisibilityEnum,
-        user_permissions: Vec<WhiteboardPermission>,
         permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnum>,
     ) -> Self {
         Self {
             name,
             visibility,
-            user_permissions,
             permissions_by_user_id,
         }
     }
@@ -618,9 +645,9 @@ impl WhiteboardMetadata {
         self.visibility
     }
 
-    pub fn user_permissions(&self) -> &[WhiteboardPermission] {
-        &self.user_permissions
-    }
+    pub fn permissions_by_user_id(&self) -> &HashMap<UserIdType, WhiteboardPermissionEnum> {
+        &self.permissions_by_user_id
+    }// -- end pub fn permissions_by_user_id
 
     pub fn permission_for_user(&self, user_id: &UserIdType) -> Option<WhiteboardPermissionEnum> {
         if self.visibility == WhiteboardVisibilityEnum::Public {
@@ -687,7 +714,11 @@ impl Whiteboard {
                 .collect(),
             root_canvas: self.root_canvas,
             visibility: self.metadata.visibility(),
-            permissions_by_user_id: self.metadata.permissions_by_user_id.clone(),
+            permissions_by_user_id: self.metadata.permissions_by_user_id.iter()
+                .map(|(uid, perm)|
+                    (uid.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm))
+                )
+                .collect(),
         }
     } // end pub fn to_client_view(&self) -> CanvasClientView
 
@@ -1169,7 +1200,6 @@ impl WhiteboardMetadataMongoDBView {
         WhiteboardMetadata::new(
             self.name.clone(),
             self.visibility,
-            self.user_permissions.clone(),
             permissions_by_user_id,
         )
     } // -- end fn to_whiteboard_metadata
@@ -2052,3 +2082,104 @@ impl NotificationClientView {
         }
     }// -- end pub fn from_notification
 }// -- end impl NotificationClientView
+
+// === Tests =======================================================================================
+//
+// =================================================================================================
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    // === deserialize_whiteboard_client_view_basic ================================================
+    //
+    // Simple example of deserializing a serialized whiteboard client view from a JSON string into a
+    // WhiteboardClientView struct.
+    //
+    // =============================================================================================
+    #[test]
+    fn deserialize_whiteboard_client_view_basic() {
+        use serde_json;
+
+        // -- Values aren't consistent: merely meant to test serde deserialization
+        let serialized_wb_s = r#"{
+            "id": "68d5e8d4829da666aece020d",
+            "name": "Whiteboard Alpha",
+            "canvases": [],
+            "rootCanvas": "68d5e8d4829da666aece020e",
+            "visibility": "public",
+            "permissionsByUserId": {
+                "68d5e8d4829da666aece020f": "view",
+                "68d5e8d4829da666aece0210": "edit",
+                "68d5e8d4829da666aece0211": "own"
+            }
+        }"#;
+        
+        let _ = serde_json::from_str::<WhiteboardClientView>(serialized_wb_s)
+            .expect("Serialized whiteboard string to deserialize into WhiteboardClientView");
+    }// -- end fn deserialize_whiteboard_client_view_basic
+
+    #[test]
+    fn serialize_whiteboard_client_view_basic() {
+        use serde_json;
+        use mongodb::bson::{Bson,oid::ObjectId};
+
+        // -- Values aren't consistent: merely meant to test serde deserialization
+        const WB_ID_S : &str = "68d5e8d4829da666aece020d";
+        const WB_NAME : &str = "Whiteboard Alpha";
+        const WB_ROOT_CANVAS_ID_S : &str = "68d5e8d4829da666aece020e";
+        const USER_A_ID_S : &str = "68d5e8d4829da666aece020f";
+        const USER_B_ID_S : &str = "68d5e8d4829da666aece0210";
+        const USER_C_ID_S : &str = "68d5e8d4829da666aece0211";
+
+        let wb_view = WhiteboardClientView {
+            id: Some(ObjectId::parse_str(WB_ID_S).unwrap()),
+            name: String::from(WB_NAME),
+            canvases: vec![],
+            root_canvas: ObjectId::parse_str(WB_ROOT_CANVAS_ID_S).unwrap(),
+            visibility: WhiteboardVisibilityEnum::Public,
+            permissions_by_user_id: HashMap::from([
+                (ObjectId::parse_str(USER_A_ID_S).unwrap(), WhiteboardPermissionEnumClientView::View),
+                (ObjectId::parse_str(USER_B_ID_S).unwrap(), WhiteboardPermissionEnumClientView::Edit),
+                (ObjectId::parse_str(USER_C_ID_S).unwrap(), WhiteboardPermissionEnumClientView::Own),
+            ])
+        };
+
+        let wb_view_serialized_s = serde_json::to_string(&wb_view)
+            .expect("To serialize WhiteboardClientView to JSON string");
+        
+        // -- unserialize to a Bson object to inspect how the object will be presented to other
+        // clients
+        let wb_view_unserialized = serde_json::from_str::<Bson>(wb_view_serialized_s.as_str())
+            .expect("To deserialize JSON string to Bson object");
+
+        match wb_view_unserialized {
+            Bson::Document(doc) => {
+                debug_assert_eq!(doc.len(), 6);
+
+                // -- check id
+                debug_assert_eq!(doc.get_str("id"), Ok(WB_ID_S));
+
+                // -- check name
+                debug_assert_eq!(doc.get_str("name"), Ok(WB_NAME));
+
+                // -- check root canvas id
+                debug_assert_eq!(doc.get_str("rootCanvas"), Ok(WB_ROOT_CANVAS_ID_S));
+
+                // -- check visibility
+                debug_assert_eq!(doc.get_str("visibility"), Ok("public"));
+
+                // -- check permissions
+                if let Ok(permissions_by_user_id) = doc.get_document("permissionsByUserId") {
+                    debug_assert_eq!(permissions_by_user_id.len(), 3);
+                    debug_assert_eq!(permissions_by_user_id.get_str(USER_A_ID_S), Ok("view"));
+                    debug_assert_eq!(permissions_by_user_id.get_str(USER_B_ID_S), Ok("edit"));
+                    debug_assert_eq!(permissions_by_user_id.get_str(USER_C_ID_S), Ok("own"));
+                } else {
+                    panic!("No permissionsByUserId field present in unserialized whiteboard")
+                }
+            },
+            _ => panic!("Expected Bson document, got {:?}", wb_view_unserialized),
+        };// -- end match wb_view_unserialized
+    }// -- end fn deserialize_whiteboard_client_view_basic
+}// -- end mod unit_tests

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -330,6 +330,7 @@ pub struct WhiteboardClientView {
     pub visibility: WhiteboardVisibilityEnum,
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     pub permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnumClientView>,
+    pub permissions_by_email: HashMap<String, WhiteboardPermissionEnumClientView>,
 } // -- end struct WhiteboardClientView
 
 // === CanvasParentRef ============================================================================
@@ -738,6 +739,11 @@ impl Whiteboard {
             permissions_by_user_id: self.metadata.permissions_by_user_id.iter()
                 .map(|(uid, perm)|
                     (uid.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm))
+                )
+                .collect(),
+            permissions_by_email: self.metadata.permissions_by_email.iter()
+                .map(|(email, perm)|
+                    (email.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm))
                 )
                 .collect(),
         }
@@ -2111,29 +2117,64 @@ mod unit_tests {
     #[test]
     fn deserialize_whiteboard_client_view_basic() {
         use serde_json;
+        use mongodb::bson::{oid::ObjectId};
+
+        const WB_ID_S : &str = "68d5e8d4829da666aece020d";
+        const WB_NAME : &str = "Whiteboard Alpha";
+        const WB_ROOT_CANVAS_ID_S : &str = "68d5e8d4829da666aece020e";
+        const USER_A_ID_S : &str = "68d5e8d4829da666aece020f";
+        const USER_B_ID_S : &str = "68d5e8d4829da666aece0210";
+        const USER_C_ID_S : &str = "68d5e8d4829da666aece0211";
+        const USER_C_EMAIL : &str = "user@example.com";
 
         // -- Values aren't consistent: merely meant to test serde deserialization
-        let serialized_wb_s = r#"{
-            "id": "68d5e8d4829da666aece020d",
-            "name": "Whiteboard Alpha",
+        let serialized_wb_s = format!(r#"{{
+            "id": "{WB_ID_S}",
+            "name": "{WB_NAME}",
             "canvases": [],
-            "rootCanvas": "68d5e8d4829da666aece020e",
+            "rootCanvas": "{WB_ROOT_CANVAS_ID_S}",
             "visibility": "public",
-            "permissionsByUserId": {
-                "68d5e8d4829da666aece020f": "view",
-                "68d5e8d4829da666aece0210": "edit",
-                "68d5e8d4829da666aece0211": "own"
-            }
-        }"#;
+            "permissionsByUserId": {{
+                "{USER_A_ID_S}": "view",
+                "{USER_B_ID_S}": "edit",
+                "{USER_C_ID_S}": "own"
+            }},
+            "permissionsByEmail": {{
+                "{USER_C_EMAIL}": "view"
+            }}
+        }}"#);
         
-        let _ = serde_json::from_str::<WhiteboardClientView>(serialized_wb_s)
+        let wb_view = serde_json::from_str::<WhiteboardClientView>(serialized_wb_s.as_str())
             .expect("Serialized whiteboard string to deserialize into WhiteboardClientView");
+
+        debug_assert_eq!(wb_view.id.unwrap().to_hex(), WB_ID_S);
+        debug_assert_eq!(wb_view.name.as_str(), WB_NAME);
+        debug_assert_eq!(wb_view.root_canvas.to_hex(), WB_ROOT_CANVAS_ID_S);
+        debug_assert_eq!(wb_view.visibility, WhiteboardVisibilityEnum::Public);
+        debug_assert_eq!(wb_view.permissions_by_user_id.len(), 3);
+        debug_assert_eq!(
+            wb_view.permissions_by_user_id.get(&ObjectId::parse_str(USER_A_ID_S).unwrap()).cloned(),
+            Some(WhiteboardPermissionEnumClientView::View)
+        );
+        debug_assert_eq!(
+            wb_view.permissions_by_user_id.get(&ObjectId::parse_str(USER_B_ID_S).unwrap()).cloned(),
+            Some(WhiteboardPermissionEnumClientView::Edit)
+        );
+        debug_assert_eq!(
+            wb_view.permissions_by_user_id.get(&ObjectId::parse_str(USER_C_ID_S).unwrap()).cloned(),
+            Some(WhiteboardPermissionEnumClientView::Own)
+        );
+        debug_assert_eq!(wb_view.permissions_by_email.len(), 1);
+        debug_assert_eq!(
+            wb_view.permissions_by_email.get(USER_C_EMAIL).cloned(),
+            Some(WhiteboardPermissionEnumClientView::View)
+        );
     }// -- end fn deserialize_whiteboard_client_view_basic
 
     #[test]
     fn serialize_whiteboard_client_view_basic() {
         use serde_json;
-        use mongodb::bson::{Bson,oid::ObjectId};
+        use mongodb::bson::{Bson,doc,oid::ObjectId};
 
         // -- Values aren't consistent: merely meant to test serde deserialization
         const WB_ID_S : &str = "68d5e8d4829da666aece020d";
@@ -2142,6 +2183,7 @@ mod unit_tests {
         const USER_A_ID_S : &str = "68d5e8d4829da666aece020f";
         const USER_B_ID_S : &str = "68d5e8d4829da666aece0210";
         const USER_C_ID_S : &str = "68d5e8d4829da666aece0211";
+        const USER_D_EMAIL : &str = "user@example.com";
 
         let wb_view = WhiteboardClientView {
             id: Some(ObjectId::parse_str(WB_ID_S).unwrap()),
@@ -2153,7 +2195,10 @@ mod unit_tests {
                 (ObjectId::parse_str(USER_A_ID_S).unwrap(), WhiteboardPermissionEnumClientView::View),
                 (ObjectId::parse_str(USER_B_ID_S).unwrap(), WhiteboardPermissionEnumClientView::Edit),
                 (ObjectId::parse_str(USER_C_ID_S).unwrap(), WhiteboardPermissionEnumClientView::Own),
-            ])
+            ]),
+            permissions_by_email: HashMap::from([
+                (String::from(USER_D_EMAIL), WhiteboardPermissionEnumClientView::View),
+            ]),
         };
 
         let wb_view_serialized_s = serde_json::to_string(&wb_view)
@@ -2164,33 +2209,22 @@ mod unit_tests {
         let wb_view_unserialized = serde_json::from_str::<Bson>(wb_view_serialized_s.as_str())
             .expect("To deserialize JSON string to Bson object");
 
-        match wb_view_unserialized {
-            Bson::Document(doc) => {
-                debug_assert_eq!(doc.len(), 6);
-
-                // -- check id
-                debug_assert_eq!(doc.get_str("id"), Ok(WB_ID_S));
-
-                // -- check name
-                debug_assert_eq!(doc.get_str("name"), Ok(WB_NAME));
-
-                // -- check root canvas id
-                debug_assert_eq!(doc.get_str("rootCanvas"), Ok(WB_ROOT_CANVAS_ID_S));
-
-                // -- check visibility
-                debug_assert_eq!(doc.get_str("visibility"), Ok("public"));
-
-                // -- check permissions
-                if let Ok(permissions_by_user_id) = doc.get_document("permissionsByUserId") {
-                    debug_assert_eq!(permissions_by_user_id.len(), 3);
-                    debug_assert_eq!(permissions_by_user_id.get_str(USER_A_ID_S), Ok("view"));
-                    debug_assert_eq!(permissions_by_user_id.get_str(USER_B_ID_S), Ok("edit"));
-                    debug_assert_eq!(permissions_by_user_id.get_str(USER_C_ID_S), Ok("own"));
-                } else {
-                    panic!("No permissionsByUserId field present in unserialized whiteboard")
-                }
+        let expected = Bson::Document(doc! {
+            "id": WB_ID_S,
+            "name": WB_NAME,
+            "canvases": [],
+            "rootCanvas": WB_ROOT_CANVAS_ID_S,
+            "visibility": "public",
+            "permissionsByUserId": {
+                USER_A_ID_S : "view",
+                USER_B_ID_S : "edit",
+                USER_C_ID_S : "own",
             },
-            _ => panic!("Expected Bson document, got {:?}", wb_view_unserialized),
-        };// -- end match wb_view_unserialized
+            "permissionsByEmail": {
+                USER_D_EMAIL : "view",
+            },
+        });// -- end let expected
+
+        debug_assert_eq!(wb_view_unserialized, expected);
     }// -- end fn deserialize_whiteboard_client_view_basic
 }// -- end mod unit_tests

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -671,6 +671,10 @@ impl WhiteboardMetadata {
         &self.permissions_by_user_id
     }// -- end pub fn permissions_by_user_id
 
+    pub fn permissions_by_email(&self) -> &HashMap<String, WhiteboardPermissionEnum> {
+        &self.permissions_by_email
+    }// -- end pub fn permissions_by_email
+
     pub fn permission_for_user(&self, user_id: &UserIdType) -> Option<WhiteboardPermissionEnum> {
         if self.visibility == WhiteboardVisibilityEnum::Public {
             return Some(WhiteboardPermissionEnum::Edit);
@@ -776,6 +780,31 @@ impl Whiteboard {
     pub fn root_canvas(&self) -> &CanvasIdType {
         &self.root_canvas
     } // -- end pub fn root_canvas
+
+    pub fn set_permissions(&mut self, permissions: &[WhiteboardPermission]) {
+        self.metadata.permissions_by_user_id.clear();
+        self.metadata.permissions_by_email.clear();
+
+        for perm in permissions.iter() {
+            match &perm.permission_type {
+                WhiteboardPermissionType::User {
+                    user: user_id,
+                    ..
+                } => {
+                    self.metadata.permissions_by_user_id.insert(
+                        user_id.clone(), perm.permission.clone()
+                    );
+                },
+                WhiteboardPermissionType::Email {
+                    email,
+                } => {
+                    self.metadata.permissions_by_email.insert(
+                        email.clone(), perm.permission.clone()
+                    );
+                },
+            };// -- end match perm.permission_type
+        }// -- end for perm
+    }// -- end pub fn set_permissions
 
     pub fn push_edit(&mut self, edit: &Edit) {
         if let Some(author_edit_history) = self.edit_history_by_author.get_mut(&edit.author) {

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -622,20 +622,41 @@ pub struct WhiteboardMetadata {
     // For permissions attached to an existing account, index by user id, to enable faster
     // retrieval when users log in.
     permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnum>,
+    // -- email address => permission
+    permissions_by_email: HashMap<String, WhiteboardPermissionEnum>,
 } // -- end WhiteboardMetadata
 
 impl WhiteboardMetadata {
     pub fn new(
         name: String,
         visibility: WhiteboardVisibilityEnum,
-        permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnum>,
+        permissions: &[WhiteboardPermission],
     ) -> Self {
+        let mut permissions_by_user_id = HashMap::<UserIdType, WhiteboardPermissionEnum>::new();
+        let mut permissions_by_email = HashMap::<String, WhiteboardPermissionEnum>::new();
+
+        for perm in permissions.iter() {
+            match &perm.permission_type {
+                WhiteboardPermissionType::User {
+                    user: user_id, ..
+                } => {
+                    let _ = permissions_by_user_id.insert(user_id.clone(), perm.permission.clone());
+                },
+                WhiteboardPermissionType::Email {
+                    email,
+                } => {
+                    let _ = permissions_by_email.insert(email.clone(), perm.permission.clone());
+                },
+            };// -- end match perm.permission_type
+        }// -- end for perm
+
         Self {
             name,
             visibility,
             permissions_by_user_id,
+            permissions_by_email,
         }
-    }
+    }// -- end fn new
 
     pub fn name(&self) -> &str {
         &self.name
@@ -1187,20 +1208,10 @@ pub struct WhiteboardMetadataMongoDBView {
 
 impl WhiteboardMetadataMongoDBView {
     pub fn to_whiteboard_metadata(&self) -> WhiteboardMetadata {
-        let permissions_by_user_id = self
-            .user_permissions
-            .iter()
-            .filter_map(|wb_perm| match wb_perm.permission_type {
-                WhiteboardPermissionType::User { ref user, .. } => {
-                    Some((user.clone(), wb_perm.permission))
-                }
-                _ => None,
-            })
-            .collect();
         WhiteboardMetadata::new(
             self.name.clone(),
             self.visibility,
-            permissions_by_user_id,
+            self.user_permissions.as_slice(),
         )
     } // -- end fn to_whiteboard_metadata
 }

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -108,6 +108,9 @@ pub enum ServerSocketIndividualMessage {
         #[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")]
         selectors_by_canvas_objects: HashMap<CanvasObjectIdType, ClientIdType>,
     },
+    Evict {
+        reason: String,
+    },
     // -- Generic message for confirming success of some action
     Confirm {
         message: String,
@@ -139,6 +142,11 @@ pub enum ServerSocketBroadcastMessage {
     LogoutUsers {
         #[serde_as(as = "Vec<DisplayFromStr>")]
         clients: Vec<ClientIdType>,
+    },
+    SetPermissions {
+        #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+        permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnumClientView>,
+        permissions_by_email: HashMap<String, WhiteboardPermissionEnumClientView>,
     },
     SelectedCanvasObject {
         #[serde_as(as = "DisplayFromStr")]
@@ -245,6 +253,11 @@ pub enum ServerSocketMessage {
     BroadcastRest {
         src_client_id: ClientIdType,
         msg: ServerSocketBroadcastRestMessage,
+    },
+    // -- Trigger disconnect
+    Evict {
+        evicted_client_id: ClientIdType,
+        reason: String,
     },
 }// -- end pub enum ServerSocketMessage
 

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -1166,7 +1166,11 @@ mod unit_tests {
         let whiteboard = Whiteboard::new(
             whiteboard_id.clone(),
             true,
-            WhiteboardMetadata::new(String::from("Test"), WhiteboardVisibilityEnum::Private, vec![], HashMap::new()),
+            WhiteboardMetadata::new(
+                String::from("Test"),
+                WhiteboardVisibilityEnum::Private,
+                HashMap::new()
+            ),
             test_canvas_id,
             HashMap::new(),
             // -- Edit history irrelevant
@@ -1313,7 +1317,11 @@ mod unit_tests {
         let whiteboard = Whiteboard::new(
             whiteboard_id.clone(),
             true,
-            WhiteboardMetadata::new(String::from("Test"), WhiteboardVisibilityEnum::Private, vec![], HashMap::new()),
+            WhiteboardMetadata::new(
+                String::from("Test"),
+                WhiteboardVisibilityEnum::Private,
+                HashMap::new()
+            ),
             canvas_a_id,
             HashMap::from([(
                 canvas_a_id.clone(),
@@ -1554,7 +1562,11 @@ mod unit_tests {
         let whiteboard = Whiteboard::new(
             whiteboard_id.clone(),
             true,
-            WhiteboardMetadata::new(String::from("Test"), WhiteboardVisibilityEnum::Private, vec![], HashMap::new()),
+            WhiteboardMetadata::new(
+                String::from("Test"),
+                WhiteboardVisibilityEnum::Private,
+                HashMap::new()
+            ),
             canvas_a_id,
             HashMap::from([(
                 canvas_a_id.clone(),
@@ -1684,7 +1696,7 @@ mod unit_tests {
 
         assert!(*whiteboard.id() == whiteboard_id);
         assert!(whiteboard.metadata().name() == "Project Alpha");
-        assert!(whiteboard.metadata().user_permissions().len() == 1);
+        assert!(whiteboard.metadata().permissions_by_user_id().len() == 1);
         assert!(*whiteboard.root_canvas() == root_canvas_id);
         assert!(whiteboard.canvases().len() == 4);
         assert!(whiteboard.canvases().contains_key(&root_canvas_id));
@@ -1823,13 +1835,6 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                vec![WhiteboardPermission {
-                    permission_type: WhiteboardPermissionType::User {
-                        user: target_uid,
-                        email: Some(String::from("bob@example.com")),
-                    },
-                    permission: WhiteboardPermissionEnum::Edit,
-                }],
                 HashMap::from([(target_uid.clone(), WhiteboardPermissionEnum::Edit)]),
             ),
             ObjectId::new(),
@@ -2062,13 +2067,6 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                vec![WhiteboardPermission {
-                    permission_type: WhiteboardPermissionType::User {
-                        user: test_user_id,
-                        email: None,
-                    },
-                    permission: WhiteboardPermissionEnum::Edit,
-                }],
                 HashMap::from([(test_user_id.clone(), WhiteboardPermissionEnum::Edit)]),
             ),
             // no canvases
@@ -2228,13 +2226,6 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                vec![WhiteboardPermission {
-                    permission_type: WhiteboardPermissionType::User {
-                        user: test_user_id.clone(),
-                        email: None,
-                    },
-                    permission: WhiteboardPermissionEnum::Edit,
-                }],
                 HashMap::from([(test_user_id.clone(), WhiteboardPermissionEnum::Edit)]),
             ),
             // One canvas only
@@ -2426,13 +2417,6 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                vec![WhiteboardPermission {
-                    permission_type: WhiteboardPermissionType::User {
-                        user: test_user_id.clone(),
-                        email: None,
-                    },
-                    permission: WhiteboardPermissionEnum::Edit,
-                }],
                 HashMap::from([(test_user_id.clone(), WhiteboardPermissionEnum::Edit)]),
             ),
             // One canvas only
@@ -2593,20 +2577,6 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                vec![WhiteboardPermission {
-                        permission_type: WhiteboardPermissionType::User {
-                            user: user_a_id.clone(),
-                            email: None,
-                        },
-                        permission: WhiteboardPermissionEnum::Edit,
-                    },
-                    WhiteboardPermission {
-                            permission_type: WhiteboardPermissionType::User {
-                                user: user_b_id.clone(),
-                                email: None,
-                            },
-                            permission: WhiteboardPermissionEnum::Edit,
-                }],
                 HashMap::from([
                     (user_a_id.clone(), WhiteboardPermissionEnum::Own),
                     (user_b_id.clone(), WhiteboardPermissionEnum::Edit),

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -61,12 +61,39 @@ pub struct ClientStateBase {
     pub whiteboard_ref: Arc<Mutex<Whiteboard>>,
     pub jwt_secret: String,
     // The permission (view/edit/own) the user has on the current whiteboard
+    // -- TODO: condense into just whiteboard, client, and edit mutexes
+    // -- Replace separate loops with one check for unauthenticated vs authenticated
     pub active_clients: Arc<Mutex<HashMap<ClientIdType, UserSummary>>>,
     pub clients_by_user_id: Arc<Mutex<OneToMany<UserIdType, ClientIdType>>>,
     // -- tracking which client is selecting, thereby currently owns, a given canvas object
     pub selectors_to_canvas_objects: Arc<Mutex<OneToOne<ClientIdType, CanvasObjectIdType>>>,
     pub edits: Arc<Mutex<Vec<Edit>>>,
 } // -- end pub struct ClientStateBase
+
+impl ClientStateBase {
+    // === pub fn authenticated_state ==============================================================
+    //
+    // Determines if the client is currently authenticated. If so, returns the authenticated
+    // extension of the client state, including the client's user permission and user summary.
+    //
+    // =============================================================================================
+    pub async fn authenticated_state<'a>(&'a self) -> Option<ClientStateAuthenticated<'a>> {
+        let wb = self.whiteboard_ref.lock().await;
+        let active_clients = self.active_clients.lock().await;
+
+        if let Some(user_summ) = active_clients.get(&self.client_id) {
+            if let Some(perm) = wb.metadata().permission_for_user(&user_summ.user_id) {
+                return Some(ClientStateAuthenticated {
+                    base: self,
+                    user_summary: user_summ.clone(),
+                    user_whiteboard_permission: perm.clone(),
+                })
+            }
+        }
+
+        None
+    }// -- end pub fn authenticated_state
+}// -- end impl ClientStateBase
 
 // === pub struct ClientStateAuthenticated =========================================================
 //
@@ -89,6 +116,18 @@ impl <'a> ClientStateAuthenticated <'a> {
         )
     }// -- end pub fn generate_edit
 }// -- end impl <'a> ClientStateAuthenticated <'a>
+
+impl <'a> std::cmp::PartialEq for ClientStateAuthenticated <'a> {
+    fn eq(&self, other: &Self) -> bool {
+        return std::ptr::from_ref(self.base) == std::ptr::from_ref(other.base)
+            && self.user_summary == other.user_summary
+            && self.user_whiteboard_permission == other.user_whiteboard_permission;
+    }// -- end fn eq
+
+    fn ne(&self, other: &Self) -> bool {
+        ! self.eq(other)
+    }// -- end fn ne
+}// -- end impl PartialEq for ClientStateAuthenticated
 
 // === Connection State ===========================================================================
 //
@@ -123,9 +162,8 @@ pub struct ClientMessageResponse {
     pub notifications: Vec<Notification>,
 }// -- end pub struct ClientMessageResponse
 
-pub struct ClientMessageUnauthenticatedResponse <'a> {
+pub struct ClientMessageUnauthenticatedResponse {
     pub base: ClientMessageResponse,
-    pub authenticated_state: Option<ClientStateAuthenticated <'a>>,
 }// -- end pub struct ClientMessageUnauthenticatedResponse
 
 // Handle raw messages from clients. Assume client has already authenticated.
@@ -930,12 +968,12 @@ pub async fn handle_authenticated_client_message<'a>(
 // @param client_msg_s          -- Content of client message
 // @return                      -- Messages to send to clients
 pub async fn handle_unauthenticated_client_message<
-    'a, StoreType: UserStore + WhiteboardMetadataStore,
+    StoreType: UserStore + WhiteboardMetadataStore,
 >(
-    client_state: &'a ClientStateBase,
+    client_state: &ClientStateBase,
     store: &StoreType,
     client_msg_s: &str,
-) -> ClientMessageUnauthenticatedResponse <'a> {
+) -> ClientMessageUnauthenticatedResponse {
     use super::jwt::get_user_id_from_jwt;
 
     match serde_json::from_str::<ClientSocketMessage>(client_msg_s) {
@@ -954,7 +992,6 @@ pub async fn handle_unauthenticated_client_message<
                             println!("Error parsing user_id from jwt: {}", e);
 
                             return ClientMessageUnauthenticatedResponse {
-                                authenticated_state: None,
                                 base: ClientMessageResponse {
                                     messages: vec![ServerSocketMessage::Individual {
                                         target_client_id: client_state.client_id.clone(),
@@ -974,7 +1011,6 @@ pub async fn handle_unauthenticated_client_message<
                             println!("Error fetching user by id: {}", e);
 
                             return ClientMessageUnauthenticatedResponse {
-                                authenticated_state: None,
                                 base: ClientMessageResponse {
                                     messages: vec![ServerSocketMessage::Individual {
                                         target_client_id: client_state.client_id.clone(),
@@ -990,7 +1026,6 @@ pub async fn handle_unauthenticated_client_message<
                         }
                         Ok(None) => {
                             return ClientMessageUnauthenticatedResponse {
-                                authenticated_state: None,
                                 base: ClientMessageResponse {
                                     messages: vec![ServerSocketMessage::Individual {
                                         target_client_id: client_state.client_id.clone(),
@@ -1061,24 +1096,26 @@ pub async fn handle_unauthenticated_client_message<
                                 .lock().await;
 
                             ClientMessageUnauthenticatedResponse {
-                                authenticated_state: Some(ClientStateAuthenticated {
-                                    base: &client_state,
-                                    user_summary: user_summary.clone(),
-                                    user_whiteboard_permission: permission,
-                                }),
                                 base: ClientMessageResponse {
-                                    messages: vec![ServerSocketMessage::Individual {
-                                        target_client_id: client_state.client_id.clone(),
-                                        msg: ServerSocketIndividualMessage::InitClient {
-                                            client_id: client_state.client_id.clone(),
-                                            whiteboard: whiteboard.to_client_view(),
-                                            active_clients,
-                                            selectors_by_canvas_objects: selectors_to_canvas_objects
-                                                .iter_key_value()
-                                                .map(|(selector_id, obj_id)| (obj_id.clone(), selector_id.clone()))
-                                                .collect()
+                                    messages: vec![
+                                        ServerSocketMessage::Broadcast {
+                                            msg: ServerSocketBroadcastMessage::LoginUsers {
+                                                users: vec![ user_summary.clone() ],
+                                            },
                                         },
-                                    }],
+                                        ServerSocketMessage::Individual {
+                                            target_client_id: client_state.client_id.clone(),
+                                            msg: ServerSocketIndividualMessage::InitClient {
+                                                client_id: client_state.client_id.clone(),
+                                                whiteboard: whiteboard.to_client_view(),
+                                                active_clients,
+                                                selectors_by_canvas_objects: selectors_to_canvas_objects
+                                                    .iter_key_value()
+                                                    .map(|(selector_id, obj_id)| (obj_id.clone(), selector_id.clone()))
+                                                    .collect()
+                                            },
+                                        }
+                                    ],
                                     notifications: vec![],
                                 },
                             }
@@ -1086,7 +1123,6 @@ pub async fn handle_unauthenticated_client_message<
                     } else {
                         // User has no valid permission; send back an error message
                         return ClientMessageUnauthenticatedResponse {
-                            authenticated_state: None,
                             base: ClientMessageResponse {
                                 messages: vec![ServerSocketMessage::Individual {
                                     target_client_id: client_state.client_id.clone(),
@@ -1101,7 +1137,6 @@ pub async fn handle_unauthenticated_client_message<
                 }
                 // -- All other messages should be responded to with an individual error
                 _ => ClientMessageUnauthenticatedResponse {
-                    authenticated_state: None,
                     base: ClientMessageResponse {
                         messages: vec![ServerSocketMessage::Individual {
                             target_client_id: client_state.client_id.clone(),
@@ -1119,7 +1154,6 @@ pub async fn handle_unauthenticated_client_message<
             println!("Reason: {}", e);
 
             ClientMessageUnauthenticatedResponse {
-                authenticated_state: None,
                 base: ClientMessageResponse {
                     messages: vec![ServerSocketMessage::Individual {
                         target_client_id: client_state.client_id.clone(),
@@ -1787,8 +1821,8 @@ mod unit_tests {
             WhiteboardPermissionEnum, WhiteboardPermissionType, WhiteboardVisibilityEnum,
         };
         use mongodb::bson::oid::ObjectId;
-        use protocol::{ServerSocketMessage,ServerSocketIndividualMessage};
-        use server::{ClientStateBase, handle_unauthenticated_client_message};
+        use protocol::{ServerSocketMessage,ServerSocketIndividualMessage,ServerSocketBroadcastMessage};
+        use server::{ClientStateBase, ClientStateAuthenticated, handle_unauthenticated_client_message};
         use sha2::Sha256;
         use std::sync::Arc;
         use utils::generate_unique_client_id;
@@ -1864,6 +1898,12 @@ mod unit_tests {
         // -- create authentication message (json)
         let client_login_msg_s = format!(r#"{{ "type": "login", "jwt": "{}" }}"#, token_s);
 
+        let expected_user_summary = UserSummary {
+            client_id: test_client_id.clone(),
+            user_id: target_uid.clone(),
+            username: String::from("bob"),
+        };
+
         // -- attempt login
         let resp = handle_unauthenticated_client_message(
             &client_state,
@@ -1872,10 +1912,27 @@ mod unit_tests {
         )
         .await;
 
-        let msg = resp
-            .base
-            .messages
-            .into_iter()
+        // -- check for login broadcast message
+        let mut iter_messages = resp.base.messages.into_iter();
+
+        let msg = iter_messages
+            .next()
+            .expect("Response to client login message");
+
+        match msg {
+            ServerSocketMessage::Broadcast {
+                msg: ServerSocketBroadcastMessage::LoginUsers {
+                    users,
+                },
+            } => {
+                debug_assert_eq!(users, vec![ expected_user_summary.clone() ]);
+            }
+            bad_resp => {
+                panic!("Expected LoginUsers message, got {:?}", bad_resp);
+            }
+        };
+        // -- check for init client message
+        let msg = iter_messages
             .next()
             .expect("Response to client login message");
 
@@ -1889,13 +1946,9 @@ mod unit_tests {
                     selectors_by_canvas_objects,
                 },
             } => {
-                let auth_state = resp.authenticated_state.expect("Authenticated state");
-                let user_perm = auth_state.user_whiteboard_permission;
-
                 assert_eq!(target_client_id, test_client_id);
                 assert_eq!(client_id, test_client_id);
                 assert_eq!(whiteboard_view, whiteboard.to_client_view());
-                assert_eq!(user_perm, WhiteboardPermissionEnum::Edit);
                 assert_eq!(
                     active_clients,
                     HashMap::from([(
@@ -1913,6 +1966,17 @@ mod unit_tests {
                 panic!("Expected InitClient message, got {:?}", bad_resp);
             }
         };
+
+        // -- Ensure that the client state is now considered authenticated
+        debug_assert_eq!(client_state.authenticated_state().await, Some(ClientStateAuthenticated {
+            base: &client_state,
+            user_summary: UserSummary {
+                client_id: test_client_id.clone(),
+                user_id: target_uid.clone(),
+                username: String::from("bob"),
+            },
+            user_whiteboard_permission: WhiteboardPermissionEnum::Edit,
+        }));
     } // -- end fn fetch_permanent_user_from_mongodb_user_store
 
     // === fetch_permanent_user_from_mongodb_user_store ===========================================

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -1169,7 +1169,7 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::new()
+                &[],
             ),
             test_canvas_id,
             HashMap::new(),
@@ -1320,7 +1320,7 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::new()
+                &[],
             ),
             canvas_a_id,
             HashMap::from([(
@@ -1565,7 +1565,7 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::new()
+                &[],
             ),
             canvas_a_id,
             HashMap::from([(
@@ -1797,6 +1797,7 @@ mod unit_tests {
         let jwt_secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
         let target_uid_s = "68d5e8d4829da666aece5f48";
         let target_uid = ObjectId::parse_str(target_uid_s).expect("UID to be valid");
+        let target_email = "bob@example.com";
 
         // -- pre-generate jwt with desired uid
         let key: Hmac<Sha256> =
@@ -1814,11 +1815,11 @@ mod unit_tests {
         // -- initialize user store
         let user_store = MockStore {
             users_by_id: HashMap::from([(
-                target_uid,
+                target_uid.clone(),
                 User::Permanent {
-                    id: ObjectId::parse_str(target_uid_s).unwrap(),
+                    id: target_uid.clone(),
                     username: String::from("bob"),
-                    email: String::from("bob@example.com"),
+                    email: String::from(target_email),
                 },
             )]),
             whiteboards_by_id: HashMap::new(), // not needed here
@@ -1835,7 +1836,13 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::from([(target_uid.clone(), WhiteboardPermissionEnum::Edit)]),
+                &[WhiteboardPermission {
+                    permission_type: WhiteboardPermissionType::User {
+                        user: target_uid.clone(),
+                        email: Some(String::from(target_email)),
+                    },
+                    permission: WhiteboardPermissionEnum::Edit,
+                }],
             ),
             ObjectId::new(),
             HashMap::new(),
@@ -2067,7 +2074,13 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::from([(test_user_id.clone(), WhiteboardPermissionEnum::Edit)]),
+                &[WhiteboardPermission {
+                    permission_type: WhiteboardPermissionType::User {
+                        user: test_user_id.clone(),
+                        email: None,
+                    },
+                    permission: WhiteboardPermissionEnum::Edit,
+                }],
             ),
             // no canvases
             ObjectId::new(),
@@ -2226,7 +2239,13 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::from([(test_user_id.clone(), WhiteboardPermissionEnum::Edit)]),
+                &[WhiteboardPermission {
+                    permission_type: WhiteboardPermissionType::User {
+                        user: test_user_id.clone(),
+                        email: None,
+                    },
+                    permission: WhiteboardPermissionEnum::Edit,
+                }],
             ),
             // One canvas only
             canvas_a_id.clone(),
@@ -2417,7 +2436,13 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::from([(test_user_id.clone(), WhiteboardPermissionEnum::Edit)]),
+                &[WhiteboardPermission {
+                    permission_type: WhiteboardPermissionType::User {
+                        user: test_user_id.clone(),
+                        email: None,
+                    },
+                    permission: WhiteboardPermissionEnum::Edit,
+                }],
             ),
             // One canvas only
             canvas_a_id.clone(),
@@ -2577,10 +2602,22 @@ mod unit_tests {
             WhiteboardMetadata::new(
                 String::from("Test"),
                 WhiteboardVisibilityEnum::Private,
-                HashMap::from([
-                    (user_a_id.clone(), WhiteboardPermissionEnum::Own),
-                    (user_b_id.clone(), WhiteboardPermissionEnum::Edit),
-                ]),
+                &[
+                    WhiteboardPermission {
+                        permission_type: WhiteboardPermissionType::User {
+                            user: user_a_id.clone(),
+                            email: None,
+                        },
+                        permission: WhiteboardPermissionEnum::Own,
+                    },
+                    WhiteboardPermission {
+                        permission_type: WhiteboardPermissionType::User {
+                            user: user_b_id.clone(),
+                            email: None,
+                        },
+                        permission: WhiteboardPermissionEnum::Edit,
+                    }
+                ],
             ),
             // One canvas only
             canvas_a_id.clone(),
@@ -2796,7 +2833,7 @@ mod unit_tests {
 
         assert!(*whiteboard.id() == whiteboard_id);
         assert!(whiteboard.metadata().name() == "Whiteboard Alpha");
-        assert!(whiteboard.metadata().user_permissions().len() == 1);
+        assert!(whiteboard.metadata().permissions_by_user_id().len() == 1);
         assert!(whiteboard.canvases().len() == 3);
     } // -- end fn fetch_canvas_with_no_objects()
 }


### PR DESCRIPTION
Fixed the bug preventing the in-editor ShareWhiteboardForm from loading with the existing user permissions as the default values. Also modified the web socket server to update user permissions when they change in the database and evict users from a whiteboard when their permision on a whiteboard is completely revoked.

To test this, I recommend opening a whiteboard in two different accounts side-by-side and attempting to change each others' permissions. A user's permission level should visibly change whenever their permission is updated, and they should be kicked off the whiteboard when their permission is removed.

- **Changed whiteboard permissionsByUserId field on client side to be a simple mapping of user ids (as strings) to permission enum values (as strings). Tests in the models submodule of the web socket server ensure the WhitebaoardClientView is serialized and deserialized accordingly.**
- **WhiteboardMetadata stores permissions both by user id and email, storing all user permissions stored in the database.**
- **Added permissionsByEmail to WhiteboardClientView.**
- **Split ShareWhiteboardForm into headless component in components/, stateful component in pages/Whiteboard.**
- **Fixed formatting of email permissions in ShareWhiteboardForm.**
- **Split sorting of userId and email permissions in ShareWhiteboardForm.**
- **Whiteboard permission update watcher checks that permissions actually changed.**
- **Web socket server evicts clients from private whiteboards whose permissions have been revoked.**
- **Authenticated and unauthenticated client messages handled in the same loop in the web socket server.**
- **WebSocketClientMessengerProvider handles eviction messages (handling logic is similar to whiteboard deletion).**
- **Fixed frontend bug in ShareWhiteboardForm caused by attempting to find user permissions for users whose permission has recently been revoked.**
- **Allow editing existing user permission types directly in ShareWhiteboardForm using a select input.**
- **ShareWhiteboardForm overrides existing user permissions if an email address for an existing permission is entered as a new permission.**
