### PR TITLE
Refactor: Simplify Web Socket Server Build

### DIFF
--- a/WebSocketServer/Cargo.toml
+++ b/WebSocketServer/Cargo.toml
@@ -16,8 +16,13 @@ sha2 = "0.10.9"
 hmac = "0.12.1"
 serde_with = "3.15.0"
 
+[lib]
+name = "wss"
+path = "src/wss/mod.rs"
+crate-type = ["lib"]
+
 [[bin]]
-# Dummy build target to make Cargo happy when installing dependencies.
-# Avoids needing to re-install dependencies every time the service is rebuilt.
-name = "dummy"
-path = "src/dummy.rs"
+name = "web_socket_server"
+path = "src/main.rs"
+test = false
+bench = false

--- a/WebSocketServer/Dockerfile
+++ b/WebSocketServer/Dockerfile
@@ -2,162 +2,74 @@
 ARG BUILD_DIR=/build
 ARG DEST_DIR=/app
 
-# ---- Stage 1: Dependency planner (cargo-chef) ----
-FROM rust:1.96 AS planner
+# ---- Stage: Create uniform build environment ---------------------------------
+FROM rust:1.96 AS build_base
+
+# -- Nothing else to do, for now
+# -- If any dependencies are added that need to be used by all build
+# environments, install them here.
+
+# ---- Stage: Build Test Runner ------------------------------------------------
+FROM build_base AS test_runtime
 
 ARG BUILD_DIR
 ARG DEST_DIR
 
 WORKDIR ${BUILD_DIR}
 
-# Install cargo-chef
+RUN mkdir -p ./src
+
+# -- Build tests
 RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  cargo install cargo-chef
-
-# Copy manifests
-COPY Cargo.toml Cargo.lock ./
-
-# Dummy build file to make Cargo happy
-COPY <<-EOF src/dummy.rs
-fn main() {}
-EOF
-
-# Generate dependency build plan
-RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  cargo chef prepare --recipe-path recipe.json
-
-# ---- Stage: Test Builder ----
-FROM rust:1.96 AS build_tests
-
-ARG BUILD_DIR
-ARG DEST_DIR
-
-WORKDIR ${BUILD_DIR}
-
-# Install cargo-chef
-RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  cargo install cargo-chef
-
-# Copy manifests, recipe
-COPY --from=planner ${BUILD_DIR}/recipe.json recipe.json
-COPY Cargo.toml Cargo.lock ./
-
-# Build test dependencies
-RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  --mount=type=cache,id=test_deps,target=${BUILD_DIR}/target \
+  --mount=type=bind,source=Cargo.toml,target=./Cargo.toml \
+  --mount=type=bind,source=Cargo.lock,target=./Cargo.lock \
+  --mount=type=bind,source=src/wss,target=./src/wss \
+  --mount=type=cache,id=whiteboard_editor.wss.test_target,target=./target \
   <<_EOF_
-#!/usr/bin/bash -e
+#!/usr/bin/bash -ve
 
-cargo chef cook --tests --recipe-path recipe.json
+# Remove old test binaries
+if [[ -d "./target/debug/deps" ]]
+then
+  find target/debug/deps -type f -name "*web_socket_server*" -delete
+fi
 
-# Copy registry and build artifacts
-cp -rp /usr/local/cargo/registry /tmp/cargo_registry
-cp -rp /usr/local/cargo/git /tmp/cargo_git
-cp -rp ./target /tmp/test_deps
-_EOF_
-
-# Copy relevant source code
-COPY ./src/wss ./src/wss
-
-# Dummy build file to make Cargo happy
-COPY <<-EOF src/dummy.rs
-fn main() {}
-EOF
-
-# Build tests
-RUN <<_EOF_
-#!/usr/bin/bash -e
-
-# Copy artifacts from dependency build step into proper locations
-rm -rf /usr/local/cargo/registry /usr/local/cargo/git
-cp -rp /tmp/cargo_registry /usr/local/cargo/registry
-cp -rp /tmp/cargo_git /usr/local/cargo/git
-cp -r --preserve=mode,timestamps /tmp/test_deps ./target
-
-# Build tests
+# Build tests anew (dependency builds should be cached)
 cargo test --no-run
