### PR TITLE
Bugfix: Enforce Canvas Allowed User Permissions

### DIFF
--- a/Frontend/src/components/AllowedUsersPopover.tsx
+++ b/Frontend/src/components/AllowedUsersPopover.tsx
@@ -180,7 +180,10 @@ const AllowedUsersPopover = ({ selected, onChange }: AllowedUsersPopoverProps) =
               ),
               'ready': () => (
                 userPermissions
-                  .filter((u): u is Extract<UserPermission, { type: "user" }> => u.type === "user")
+                  .filter((perm): perm is Extract<UserPermission, { type: "user" }> => {
+                    // -- only users with edit or owner permission
+                    return (perm.type === "user") && (perm.permission !== 'view');
+                  })
                   .map((userPerm) => (
                     <CommandItem
                       key={userPerm.user.id}

--- a/Frontend/src/components/CanvasMenu.tsx
+++ b/Frontend/src/components/CanvasMenu.tsx
@@ -297,11 +297,16 @@ const CanvasMenu = ({
                   </>
                 ))
               }
-              {allowedUsernames.map((u) => (
+              {(allowedUsernames.length > 0) && allowedUsernames.map((u) => (
                 <DropdownMenuLabel key={u}>
                   {u}
                 </DropdownMenuLabel>
-              ))}
+              ))
+              || (
+                <DropdownMenuLabel>
+                  All users can edit
+                </DropdownMenuLabel>
+              )}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
 

--- a/Frontend/src/components/CanvasObject.tsx
+++ b/Frontend/src/components/CanvasObject.tsx
@@ -123,6 +123,7 @@ export const CanvasObject = ({
         return (
           <VectorCanvasObject
             id={id}
+            canvasId={canvasId}
             model={canvasObject}
             isDraggable={isDraggable}
             onUpdateObject={handleUpdateObject}
@@ -132,6 +133,7 @@ export const CanvasObject = ({
         return (
           <TextCanvasObject
             id={id}
+            canvasId={canvasId}
             record={canvasObject}
             isDraggable={isDraggable}
             onUpdateObject={handleUpdateObject}

--- a/Frontend/src/components/EditableShape.tsx
+++ b/Frontend/src/components/EditableShape.tsx
@@ -34,6 +34,10 @@ import {
   selectSelectorByCanvasObject,
 } from '@/store/activeUsers/activeUsersSelectors';
 
+import {
+  selectUserHasAccessToCanvas,
+} from '@/store/canvases/canvasesSelectors';
+
 import type { 
   EditableObjectProps 
 } from "@/dispatchers/editableObjectProps";
@@ -54,6 +58,10 @@ import {
 } from '@/context/ClientMessengerContext';
 
 import {
+  useUser,
+} from '@/hooks/useUser';
+
+import {
   SnappingMonitor,
   useSnapping,
 } from "@/hooks/useSnapping";
@@ -70,6 +78,7 @@ interface EditableShapeProps<ShapeType extends ShapeModel> extends EditableObjec
 
 const EditableShape = <ShapeType extends ShapeModel> ({
   id,
+  canvasId,
   shapeModel,
   draggable,
   onUpdateObject,
@@ -90,6 +99,14 @@ const EditableShape = <ShapeType extends ShapeModel> ({
     clientMessenger,
   } = clientMessengerContext;
 
+  const {
+    user,
+  } = useUser();
+
+  if (! user) {
+    throw new Error('No authenticated user provided');
+  }
+
   const clientId = useSelector(
     (state: RootState) => selectClientId(state),
     lodash.isEqual
@@ -100,14 +117,19 @@ const EditableShape = <ShapeType extends ShapeModel> ({
     lodash.isEqual
   );
 
+  const userHasCanvasAccess = useSelector(
+    (state: RootState) => selectUserHasAccessToCanvas(state, canvasId, user.id),
+    lodash.isEqual
+  );// -- end const userHasCanvasAccess
+
   const isDraggable = draggable && ((! editor) || editor.clientId === clientId);
 
   useSnapping(shapeRef, snappingMonitor);
 
   const isSelected : boolean = useMemo(
-    () => editor?.clientId === clientId,
-    [editor, clientId]
-  );
+    () => userHasCanvasAccess && (editor?.clientId === clientId),
+    [userHasCanvasAccess, editor, clientId]
+  );// -- end const isSelected
 
   // Transformer attach/detach
   useEffect(() => {

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -34,20 +34,41 @@ import {
 } from '@/store/activeUsers/activeUsersSelectors';
 
 import {
+  selectUserHasAccessToCanvas,
+} from '@/store/canvases/canvasesSelectors';
+
+import {
   ClientMessengerContext,
 } from '@/context/ClientMessengerContext';
 
 import TextEditor from "./TextEditor";
 
-import { type EditableObjectProps } from "@/dispatchers/editableObjectProps";
-import type { ShapeModel, TextRecord } from "@/types/CanvasObjectModel";
+import {
+  type EditableObjectProps,
+} from "@/dispatchers/editableObjectProps";
+
+import {
+  type CanvasObjectIdType,
+  type ShapeModel,
+  type TextRecord,
+} from "@/types/CanvasObjectModel";
+
+import {
+  type CanvasIdType,
+} from '@/types/WebSocketProtocol';
+
+import {
+  useUser,
+} from '@/hooks/useUser';
+
 import {
   SnappingMonitor,
   useSnapping,
 } from "@/hooks/useSnapping";
 
 export interface EditableTextProps extends EditableObjectProps {
-  id: string;
+  id: CanvasObjectIdType;
+  canvasId: CanvasIdType,
   fontSize: number;
   text: string;
   color: string;
@@ -63,6 +84,7 @@ export interface EditableTextProps extends EditableObjectProps {
 
 const EditableText = ({
   id,
+  canvasId,
   fontSize,
   text,
   color,
@@ -97,6 +119,19 @@ const EditableText = ({
     clientMessenger,
   } = clientMessengerContext;
 
+  const {
+    user,
+  } = useUser();
+
+  if (! user) {
+    throw new Error('No authenticated user provided');
+  }
+
+  const userHasCanvasAccess = useSelector(
+    (state: RootState) => selectUserHasAccessToCanvas(state, canvasId, user.id),
+    lodash.isEqual
+  );// -- end const userHasCanvasAccess
+
   useSnapping(textRef, snappingMonitor);
 
   const clientId = useSelector(
@@ -110,9 +145,9 @@ const EditableText = ({
   );
 
   const isSelected : boolean = useMemo(
-    () => editor?.clientId === clientId,
-    [editor, clientId]
-  );
+    () => userHasCanvasAccess && (editor?.clientId === clientId),
+    [userHasCanvasAccess, editor, clientId]
+  );// -- end const isSelected
 
   // attach Transformer for editing when selected
   useEffect(() => {

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -30,14 +30,29 @@ import {
 } from '@/store/activeUsers/activeUsersSelectors';
 
 import {
+  selectUserHasAccessToCanvas,
+} from '@/store/canvases/canvasesSelectors';
+
+import {
+  useUser,
+} from '@/hooks/useUser';
+
+import {
   ClientMessengerContext,
 } from '@/context/ClientMessengerContext';
 
-import type { CanvasObjectIdType, CanvasObjectModel, VectorModel } from "@/types/CanvasObjectModel";
-import type { EditableObjectProps } from "@/dispatchers/editableObjectProps";
+import {
+  type CanvasObjectIdType,
+  type CanvasObjectModel,
+  type VectorModel,
+} from "@/types/CanvasObjectModel";
+import {
+  type EditableObjectProps,
+} from "@/dispatchers/editableObjectProps";
 import editableObjectProps from "@/dispatchers/editableObjectProps";
 import {
   type ClientIdType,
+  type CanvasIdType,
 } from '@/types/WebSocketProtocol';
 import {
   SnappingMonitor,
@@ -46,6 +61,7 @@ import {
 
 export interface EditableVectorProps<VectorType extends VectorModel> extends EditableObjectProps {
   id: CanvasObjectIdType;
+  canvasId: CanvasIdType;
   model: VectorType;
   draggable: boolean;
   onUpdateObject: (updatedObject: CanvasObjectModel) => unknown;
@@ -54,6 +70,7 @@ export interface EditableVectorProps<VectorType extends VectorModel> extends Edi
 
 const EditableVector = <VectorType extends VectorModel>({
   id,
+  canvasId,
   model,
   draggable,
   onUpdateObject,
@@ -73,6 +90,19 @@ const EditableVector = <VectorType extends VectorModel>({
     clientMessenger,
   } = clientMessengerContext;
 
+  const {
+    user,
+  } = useUser();
+
+  if (! user) {
+    throw new Error('No authenticated user provided');
+  }
+
+  const userHasCanvasAccess = useSelector(
+    (state: RootState) => selectUserHasAccessToCanvas(state, canvasId, user.id),
+    lodash.isEqual
+  );// -- end const userHasCanvasAccess
+
   useSnapping(vectorRef, snappingMonitor);
 
   const clientId : ClientIdType | null = useSelector(
@@ -85,10 +115,10 @@ const EditableVector = <VectorType extends VectorModel>({
     lodash.isEqual
   );
 
-  const isSelected = useMemo(
-    () => editor?.clientId === clientId,
-    [editor, clientId]
-  );
+  const isSelected : boolean = useMemo(
+    () => userHasCanvasAccess && (editor?.clientId === clientId),
+    [userHasCanvasAccess, editor, clientId]
+  );// -- end const isSelected
 
   const isDraggable : boolean = useMemo(
     () => draggable && (isSelected || (! editor)),

--- a/Frontend/src/components/TextCanvasObject.tsx
+++ b/Frontend/src/components/TextCanvasObject.tsx
@@ -14,12 +14,17 @@ import {
   type TextRecord,
 } from '@/types/CanvasObjectModel';
 
+import {
+  type CanvasIdType,
+} from '@/types/WebSocketProtocol';
+
 import EditableText from '@/components/EditableText';
 
 import editableObjectProps from '@/dispatchers/editableObjectProps';
 
 export interface TextCanvasObjectProps {
   id: CanvasObjectIdType;
+  canvasId: CanvasIdType;
   record: TextRecord;
   isDraggable: boolean;
   onUpdateObject: (updatedObject: CanvasObjectModel) => unknown;
@@ -27,6 +32,7 @@ export interface TextCanvasObjectProps {
 
 export const TextCanvasObject = ({
   id,
+  canvasId,
   record,
   isDraggable,
   onUpdateObject,
@@ -45,6 +51,7 @@ export const TextCanvasObject = ({
   return (
     <EditableText
       id={id}
+      canvasId={canvasId}
       fontSize={fontSize}
       text={text}
       color={color}

--- a/Frontend/src/components/VectorCanvasObject.tsx
+++ b/Frontend/src/components/VectorCanvasObject.tsx
@@ -18,10 +18,15 @@ import {
   type VectorModel,
 } from '@/types/CanvasObjectModel';
 
+import {
+  type CanvasIdType,
+} from '@/types/WebSocketProtocol';
+
 import EditableVector from '@/components/EditableVector';
 
 export interface VectorCanvasObjectProps {
   id: CanvasObjectIdType;
+  canvasId: CanvasIdType;
   model: VectorModel;
   isDraggable: boolean;
   onUpdateObject: (updatedObject: CanvasObjectModel) => unknown;
@@ -29,6 +34,7 @@ export interface VectorCanvasObjectProps {
 
 export const VectorCanvasObject = ({
   id,
+  canvasId,
   model,
   isDraggable,
   onUpdateObject,
@@ -38,6 +44,7 @@ export const VectorCanvasObject = ({
   return (
     <EditableVector<VectorModel>
       id={id}
+      canvasId={canvasId}
       draggable={isDraggable}
       model={model}
       onUpdateObject={onUpdateObject}

--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -517,7 +517,7 @@ const WebSocketClientMessengerProvider = ({
                   // need to submit an error report.
                   popupErrorMsg = 'ERROR: app sent an invalid message to the server. See console logs for details';
                   break;
-                case 'unauthorized':
+                case 'unauthorized_whiteboard':
                   console.error('Socket error: not authorized to view this whiteboard');
                   popupErrorMsg = 'You are not authorized to view this whiteboard';
                   break;
@@ -548,6 +548,10 @@ const WebSocketClientMessengerProvider = ({
                 case 'canvas_not_found':
                   console.error(`Socket error: canvas ${error.canvasId} not found`);
                   popupErrorMsg = `Canvas ${error.canvasId} not found`;
+                  break;
+                case 'unauthorized_canvas':
+                  console.error('Socket error: not authorized to edit this canvas');
+                  popupErrorMsg = 'You are not authorized to edit this canvas';
                   break;
                 case 'canvas_object_not_found':
                   console.error(`Socket error: canvas object ${error.canvasObjectId} not found`);

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -110,9 +110,12 @@ export interface ClientErrorInvalidMessage {
   clientMessageRaw: string;
 }
 
-// -- client did not send an auth token
-export interface ClientErrorUnauthorized {
-  type: 'unauthorized';
+export interface ClientErrorUnauthorizedWhiteboard {
+  type: 'unauthorized_whiteboard';
+}
+
+export interface ClientErrorUnauthorizedCanvas {
+  type: 'unauthorized_canvas';
 }
 
 // -- client not authorized to view this whiteboard at all
@@ -186,7 +189,7 @@ export interface ClientErrorOther {
 
 export type ClientError =
   | ClientErrorInvalidMessage
-  | ClientErrorUnauthorized
+  | ClientErrorUnauthorizedWhiteboard
   | ClientErrorNotAuthenticated
   | ClientErrorAlreadyAuthorized
   | ClientErrorInvalidAuth
@@ -194,6 +197,7 @@ export type ClientError =
   | ClientErrorUserNotFound
   | ClientErrorWhiteboardNotFound
   | ClientErrorCanvasNotFound
+  | ClientErrorUnauthorizedCanvas
   | ClientErrorCanvasObjectNotFound
   | ClientErrorActionForbidden
   | ClientErrorCanvasObjectAlreadySelected

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -802,6 +802,10 @@ impl Whiteboard {
         &mut self.canvases_to_canvas_objects
     }// -- end pub fn canvases_to_canvas_objects
 
+    pub fn user_permissions(&self) -> &[WhiteboardPermission] {
+        self.metadata.user_permissions.as_slice()
+    }// -- end pub fn user_permissions
+
     pub fn metadata(&self) -> &WhiteboardMetadata {
         &self.metadata
     } // -- end pub fn metadata

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -802,10 +802,6 @@ impl Whiteboard {
         &mut self.canvases_to_canvas_objects
     }// -- end pub fn canvases_to_canvas_objects
 
-    pub fn user_permissions(&self) -> &[WhiteboardPermission] {
-        self.metadata.user_permissions.as_slice()
-    }// -- end pub fn user_permissions
-
     pub fn metadata(&self) -> &WhiteboardMetadata {
         &self.metadata
     } // -- end pub fn metadata

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -4,7 +4,14 @@
 //
 // =================================================================================================
 
-use super::{db::WhiteboardDiff,protocol::{ServerSocketMessage,ServerSocketBroadcastMessage}};
+use super::{
+    collections,
+    db::WhiteboardDiff,
+    protocol::{
+        ServerSocketMessage,
+        ServerSocketBroadcastMessage,
+    },
+};
 
 use chrono::{self, Utc};
 use mongodb::bson::{self, oid::ObjectId, serde_helpers::bson_datetime_as_rfc3339_string};
@@ -534,6 +541,15 @@ impl Canvas {
             self.allowed_users = None;
         }
     } // -- end pub fn set_allowed_users
+
+    pub fn user_can_edit(&self, user_id: &UserIdType) -> bool {
+        if let Some(ref allowed_users_set) = self.allowed_users {
+            allowed_users_set.is_empty() || allowed_users_set.contains(user_id)
+        } else {
+            // -- None => true for all
+            true
+        }
+    }// -- end pub fn user_can_edit
 } // -- end impl Canvas
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
@@ -694,6 +710,7 @@ pub struct Whiteboard {
     is_active: bool,
     metadata: WhiteboardMetadata,
     canvases: HashMap<CanvasIdType, Canvas>,
+    canvases_to_canvas_objects: collections::OneToMany<CanvasIdType, CanvasObjectIdType>,
     root_canvas: CanvasIdType,
     // -- A series of contiguous, chronologically-ordered edits applied to this edit by each author
     edit_history_by_author: HashMap<UserIdType, Vec<Edit>>,
@@ -710,6 +727,7 @@ impl Whiteboard {
     ) -> Self {
         let mut edit_history_by_author = HashMap::<UserIdType, Vec<Edit>>::new();
 
+        // -- create edit history
         for edit in edit_history.iter() {
             if let Some(edits) = edit_history_by_author.get_mut(&edit.author) {
                 edits.push(edit.clone());
@@ -718,12 +736,23 @@ impl Whiteboard {
             }
         }// -- end for edit
 
+        // -- initialize canvas => canvas objects mapping
+        let mut canvases_to_canvas_objects
+            = collections::OneToMany::<CanvasIdType, CanvasObjectIdType>::new();
+
+        for (canvas_id, canvas) in canvases.iter() {
+            for obj_id in canvas.canvas_objects().keys() {
+                canvases_to_canvas_objects.insert(canvas_id.clone(), obj_id.clone());
+            }// -- end for obj_id
+        }// -- end for canvas_id, canvas
+
         Self {
             id,
             is_active,
             metadata,
             canvases,
             root_canvas,
+            canvases_to_canvas_objects,
             edit_history_by_author,
         }
     } // -- end pub fn new
@@ -764,6 +793,14 @@ impl Whiteboard {
     pub fn canvases_mut(&mut self) -> &mut HashMap<CanvasIdType, Canvas> {
         &mut self.canvases
     } // -- end pub fn canvases
+
+    pub fn canvases_to_canvas_objects(&self) -> &collections::OneToMany<CanvasIdType, CanvasObjectIdType> {
+        &self.canvases_to_canvas_objects
+    }// -- end pub fn canvases_to_canvas_objects
+
+    pub fn canvases_to_canvas_objects_mut(&mut self) -> &mut collections::OneToMany<CanvasIdType, CanvasObjectIdType> {
+        &mut self.canvases_to_canvas_objects
+    }// -- end pub fn canvases_to_canvas_objects
 
     pub fn metadata(&self) -> &WhiteboardMetadata {
         &self.metadata
@@ -1001,7 +1038,13 @@ impl Whiteboard {
                     for (obj_id, canvas_object) in canvas_objects.iter() {
                         canvas.canvas_objects.insert(obj_id.clone(), canvas_object.clone());
                     }// -- end for canvas_object in canvas_objects.values()
+                } else {
+                    return;
                 }
+
+                for obj_id in canvas_objects.keys() {
+                    self.canvases_to_canvas_objects.insert(canvas_id.clone(), obj_id.clone());
+                }// -- end for obj
             },
             UpdateCanvasObjects {
                 canvas_id,
@@ -1023,20 +1066,31 @@ impl Whiteboard {
                     for obj_id in canvas_objects.keys() {
                         canvas.canvas_objects_mut().remove(obj_id);
                     }// -- end for (obj_id, update) in updates.iter()
+                } else {
+                    return;
                 }
+
+                for obj_id in canvas_objects.keys() {
+                    self.canvases_to_canvas_objects.remove_value(obj_id);
+                }// -- end for obj_id
             },
             CreateCanvases {
                 canvases,
             } => {
-                for (canvas_id, canvas)  in canvases.iter() {
+                for (canvas_id, canvas) in canvases.iter() {
                     self.canvases_mut().insert(canvas_id.clone(), canvas.clone());
+
+                    for obj_id in canvas.canvas_objects().keys() {
+                        self.canvases_to_canvas_objects.insert(canvas_id.clone(), obj_id.clone());
+                    }// -- end for obj_id
                 }// -- end for (canvas_id, canvas)  in canvases.iter()
             },
             DeleteCanvases {
                 canvases,
             } => {
-                for canvas_id  in canvases.keys() {
+                for canvas_id in canvases.keys() {
                     let _ = self.canvases_mut().remove(canvas_id);
+                    self.canvases_to_canvas_objects.remove_key(&canvas_id);
                 }// -- end for (canvas_id, canvas)  in canvases.iter()
             },
             MergeCanvas {
@@ -1082,6 +1136,20 @@ impl Whiteboard {
 
                     // -- Delete old child canvas
                     let _ = self.canvases_mut().remove(child_canvas.id());
+
+                    // -- Transfer references to canvas objects
+                    let transferred_obj_ids = self.canvases_to_canvas_objects
+                        .get_values_by_key(child_canvas.id())
+                        .map(|obj_id_set| obj_id_set.iter().cloned().collect::<Vec<CanvasObjectIdType>>())
+                        .unwrap_or(vec![]);
+
+                    for obj_id in transferred_obj_ids.iter() {
+                        self.canvases_to_canvas_objects.insert(
+                            parent_ref.canvas_id.clone(), obj_id.clone()
+                        );
+                    }// -- end for obj_id
+
+                    self.canvases_to_canvas_objects.remove_key(&parent_ref.canvas_id);
                 }
             },
             SplitCanvas {
@@ -1127,6 +1195,13 @@ impl Whiteboard {
 
                     for obj_id in restored_canvas.canvas_objects().keys() {
                         parent_canvas_objects.remove(obj_id);
+                    }// -- end for obj_id
+
+                    for obj_id in restored_canvas.canvas_objects().keys() {
+                        self.canvases_to_canvas_objects.insert(
+                            restored_canvas.id().clone(),
+                            obj_id.clone()
+                        );
                     }// -- end for obj_id
                 }
             },
@@ -1262,27 +1337,17 @@ pub struct WhiteboardMongoDBView {
 
 impl WhiteboardMongoDBView {
     pub fn to_whiteboard(&self, canvases: &[Canvas], edits: &[Edit]) -> Whiteboard {
-        let mut edit_history_by_author = HashMap::<UserIdType, Vec<Edit>>::new();
-
-        for edit in edits.iter() {
-            if let Some(edits) = edit_history_by_author.get_mut(&edit.author) {
-                edits.push(edit.clone());
-            } else {
-                edit_history_by_author.insert(edit.author.clone(), vec![ edit.clone() ]);
-            }
-        }// -- end for edit
-         //
-        Whiteboard {
-            id: self.id,
-            is_active: true,
-            metadata: self.metadata.to_whiteboard_metadata(),
-            canvases: canvases
+        Whiteboard::new(
+            self.id.clone(),
+            true,
+            self.metadata.to_whiteboard_metadata(),
+            self.root_canvas.clone(),
+            canvases
                 .iter()
-                .map(|canvas| (canvas.id, canvas.clone()))
+                .map(|canvas| (canvas.id.clone(), canvas.clone()))
                 .collect(),
-            root_canvas: self.root_canvas,
-            edit_history_by_author,
-        }
+            Vec::from(edits),
+        )
     }
 }
 

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -33,7 +33,7 @@ pub enum ClientError {
     // -- client did not send an auth token
     NotAuthenticated,
     // -- client not authorized to view this whiteboard at all
-    Unauthorized,
+    UnauthorizedWhiteboard,
     // -- client already authorized (cannot re-authenticate within the same connection)
     AlreadyAuthorized,
     // -- client's auth token is somehow malformed
@@ -52,6 +52,11 @@ pub enum ClientError {
     },
     // -- Client attempted to access canvas that doesn't exist
     CanvasNotFound {
+        #[serde_as(as = "DisplayFromStr")]
+        canvas_id: CanvasIdType,
+    },
+    // -- Client not authorized to edit this canvas
+    UnauthorizedCanvas {
         #[serde_as(as = "DisplayFromStr")]
         canvas_id: CanvasIdType,
     },

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -803,7 +803,13 @@ pub async fn handle_authenticated_client_message<'a>(
                     allowed_users,
                 } => {
                     let mut whiteboard = client_state.base.whiteboard_ref.lock().await;
+                    let clients_by_user_id = client_state.base.clients_by_user_id.lock().await;
+                    let mut selectors_to_canvas_objects = client_state.base.selectors_to_canvas_objects
+                        .lock().await;
                     let client_user_id : &UserIdType = &client_state.user_summary.user_id;
+
+                    let mut response_msgs = Vec::<ServerSocketMessage>::new();
+
                     if ! whiteboard.canvases().contains_key(&canvas_id) {
                         // -- Return error
                         return ClientMessageResponse {
@@ -879,12 +885,75 @@ pub async fn handle_authenticated_client_message<'a>(
                         };
                     } // -- end for user_id in allowed_users.iter()
 
-                    let canvas : &mut Canvas = whiteboard.canvases_mut()
-                        .get_mut(&canvas_id).unwrap();
+                    let canvas : &Canvas = whiteboard.canvases()
+                        .get(&canvas_id).unwrap();
 
                     let old_allowed_users = canvas.allowed_users().map(
                         |users_set| users_set.clone()
                     );
+
+                    let users_removed : Vec<UserIdType>
+                        = if let Some(old_allowed_users_set) = old_allowed_users.as_ref() {
+                        // -- any old allowed users who aren't in the new allowed users
+                        old_allowed_users_set.iter()
+                            .filter_map(|uid| {
+                                if allowed_users.contains(&uid) {
+                                    None
+                                } else {
+                                    Some(uid.clone())
+                                }
+                            })
+                            .collect()
+                    } else {
+                        // -- all whiteboard users with edit or owner permission, minus the new
+                        // allowed users
+                        whiteboard.user_permissions().iter()
+                            .filter_map(|perm| {
+                                if let &WhiteboardPermissionType::User {
+                                    user: user_id,
+                                    ..
+                                } = &perm.permission_type {
+                                    if allowed_users.contains(&user_id) {
+                                        None
+                                    } else {
+                                        Some(user_id.clone())
+                                    }
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect()
+                    };// -- end let users_removed
+
+                    // -- Remove removed users from selectors
+                    {
+                        for removed_user_id in users_removed.iter() {
+                            if let Some(removed_client_ids) = clients_by_user_id.get_values_by_key(&removed_user_id) {
+                                for client_id in removed_client_ids.iter() {
+                                    if let Some(obj_id) = selectors_to_canvas_objects.get_value_by_key(&client_id).cloned() {
+                                        match whiteboard.canvases_to_canvas_objects().get_key_by_value(&obj_id) {
+                                            Some(canv_id) if *canv_id == canvas_id => {
+                                                // -- found an object to deselect
+                                                selectors_to_canvas_objects.remove_key(&client_id);
+
+                                                // -- notify clients of forced deselect
+                                                response_msgs.push(ServerSocketMessage::Broadcast {
+                                                    msg: ServerSocketBroadcastMessage::UnselectedCanvasObject {
+                                                        client_id: client_id.clone(),
+                                                        canvas_object_id: obj_id.clone(),
+                                                    },
+                                                });
+                                            },
+                                            _ => {},
+                                        };// -- end match
+                                    }
+                                }// -- end for client_id
+                            }
+                        }// -- end for removed_user_id
+                    }
+
+                    let canvas : &mut Canvas = whiteboard.canvases_mut()
+                        .get_mut(&canvas_id).unwrap();
 
                     // -- Generate and commit edit
                     let edit = client_state.generate_edit(EditKind::UpdateCanvasAllowedUsers {
@@ -903,17 +972,19 @@ pub async fn handle_authenticated_client_message<'a>(
                     }
 
                     // -- broadcast to all users
+                    response_msgs.push(ServerSocketMessage::Broadcast {
+                        msg: ServerSocketBroadcastMessage::UpdateCanvasAllowedUsers {
+                            client_id: client_state.base.client_id.clone(),
+                            canvas_id: canvas_id.clone(),
+                            allowed_users: allowed_users
+                                .iter()
+                                .map(|oid| oid.clone())
+                                .collect(),
+                        },
+                    });
+
                     ClientMessageResponse {
-                        messages: vec![ServerSocketMessage::Broadcast {
-                            msg: ServerSocketBroadcastMessage::UpdateCanvasAllowedUsers {
-                                client_id: client_state.base.client_id.clone(),
-                                canvas_id: canvas_id.clone(),
-                                allowed_users: allowed_users
-                                    .iter()
-                                    .map(|oid| oid.clone())
-                                    .collect(),
-                            },
-                        }],
+                        messages: response_msgs,
                         notifications: vec![],
                     }
                 }

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -907,19 +907,12 @@ pub async fn handle_authenticated_client_message<'a>(
                     } else {
                         // -- all whiteboard users with edit or owner permission, minus the new
                         // allowed users
-                        whiteboard.user_permissions().iter()
-                            .filter_map(|perm| {
-                                if let &WhiteboardPermissionType::User {
-                                    user: user_id,
-                                    ..
-                                } = &perm.permission_type {
-                                    if allowed_users.contains(&user_id) {
-                                        None
-                                    } else {
-                                        Some(user_id.clone())
-                                    }
-                                } else {
+                        whiteboard.metadata().permissions_by_user_id().keys()
+                            .filter_map(|user_id| {
+                                if allowed_users.contains(&user_id) {
                                     None
+                                } else {
+                                    Some(user_id.clone())
                                 }
                             })
                             .collect()

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -218,24 +218,97 @@ pub async fn handle_authenticated_client_message<'a>(
                     notifications: vec![],
                 },
                 EditingCanvas { canvas_id } => {
-                    // TODO: validate that canvas id is valid and user has permission to edit
-                    // canvas.
-                    ClientMessageResponse {
-                        messages: vec![ServerSocketMessage::Broadcast {
-                            msg: ServerSocketBroadcastMessage::EditingCanvas {
-                                client_id: client_state.base.client_id.clone(),
-                                canvas_id,
-                            },
-                        }],
-                        notifications: vec![],
+                    let whiteboard = client_state.base.whiteboard_ref.lock().await;
+
+                    if let Some(canvas) = whiteboard.canvases().get(&canvas_id) {
+                        if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::UnauthorizedCanvas {
+                                            canvas_id: canvas_id.clone(),
+                                        },
+                                    },
+                                }],
+                                notifications: vec![],
+                            };
+                        } else {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Broadcast {
+                                    msg: ServerSocketBroadcastMessage::EditingCanvas {
+                                        client_id: client_state.base.client_id.clone(),
+                                        canvas_id: canvas_id.clone(),
+                                    },
+                                }],
+                                notifications: vec![],
+                            }
+                        }
+                    } else {
+                        return ClientMessageResponse {
+                            messages: vec![ServerSocketMessage::Individual {
+                                target_client_id: client_state.base.client_id.clone(),
+                                msg: ServerSocketIndividualMessage::Error {
+                                    error: ClientError::CanvasNotFound {
+                                        canvas_id: canvas_id.clone(),
+                                    },
+                                },
+                            }],
+                            notifications: vec![],
+                        }
                     }
                 }
                 SelectedCanvasObject {
                     canvas_object_id,
                 } => {
-                    // -- ensure the object isn't already selected by someone else
-                    let mut selectors_to_canvas_objects = client_state.base.selectors_to_canvas_objects.lock().await;
+                    let wb = client_state.base.whiteboard_ref.lock().await;
+                    let mut selectors_to_canvas_objects
+                        = client_state.base.selectors_to_canvas_objects.lock().await;
 
+                    // -- ensure the client has permission to edit the canvas
+                    if let Some(canvas_id) = wb.canvases_to_canvas_objects().get_key_by_value(&canvas_object_id) {
+                        if let Some(canvas) = wb.canvases().get(&canvas_id) {
+                            if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                                return ClientMessageResponse {
+                                    messages: vec![ServerSocketMessage::Individual {
+                                        target_client_id: client_state.base.client_id.clone(),
+                                        msg: ServerSocketIndividualMessage::Error {
+                                            error: ClientError::UnauthorizedCanvas {
+                                                canvas_id: canvas_id.clone(),
+                                            },
+                                        }
+                                    }],
+                                    notifications: vec![],
+                                };
+                            }
+                        } else {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::CanvasNotFound {
+                                            canvas_id: canvas_id.clone(),
+                                        },
+                                    }
+                                }],
+                                notifications: vec![],
+                            };
+                        }
+                    } else {
+                        return ClientMessageResponse {
+                            messages: vec![ServerSocketMessage::Individual {
+                                target_client_id: client_state.base.client_id.clone(),
+                                msg: ServerSocketIndividualMessage::Error {
+                                    error: ClientError::CanvasObjectNotFound {
+                                        canvas_object_id: canvas_object_id.clone(),
+                                    },
+                                }
+                            }],
+                            notifications: vec![],
+                        };
+                    }
+
+                    // -- ensure the object isn't already selected by someone else
                     match selectors_to_canvas_objects.get_key_by_value(&canvas_object_id).cloned() {
                         Some(selector_id) if selector_id != client_state.base.client_id => {
                             ClientMessageResponse {
@@ -324,9 +397,8 @@ pub async fn handle_authenticated_client_message<'a>(
                     ref canvas_objects,
                 } => {
                     let mut whiteboard = client_state.base.whiteboard_ref.lock().await;
-                    println!("Creating canvas_object on canvas {} ...", canvas_id);
 
-                    match whiteboard.canvases_mut().get_mut(&canvas_id) {
+                    match whiteboard.canvases().get(&canvas_id) {
                         None => ClientMessageResponse {
                             messages: vec![ServerSocketMessage::Individual {
                                 target_client_id: client_state.base.client_id.clone(),
@@ -339,6 +411,21 @@ pub async fn handle_authenticated_client_message<'a>(
                             notifications: vec![],
                         },
                         Some(canvas) => {
+                            // -- Check that the user can edit this canvas
+                            if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                                return ClientMessageResponse {
+                                    messages: vec![ServerSocketMessage::Individual {
+                                        target_client_id: client_state.base.client_id.clone(),
+                                        msg: ServerSocketIndividualMessage::Error {
+                                            error: ClientError::UnauthorizedCanvas {
+                                                canvas_id: canvas_id.clone(),
+                                            },
+                                        }
+                                    }],
+                                    notifications: vec![],
+                                };
+                            }
+
                             // -- Generate new canvas_objects
                             let new_canvas_objects : HashMap::<CanvasObjectIdType, CanvasObjectModel>
                                 = canvas_objects.iter()
@@ -382,10 +469,8 @@ pub async fn handle_authenticated_client_message<'a>(
                     ref canvas_objects,
                 } => {
                     let mut whiteboard = client_state.base.whiteboard_ref.lock().await;
-                    println!("Updating canvas_objects on canvas {} ...", canvas_id);
-                    println!("CanvasObjects: {:?}", canvas_objects);
 
-                    match whiteboard.canvases_mut().get_mut(&canvas_id) {
+                    match whiteboard.canvases().get(&canvas_id) {
                         None => ClientMessageResponse {
                             messages: vec![ServerSocketMessage::Individual {
                                 target_client_id: client_state.base.client_id.clone(),
@@ -398,6 +483,20 @@ pub async fn handle_authenticated_client_message<'a>(
                             notifications: vec![],
                         },
                         Some(canvas) => {
+                            if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                                return ClientMessageResponse {
+                                    messages: vec![ServerSocketMessage::Individual {
+                                        target_client_id: client_state.base.client_id.clone(),
+                                        msg: ServerSocketIndividualMessage::Error {
+                                            error: ClientError::UnauthorizedCanvas {
+                                                canvas_id: canvas_id.clone(),
+                                            },
+                                        }
+                                    }],
+                                    notifications: vec![],
+                                };
+                            }
+
                             let selectors_to_canvas_objects = client_state.base
                                 .selectors_to_canvas_objects.lock().await;
                             let mut updated_canvas_objects = HashMap::<CanvasObjectIdType, CanvasObjectModel>::new();
@@ -420,7 +519,7 @@ pub async fn handle_authenticated_client_message<'a>(
                                     },
                                     _ => {
                                         // -- modify canvas_objects
-                                        if let Some(old_obj) = canvas.canvas_objects_mut().get_mut(&obj_id) {
+                                        if let Some(old_obj) = canvas.canvas_objects().get(&obj_id) {
                                             edit_updates.insert(obj_id.clone(), CanvasObjectUpdate {
                                                 old_fields: old_obj.clone(),
                                                 new_fields: canvas_object.clone(),
@@ -485,6 +584,20 @@ pub async fn handle_authenticated_client_message<'a>(
 
                     // Mark objects for deletion locally
                     if let Some(canvas) = whiteboard.canvases_mut().get_mut(&canvas_id) {
+                        if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::UnauthorizedCanvas {
+                                            canvas_id: canvas_id.clone(),
+                                        },
+                                    }
+                                }],
+                                notifications: vec![],
+                            };
+                        }
+
                         // TODO: refactor to store all canvas objects in one large HashMap
                         for object_id in canvas_object_ids.iter() {
                             match selectors_to_canvas_objects.get_key_by_value(&object_id) {
@@ -548,6 +661,35 @@ pub async fn handle_authenticated_client_message<'a>(
                     allowed_users,
                 } => {
                     let mut whiteboard = client_state.base.whiteboard_ref.lock().await;
+
+                    if let Some(canvas) = whiteboard.canvases().get(&parent_canvas.canvas_id) {
+                        if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::UnauthorizedCanvas {
+                                            canvas_id: parent_canvas.canvas_id.clone(),
+                                        },
+                                    }
+                                }],
+                                notifications: vec![],
+                            };
+                        }
+                    } else {
+                        return ClientMessageResponse {
+                            messages: vec![ServerSocketMessage::Individual {
+                                target_client_id: client_state.base.client_id.clone(),
+                                msg: ServerSocketIndividualMessage::Error {
+                                    error: ClientError::CanvasNotFound {
+                                        canvas_id: parent_canvas.canvas_id.clone(),
+                                    },
+                                }
+                            }],
+                            notifications: vec![],
+                        };
+                    }
+
                     let new_canvas_id = ObjectId::new();
 
                     // Initialize new canvas with only current user allowed to edit
@@ -601,8 +743,34 @@ pub async fn handle_authenticated_client_message<'a>(
                     // delete canvases identified by the given ids
                     for id in &canvas_ids {
                         if let Some(old_canvas) = whiteboard.canvases().get(id) {
+                            if ! old_canvas.user_can_edit(&client_state.user_summary.user_id) {
+                                return ClientMessageResponse {
+                                    messages: vec![ServerSocketMessage::Individual {
+                                        target_client_id: client_state.base.client_id.clone(),
+                                        msg: ServerSocketIndividualMessage::Error {
+                                            error: ClientError::UnauthorizedCanvas {
+                                                canvas_id: id.clone(),
+                                            },
+                                        }
+                                    }],
+                                    notifications: vec![],
+                                };
+                            }
+
                             edit_update.insert(id.clone(), old_canvas.clone());
                             deleted_canvas_ids.push(id.clone());
+                        } else {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::CanvasNotFound {
+                                            canvas_id: id.clone(),
+                                        },
+                                    }
+                                }],
+                                notifications: vec![],
+                            };
                         }
                     } // end for id in canvas_ids
 
@@ -662,7 +830,7 @@ pub async fn handle_authenticated_client_message<'a>(
                                     messages: vec![ServerSocketMessage::Individual {
                                         target_client_id: client_state.base.client_id.clone(),
                                         msg: ServerSocketIndividualMessage::Error {
-                                            error: ClientError::Unauthorized,
+                                            error: ClientError::UnauthorizedWhiteboard,
                                         },
                                     }],
                                     notifications: vec![],
@@ -760,6 +928,20 @@ pub async fn handle_authenticated_client_message<'a>(
                     //  then extend it with the canvas_objects from the child canvas, then make it the new
                     //  parent canvas canvas_objects
                     let old_child_canvas = if let Some(child_canvas) = whiteboard.canvases().get(&canvas_id) {
+                        if ! child_canvas.user_can_edit(&client_state.user_summary.user_id) {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::UnauthorizedCanvas {
+                                            canvas_id: canvas_id.clone(),
+                                        },
+                                    }
+                                }],
+                                notifications: vec![],
+                            };
+                        }
+
                         if let Some(parent_canvas) = child_canvas.parent_canvas() {
                             // Store copy of parent canvas ref, to allow resetting parent canvas refs
                             // later
@@ -793,7 +975,21 @@ pub async fn handle_authenticated_client_message<'a>(
                         };
                     };
 
-                    if ! whiteboard.canvases().contains_key(parent_ref.canvas_id()) {
+                    if let Some(parent_canvas) = whiteboard.canvases().get(parent_ref.canvas_id()) {
+                        if ! parent_canvas.user_can_edit(&client_state.user_summary.user_id) {
+                            return ClientMessageResponse {
+                                messages: vec![ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::UnauthorizedCanvas {
+                                            canvas_id: parent_canvas.id().clone(),
+                                        },
+                                    }
+                                }],
+                                notifications: vec![],
+                            };
+                        }
+                    } else {
                         return ClientMessageResponse {
                             messages: vec![ServerSocketMessage::Individual {
                                 target_client_id: client_state.base.client_id.clone(),
@@ -1127,7 +1323,7 @@ pub async fn handle_unauthenticated_client_message<
                                 messages: vec![ServerSocketMessage::Individual {
                                     target_client_id: client_state.client_id.clone(),
                                     msg: ServerSocketIndividualMessage::Error {
-                                        error: ClientError::Unauthorized,
+                                        error: ClientError::UnauthorizedWhiteboard,
                                     }
                                 }],
                                 notifications: vec![],


### PR DESCRIPTION
Previously the web socket server didn't actually enforce allowed user permissions on canvases, so anyone could edit any canvas. This PR fixes that, enforcing allowed user permissions in both the web socket server and the frontend.

- **Enforce canvas allowed users on the web socket server side.**
- **Editable canvas object components in frontend prevent further editing of objects when edit access to canvas has been revoked from the user.**
- **Web socket server removes selectors from canvas objects if their permission to edit a given canvas is revoked.**
- **Re-implemented removing canvas object selectors when a user's permission to edit a canvas is revoked.**
- **Allowed users popover from canvas menu filters possible editors down to users with editor or owner permission on the whiteboard.**
- **Canvas menu informs users that all users can edit a canvas if no specific allowed users are specified for a canvas.**