+
+# Copy artifacts to final destination
+mkdir -p "${DEST_DIR}"
+cp -p ./Cargo.toml ./Cargo.lock "${DEST_DIR}"
+cp -rp ./src "${DEST_DIR}/src"
+cp -rp ./target "${DEST_DIR}/target"
 _EOF_
 
-# ---- Stage: Prepare Test Runtime Environment ----
-FROM rust:1.96 AS test_runtime
-
-ARG BUILD_DIR
-ARG DEST_DIR
-
-# Set working directory to destination
+# -- Set up test runtime
 WORKDIR ${DEST_DIR}
-
-COPY Cargo.toml Cargo.lock .
-COPY ./src ./src
-
-# Copy registries from previous stage
-COPY --from=build_tests /usr/local/cargo/registry /usr/local/cargo/registry
-COPY --from=build_tests /usr/local/cargo/git /usr/local/cargo/git
-
-# Copy target directory
-COPY --from=build_tests ${BUILD_DIR}/target ./target
-
-# Dummy build file to make Cargo happy
-COPY <<-EOF src/dummy.rs
-fn main() {}
-EOF
 
 ENTRYPOINT ["cargo", "test"]
 
 # ---- Stage: Build Release Binary ----
-FROM rust:1.96 AS build_release
+FROM build_base AS build_release
 
 ARG BUILD_DIR
 ARG DEST_DIR
 
 WORKDIR ${BUILD_DIR}
 
-# Install cargo-chef
-RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  cargo install cargo-chef
-
-# Copy manifests, recipe
-COPY --from=planner ${BUILD_DIR}/recipe.json recipe.json
-COPY Cargo.toml Cargo.lock ./
-
-# Build release dependencies
-RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  --mount=type=cache,id=release_target,target=${BUILD_DIR}/target \
-  cargo chef cook --release --recipe-path recipe.json
-
-# Copy relevant source code
-COPY ./src/main.rs ./src
-COPY ./src/wss ./src/wss
-
-# Dummy build file to make Cargo happy
-COPY <<-EOF src/dummy.rs
-fn main() {}
-EOF
-
 # Build release binary
 RUN \
-  --mount=type=cache,id=cargo_registry,target=/usr/local/cargo/registry \
-  --mount=type=cache,id=cargo_git,target=/usr/local/cargo/git \
-  --mount=type=cache,id=release_target,target=${BUILD_DIR}/target \
+  --mount=type=bind,source=Cargo.toml,target=./Cargo.toml \
+  --mount=type=bind,source=Cargo.lock,target=./Cargo.lock \
+  --mount=type=bind,source=src,target=./src \
+  --mount=type=cache,id=whiteboard_editor.wss.release_target,target=${BUILD_DIR}/target \
   cargo build --release
 
 # Copy final build from cache
 WORKDIR ${DEST_DIR}
 
 RUN \
-  --mount=type=cache,id=release_target,target=${BUILD_DIR}/target \
+  --mount=type=cache,id=whiteboard_editor.wss.release_target,target=${BUILD_DIR}/target \
   cp \
     --preserve=mode,timestamps \
     ${BUILD_DIR}/target/release/web_socket_server \
@@ -172,15 +84,12 @@ ARG DEST_DIR
 WORKDIR ${DEST_DIR}
 
 RUN <<_EOF_
-#!/bin/bash -e
+#!/usr/bin/bash -ve
 
 apt-get update
 apt-get install -y ca-certificates
 rm -rf /var/lib/apt/lists/*
 _EOF_
-
-# Establishes dependency relationship between stages
-COPY --from=build_release ${BUILD_DIR}/recipe.json recipe.json
 
 # Copy cached binary into final location
 COPY --from=build_release ${DEST_DIR}/web_socket_server /usr/local/bin/web_socket_server

--- a/WebSocketServer/Dockerfile
+++ b/WebSocketServer/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_DIR=/build
 ARG DEST_DIR=/app
 
 # ---- Stage 1: Dependency planner (cargo-chef) ----
-FROM rust:1.95 AS planner
+FROM rust:1.96 AS planner
 
 ARG BUILD_DIR
 ARG DEST_DIR
@@ -31,7 +31,7 @@ RUN \
   cargo chef prepare --recipe-path recipe.json
 
 # ---- Stage: Test Builder ----
-FROM rust:1.95 AS build_tests
+FROM rust:1.96 AS build_tests
 
 ARG BUILD_DIR
 ARG DEST_DIR
@@ -87,7 +87,7 @@ cargo test --no-run
 _EOF_
 
 # ---- Stage: Prepare Test Runtime Environment ----
-FROM rust:1.95 AS test_runtime
+FROM rust:1.96 AS test_runtime
 
 ARG BUILD_DIR
 ARG DEST_DIR
@@ -113,7 +113,7 @@ EOF
 ENTRYPOINT ["cargo", "test"]
 
 # ---- Stage: Build Release Binary ----
-FROM rust:1.95 AS build_release
+FROM rust:1.96 AS build_release
 
 ARG BUILD_DIR
 ARG DEST_DIR

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -250,7 +250,6 @@ async fn handle_connection(
         db::{MongoDBInterface, get_whiteboard_by_id},
         models::{
             ClientIdType,
-            NotificationClientView,
         },
         protocol::{
             ClientError,

--- a/WebSocketServer/src/wss/collections.rs
+++ b/WebSocketServer/src/wss/collections.rs
@@ -85,23 +85,23 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToM
         self.keys_by_value.insert(value.clone(), key.clone());
     }// -- end pub fn insert
 
-    // pub fn get_values_by_key(&self, key: &K) -> Option<&BTreeSet<V>> {
-    //     self.values_by_key.get(key)
-    // }// -- end pub fn get_values_by_key
+    pub fn get_values_by_key(&self, key: &K) -> Option<&BTreeSet<V>> {
+        self.values_by_key.get(key)
+    }// -- end pub fn get_values_by_key
 
-    // pub fn get_key_by_value(&self, value: &V) -> Option<&K> {
-    //     self.keys_by_value.get(value)
-    // }// -- end pub fn get_key_by_value
+    pub fn get_key_by_value(&self, value: &V) -> Option<&K> {
+        self.keys_by_value.get(value)
+    }// -- end pub fn get_key_by_value
 
-    // pub fn remove_key(&mut self, key: &K) {
-    //     if let Some(values_set) = self.values_by_key.get(key) {
-    //         for value in values_set.iter() {
-    //             self.keys_by_value.remove(value);
-    //         }// -- end for value in values_set.iter()
-    //     }
+    pub fn remove_key(&mut self, key: &K) {
+        if let Some(values_set) = self.values_by_key.get(key) {
+            for value in values_set.iter() {
+                self.keys_by_value.remove(value);
+            }// -- end for value in values_set.iter()
+        }
 
-    //     self.values_by_key.remove(key);
-    // }// -- end pub fn remove_key
+        self.values_by_key.remove(key);
+    }// -- end pub fn remove_key
 
     pub fn remove_value(&mut self, value: &V) {
         if let Some(key) = self.keys_by_value.get(value) {

--- a/WebSocketServer/src/wss/collections.rs
+++ b/WebSocketServer/src/wss/collections.rs
@@ -49,9 +49,9 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToM
         }
     }// -- end pub fn new
 
-    pub fn len(&self) -> usize {
-        self.keys_by_value.len()
-    }// -- end pub fn len
+    // pub fn len(&self) -> usize {
+    //     self.keys_by_value.len()
+    // }// -- end pub fn len
 
     pub fn iter(&self) -> OneToManyIter<'_, K, V> {
         OneToManyIter {
@@ -85,23 +85,23 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToM
         self.keys_by_value.insert(value.clone(), key.clone());
     }// -- end pub fn insert
 
-    pub fn get_values_by_key(&self, key: &K) -> Option<&BTreeSet<V>> {
-        self.values_by_key.get(key)
-    }// -- end pub fn get_values_by_key
+    // pub fn get_values_by_key(&self, key: &K) -> Option<&BTreeSet<V>> {
+    //     self.values_by_key.get(key)
+    // }// -- end pub fn get_values_by_key
 
-    pub fn get_key_by_value(&self, value: &V) -> Option<&K> {
-        self.keys_by_value.get(value)
-    }// -- end pub fn get_key_by_value
+    // pub fn get_key_by_value(&self, value: &V) -> Option<&K> {
+    //     self.keys_by_value.get(value)
+    // }// -- end pub fn get_key_by_value
 
-    pub fn remove_key(&mut self, key: &K) {
-        if let Some(values_set) = self.values_by_key.get(key) {
-            for value in values_set.iter() {
-                self.keys_by_value.remove(value);
-            }// -- end for value in values_set.iter()
-        }
+    // pub fn remove_key(&mut self, key: &K) {
+    //     if let Some(values_set) = self.values_by_key.get(key) {
+    //         for value in values_set.iter() {
+    //             self.keys_by_value.remove(value);
+    //         }// -- end for value in values_set.iter()
+    //     }
 
-        self.values_by_key.remove(key);
-    }// -- end pub fn remove_key
+    //     self.values_by_key.remove(key);
+    // }// -- end pub fn remove_key
 
     pub fn remove_value(&mut self, value: &V) {
         if let Some(key) = self.keys_by_value.get(value) {
@@ -145,6 +145,7 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToO
         }
     }// -- end pub fn new
 
+    #[allow(unused)]
     pub fn len(&self) -> usize {
         self.values_by_key.len()
     }// -- end pub fn len
@@ -162,6 +163,7 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToO
         self.keys_by_value.insert(value.clone(), key.clone());
     }// -- end pub fn insert
 
+    #[allow(unused)]
     pub fn get_value_by_key(&self, key: &K) -> Option<&V> {
         self.values_by_key.get(key)
     }// -- end pub fn get_values_by_key

--- a/WebSocketServer/src/wss/db.rs
+++ b/WebSocketServer/src/wss/db.rs
@@ -45,6 +45,7 @@ pub async fn connect_mongodb(uri: &str) -> mongodb::error::Result<mongodb::Clien
 // Interface for fetching objects from the MongoDB database, by id.
 //
 // ================================================================================================
+#[allow(unused)]
 #[derive(Debug)]
 pub struct MongoDBStore {
     user_collection: Collection<UserMongoDBView>,
@@ -52,6 +53,7 @@ pub struct MongoDBStore {
 } // -- end MongoDBStore
 
 impl MongoDBStore {
+    #[allow(unused)]
     pub fn new(
         user_coll: &Collection<UserMongoDBView>,
         whiteboard_metadata_coll: &Collection<WhiteboardMetadataMongoDBView>,
@@ -143,10 +145,12 @@ pub enum WhiteboardDiff {
         target_edit_id: EditIdType,
     },
     RedoEdit {
+        #[allow(unused)]
         target_edit_id: EditIdType,
     },
 } // -- end enum WhiteboardDiff
 
+#[allow(unused)]
 pub async fn get_whiteboard_metadata_by_id(
     db: &Database,
     wid: &WhiteboardIdType,
@@ -302,6 +306,7 @@ pub struct MongoDBInterface {
     canvas_object_coll: Collection<CanvasObjectMongoDBView>,
     user_coll: Collection<UserMongoDBView>,
     edit_coll: Collection<EditMongoDBView>,
+    #[allow(unused)]
     notification_coll: Collection<NotificationMongoDBView>,
 }// -- end pub struct MongoDBInterface
 
@@ -724,10 +729,10 @@ impl MongoDBInterface {
         }
     }// -- end pub async fn process_edit
 
-    pub async fn save_notification(&self, notif: &Notification) {
-        let notif_view = NotificationMongoDBView::from_notification(&notif);
-        let _ = self.notification_coll.insert_one(notif_view).await;
-    }// -- end save_notification
+    // pub async fn save_notification(&self, notif: &Notification) {
+    //     let notif_view = NotificationMongoDBView::from_notification(&notif);
+    //     let _ = self.notification_coll.insert_one(notif_view).await;
+    // }// -- end save_notification
 }// -- end impl MongoDBInterface
 
 impl UserStore for MongoDBInterface {

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -3,7 +3,6 @@
 // Contains specifications of objects that the user manipulates via the whiteboard editor interface.
 //
 // =================================================================================================
-
 use super::{db::WhiteboardDiff,protocol::{ServerSocketMessage,ServerSocketBroadcastMessage}};
 
 use chrono::{self, Utc};
@@ -70,6 +69,7 @@ pub struct CanvasObject {
     pub canvas_object: CanvasObjectModel,
 }
 
+#[allow(unused)]
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -83,21 +83,21 @@ pub struct CanvasObjectClientView {
 }
 
 impl CanvasObjectClientView {
-    pub fn from_canvas_object(src: &CanvasObject) -> Self {
-        Self {
-            id: src.id.clone(),
-            canvas_id: src.canvas_id.clone(),
-            canvas_object: src.canvas_object.clone(),
-        }
-    }// -- end pub fn from_canvas_object
+    // pub fn from_canvas_object(src: &CanvasObject) -> Self {
+    //     Self {
+    //         id: src.id.clone(),
+    //         canvas_id: src.canvas_id.clone(),
+    //         canvas_object: src.canvas_object.clone(),
+    //     }
+    // }// -- end pub fn from_canvas_object
 
-    pub fn to_canvas_object(&self) -> CanvasObject {
-        CanvasObject {
-            id: self.id.clone(),
-            canvas_id: self.canvas_id.clone(),
-            canvas_object: self.canvas_object.clone(),
-        }
-    }// -- end pub fn to_canvas_object
+    // pub fn to_canvas_object(&self) -> CanvasObject {
+    //     CanvasObject {
+    //         id: self.id.clone(),
+    //         canvas_id: self.canvas_id.clone(),
+    //         canvas_object: self.canvas_object.clone(),
+    //     }
+    // }// -- end pub fn to_canvas_object
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -150,72 +150,72 @@ pub enum UserMongoDBView {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(
-    tag = "kind",
-    rename_all = "camelCase",
-    rename_all_fields = "camelCase"
-)]
-pub enum UserClientView {
-    Permanent {
-        id: String,
-        username: String,
-        email: String,
-    },
-    Temp {
-        id: String,
-        username: String,
-        // temp_expires_at: String,
-    },
-}
+// #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+// #[serde(
+//     tag = "kind",
+//     rename_all = "camelCase",
+//     rename_all_fields = "camelCase"
+// )]
+// pub enum UserClientView {
+//     Permanent {
+//         id: String,
+//         username: String,
+//         email: String,
+//     },
+//     Temp {
+//         id: String,
+//         username: String,
+//         // temp_expires_at: String,
+//     },
+// }
 
-impl UserClientView {
-    pub fn from_user(user: &User) -> Self {
-        match user {
-            User::Permanent {
-                id,
-                username,
-                email,
-            } => Self::Permanent {
-                id: id.to_hex(),
-                username: username.clone(),
-                email: email.clone(),
-            },
-            User::Temp {
-                id,
-                username,
-                // temp_expires_at,
-            } => Self::Temp {
-                id: id.to_hex(),
-                username: username.clone(),
-                // temp_expires_at: temp_expires_at.clone(),
-            },
-        }
-    } // end from_user
-
-    pub fn to_user(&self) -> Result<User, mongodb::bson::oid::Error> {
-        match self {
-            Self::Permanent {
-                id,
-                username,
-                email,
-            } => Ok(User::Permanent {
-                id: ObjectId::parse_str(id)?,
-                username: username.clone(),
-                email: email.clone(),
-            }),
-            Self::Temp {
-                id,
-                username,
-                // temp_expires_at,
-            } => Ok(User::Temp {
-                id: ObjectId::parse_str(id)?,
-                username: username.clone(),
-                // temp_expires_at: temp_expires_at.clone(),
-            }),
-        }
-    } // end to_user
-}
+// impl UserClientView {
+//     pub fn from_user(user: &User) -> Self {
+//         match user {
+//             User::Permanent {
+//                 id,
+//                 username,
+//                 email,
+//             } => Self::Permanent {
+//                 id: id.to_hex(),
+//                 username: username.clone(),
+//                 email: email.clone(),
+//             },
+//             User::Temp {
+//                 id,
+//                 username,
+//                 // temp_expires_at,
+//             } => Self::Temp {
+//                 id: id.to_hex(),
+//                 username: username.clone(),
+//                 // temp_expires_at: temp_expires_at.clone(),
+//             },
+//         }
+//     } // end from_user
+// 
+//     pub fn to_user(&self) -> Result<User, mongodb::bson::oid::Error> {
+//         match self {
+//             Self::Permanent {
+//                 id,
+//                 username,
+//                 email,
+//             } => Ok(User::Permanent {
+//                 id: ObjectId::parse_str(id)?,
+//                 username: username.clone(),
+//                 email: email.clone(),
+//             }),
+//             Self::Temp {
+//                 id,
+//                 username,
+//                 // temp_expires_at,
+//             } => Ok(User::Temp {
+//                 id: ObjectId::parse_str(id)?,
+//                 username: username.clone(),
+//                 // temp_expires_at: temp_expires_at.clone(),
+//             }),
+//         }
+//     } // end to_user
+// }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(
@@ -237,6 +237,7 @@ pub enum User {
 }
 
 impl UserMongoDBView {
+    #[allow(unused)]
     pub fn from_user(user: &User) -> Self {
         match user {
             User::Permanent {
@@ -499,6 +500,7 @@ impl Canvas {
         self.height
     } // -- end pub fn height
 
+    #[allow(unused)]
     pub fn time_created(&self) -> &chrono::DateTime<Utc> {
         &self.time_created
     } // -- end pub fn time_created
@@ -570,15 +572,15 @@ impl WhiteboardPermissionEnumClientView {
         }// -- end match perm
     }// -- end pub fn from_permission_enum
 
-    pub fn to_permission_enum(&self) -> WhiteboardPermissionEnum {
-        use WhiteboardPermissionEnum::*;
+    // pub fn to_permission_enum(&self) -> WhiteboardPermissionEnum {
+    //     use WhiteboardPermissionEnum::*;
 
-        match self {
-            Self::View => View,
-            Self::Edit => Edit,
-            Self::Own => Own,
-        }// -- end match self
-    }// -- end pub fn to_permission_enum
+    //     match self {
+    //         Self::View => View,
+    //         Self::Edit => Edit,
+    //         Self::Own => Own,
+    //     }// -- end match self
+    // }// -- end pub fn to_permission_enum
 }// -- end impl WhiteboardPermissionEnumClientView
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -607,7 +609,7 @@ pub struct WhiteboardPermission {
 }
 
 pub type WhiteboardPermissionMongoDBView = WhiteboardPermission;
-pub type WhiteboardPermissionClientView = WhiteboardPermission;
+// pub type WhiteboardPermissionClientView = WhiteboardPermission;
 
 // === WhiteboardMetadata =========================================================================
 //
@@ -700,6 +702,7 @@ pub struct Whiteboard {
 } // -- end struct Whiteboard
 
 impl Whiteboard {
+    #[allow(unused)]
     pub fn new(
         id: WhiteboardIdType,
         is_active: bool,
@@ -777,6 +780,7 @@ impl Whiteboard {
         self.is_active
     } // -- end pub fn is_active
 
+    #[allow(unused)]
     pub fn root_canvas(&self) -> &CanvasIdType {
         &self.root_canvas
     } // -- end pub fn root_canvas
@@ -866,16 +870,13 @@ impl Whiteboard {
         }
     }// -- end pub fn pop_edit_by_author
 
+    #[allow(unused)]
     pub fn clear_edits_by_author(&mut self, author_id: &UserIdType) {
         self.edit_history_by_author.remove(author_id);
     }// -- end pub fn clear_edits_by_author
 
     pub fn can_apply_edit(&self, edit: &Edit) -> bool {
         use EditKind::*;
-
-        // -- Tolerance for difference between two f64 values, below which they will be treated as
-        // equal
-        const F64_MIN_DIFF : f64 = 1.0e-4;
 
         match &edit.edit {
             CreateCanvasObjects{ .. } => true, // -- always vacuously true
@@ -1210,6 +1211,7 @@ impl CanvasMongoDBView {
     } // -- end pub fn from_canvas
 }
 
+#[allow(unused)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum UserPermissionEnum {
@@ -1218,6 +1220,7 @@ pub enum UserPermissionEnum {
     View,
 }
 
+#[allow(unused)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum UserPermission {
@@ -1699,6 +1702,7 @@ impl Edit {
 // socket server to apply/reverse each edit.
 //
 // =================================================================================================
+#[allow(unused)]
 #[serde_as]
 #[derive(Debug,Clone,Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1711,6 +1715,7 @@ pub struct EditClientView {
 }// -- end pub struct Edit
 
 impl EditClientView {
+    #[allow(unused)]
     pub fn from_edit(edit: &Edit) -> Self {
         use super::utils::dt_chrono_utc_to_bson;
 
@@ -1937,6 +1942,7 @@ impl EditMongoDBView {
 // ================================================================================================
 pub type NotificationIdType = ObjectId;
 
+#[allow(unused)]
 #[derive(Clone, Debug)]
 pub enum NotificationKind {
     RequestCanvasEditPermission {
@@ -1946,6 +1952,7 @@ pub enum NotificationKind {
     },
 }// -- end pub enum NotificationKind
 
+#[allow(unused)]
 #[derive(Clone, Debug)]
 pub struct Notification {
     pub id: NotificationIdType,
@@ -1982,6 +1989,7 @@ pub enum NotificationKindMongoDBView {
 }// -- end pub struct NotificationKindMongoDBView
 
 impl NotificationKindMongoDBView {
+    #[allow(unused)]
     pub fn from_notification_kind(nk: &NotificationKind) -> Self {
         use NotificationKind::*;
 
@@ -1998,6 +2006,7 @@ impl NotificationKindMongoDBView {
         }// -- end match nk
     }// -- end fn from_notification_kind
 
+    #[allow(unused)]
     pub fn to_notification_kind(&self) -> NotificationKind {
         use NotificationKind::*;
 
@@ -2028,6 +2037,7 @@ pub struct NotificationMongoDBView {
 }// -- end pub struct NotificationMongoDBView
 
 impl NotificationMongoDBView {
+    #[allow(unused)]
     pub fn from_notification(nt: &Notification) -> Self {
         use super::utils::dt_chrono_utc_to_bson;
 
@@ -2040,6 +2050,7 @@ impl NotificationMongoDBView {
         }
     }// -- end pub fn from_notification
 
+    #[allow(unused)]
     pub fn to_notification(&self) -> Notification {
         use super::utils::dt_bson_to_chrono_utc;
 
@@ -2072,6 +2083,7 @@ pub enum NotificationKindClientView {
 }// -- end pub struct NotificationKindClientView
 
 impl NotificationKindClientView {
+    #[allow(unused)]
     pub fn from_notification_kind(nk: &NotificationKind) -> Self {
         use NotificationKind::*;
 
@@ -2088,6 +2100,7 @@ impl NotificationKindClientView {
         }// -- end match nk
     }// -- end fn from_notification_kind
 
+    #[allow(unused)]
     pub fn to_notification_kind(&self) -> NotificationKind {
         use NotificationKind::*;
 
@@ -2118,6 +2131,7 @@ pub struct NotificationClientView {
 }// -- end pub struct NotificationClientView
 
 impl NotificationClientView {
+    #[allow(unused)]
     pub fn from_notification(nt: &Notification) -> Self {
         use super::utils::dt_chrono_utc_to_bson;
 

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -39,6 +39,7 @@ pub enum ClientError {
     // -- client's auth token is somehow malformed
     InvalidAuth,
     // -- client's auth token has expired
+    #[allow(unused)]
     AuthTokenExpired,
     // -- Client attempted to sign in as or access user that doesn't exist
     UserNotFound {
@@ -115,6 +116,7 @@ pub enum ServerSocketIndividualMessage {
     Confirm {
         message: String,
     },
+    #[allow(unused)]
     Notify {
         notification: NotificationClientView,
     },
@@ -214,6 +216,7 @@ pub enum ServerSocketBroadcastMessage {
         canvas_id: CanvasIdType,
     },
     DeleteWhiteboard,
+    #[allow(unused)]
     Error {
         error: ClientError,
     },

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -159,6 +159,7 @@ struct ClientMessageInspector {
 pub struct ClientMessageResponse {
     // -- Messages to send back to the client(s)
     pub messages: Vec<ServerSocketMessage>,
+    #[allow(unused)]
     pub notifications: Vec<Notification>,
 }// -- end pub struct ClientMessageResponse
 
@@ -1064,7 +1065,7 @@ pub async fn handle_unauthenticated_client_message<
                             .permission_for_user(&user_id.clone())
                     };
 
-                    if let Some(permission) = permission {
+                    if let Some(_) = permission {
                         // User has a valid permission
                         let user_summary = UserSummary {
                             client_id: client_state.client_id.clone(),

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -1172,7 +1172,7 @@ pub async fn handle_unauthenticated_client_message<
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::wss::{self, db, models, protocol, server, store, collections, utils};
+    use crate::{db, models, protocol, server, store, collections, utils};
     use models::*;
     use std::collections::HashMap;
 
@@ -1698,7 +1698,7 @@ mod unit_tests {
     async fn fetch_whiteboard_from_mongodb() {
         // -- try fetching Project Alpha and its constituent components (see
         // TestDatabase/init-db.js for document definitions)
-        use crate::bson::oid::ObjectId;
+        use mongodb::bson::oid::ObjectId;
         use chrono::{MappedLocalTime, TimeZone, Utc};
         use db::{connect_mongodb, get_whiteboard_by_id};
 
@@ -1826,7 +1826,7 @@ mod unit_tests {
         use sha2::Sha256;
         use std::sync::Arc;
         use utils::generate_unique_client_id;
-        use wss::jwt::JWTClaims;
+        use crate::jwt::JWTClaims;
 
         let jwt_secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
         let target_uid_s = "68d5e8d4829da666aece5f48";
@@ -2877,7 +2877,7 @@ mod unit_tests {
     async fn fetch_canvas_with_no_objects() {
         // -- try fetching Project Alpha and its constituent components (see
         // TestDatabase/init-db.js for document definitions)
-        use crate::bson::oid::ObjectId;
+        use mongodb::bson::oid::ObjectId;
         use db::{connect_mongodb, get_whiteboard_by_id};
 
         // -- initialize database connection


### PR DESCRIPTION
Simplified the web socket server build process by removing the stage which used cargo chef to build the dependencies before compiling the final programs. In many use cases cargo chef helps speed up build times, but in our case it turned out to be unnecessary, and actually slows down the build process in some cases. At the same time, I implemented better caching of dependency builds, which has a more tangible effect on build times.

Github Actions will take a while building and testing this one the first time it runs because the older caches will be thrown out, but after that it should build more quickly.

- **Bumped rust version from 1.95 to 1.96 in WebSocketServer Dockerfile.**
- **Implemented a simplified build process in the web socket server Dockerfile which builds dependencies without cargo chef; caching ensures that prebuilt dependencies are reused between builds. The new build process also makes use of bind mounts instead of copying all source files into the build images.**
- **Removed unused code and added #![allow(unused)] directives to unused functions in the web socket server library, in order to satisfy the compiler's linter.**
