### PR TITLE
Refactor/whiteboard card buttons

### DIFF
--- a/Frontend/src/components/RenameWhiteboardForm.tsx
+++ b/Frontend/src/components/RenameWhiteboardForm.tsx
@@ -1,0 +1,89 @@
+// -- std imports
+import {
+  useState,
+  useCallback,
+} from 'react';
+
+// -- local imports
+import {
+  type ButtonStatus,
+  Button,
+} from '@/components/ui/button';
+
+import {
+  Input,
+} from '@/components/ui/input';
+
+export interface RenameWhiteboardFormProps {
+  currentName: string;
+  onSubmit: (newName: string) => Promise<unknown>;
+  onCancel: () => unknown;
+}
+
+export const RenameWhiteboardForm = ({
+  currentName,
+  onSubmit,
+  onCancel,
+}: RenameWhiteboardFormProps): React.JSX.Element => {
+  const [newName, setNewName] = useState<string>(currentName);
+  const [renameButtonStatus, setRenameButtonStatus] = useState<ButtonStatus>('enabled');
+
+  const handleNewNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      e.preventDefault();
+
+      setNewName(e.currentTarget.value);
+    },
+    [setNewName]
+  );// -- end handleNewNameChange
+
+  const handleSubmit = useCallback(
+    (ev: React.FormEvent<HTMLFormElement>) => {
+      ev.preventDefault();
+
+      setRenameButtonStatus('pending');
+
+      onSubmit(newName)
+        .finally(() => {
+          setRenameButtonStatus('enabled');
+        });
+    },
+    [onSubmit, newName, setRenameButtonStatus]
+  );// -- end handleSubmit
+
+  // -- derived state
+  const trimmedName = newName.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedName !== currentName;
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <h1 className="text-lg font-semibold">Rename "{currentName}"</h1>
+        <div className="flex flex-row justify-center pt-2 gap-2">
+          <Input
+            type="text"
+            name="newName"
+            placeholder="New whiteboard name"
+            value={newName}
+            onChange={handleNewNameChange}
+            autoFocus
+          />
+          <Button
+            disabled={!canSubmit}
+            status={renameButtonStatus}
+            type="submit"
+          >
+            Rename
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};// -- end RenameWhiteboardForm

--- a/Frontend/src/components/WhiteboardCard.tsx
+++ b/Frontend/src/components/WhiteboardCard.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   useCallback,
   useState,
+  useMemo,
 } from 'react';
 
 import {
@@ -34,7 +35,13 @@ import {
 
 import {
   type UserPermissionEnum,
+  type UserPermissionByUser,
+  type UserPermissionByEmail,
 } from '@/types/UserPermission';
+
+import {
+  type UserIdType,
+} from '@/types/WebSocketProtocol';
 
 import AuthContext from '@/context/AuthContext';
 
@@ -132,6 +139,25 @@ function WhiteboardCard({
     ? userPermissions
     : userPermissions.slice(0, WB_CARD_COLLABORATORS_DISPLAY_LIMIT);
   const hiddenCount = Math.max(0, userPermissions.length - WB_CARD_COLLABORATORS_DISPLAY_LIMIT);
+
+  // -- split permissions into the by-user-id / by-email structure the share form expects
+  const initPermissionsByUserId = useMemo<Record<UserIdType, UserPermissionByUser>>(
+    () => Object.fromEntries(
+      userPermissions
+        .filter((perm): perm is UserPermissionByUser => perm.type === 'user')
+        .map(perm => [perm.user.id, perm])
+    ),
+    [userPermissions]
+  );
+
+  const initPermissionsByEmail = useMemo<Record<string, UserPermissionByEmail>>(
+    () => Object.fromEntries(
+      userPermissions
+        .filter((perm): perm is UserPermissionByEmail => perm.type === 'email')
+        .map(perm => [perm.email, perm])
+    ),
+    [userPermissions]
+  );
 
   // -- miscellaneous callback functions
   const handleSubmitDeleteWhiteboard = useCallback(
@@ -460,7 +486,9 @@ function WhiteboardCard({
           </div>
 
           <ShareWhiteboardForm
-            initUserPermissions={userPermissions}
+            isActive={true}
+            initPermissionsByUserId={initPermissionsByUserId}
+            initPermissionsByEmail={initPermissionsByEmail}
             onSubmit={handleSubmitShareWhiteboard}
           />
         </div>

--- a/Frontend/src/components/WhiteboardCard.tsx
+++ b/Frontend/src/components/WhiteboardCard.tsx
@@ -23,7 +23,7 @@ import {
   toast,
 } from 'react-toastify';
 
-import { FilePen, Share, Trash2 } from 'lucide-react';
+import { FilePen, Share, Trash2, X } from 'lucide-react';
 
 // -- local imports
 import api from '@/api/axios';
@@ -50,6 +50,14 @@ import {
 import {
   DeleteWhiteboardForm,
 } from '@/components/DeleteWhiteboardForm';
+
+import {
+  RenameWhiteboardForm,
+} from '@/components/RenameWhiteboardForm';
+
+import ShareWhiteboardForm, {
+  type ShareWhiteboardFormData,
+} from '@/components/ShareWhiteboardForm';
 
 import {
   Button,
@@ -166,6 +174,128 @@ function WhiteboardCard({
     },
     [id, queryClient, user.id]
   );// -- end handleSubmitDeleteWhiteboard
+
+  const handleSubmitRenameWhiteboard = useCallback(
+    async (newName: string) => {
+      try {
+        await api.put(`/whiteboards/${id}/newName`, ({
+          newName,
+        }));
+
+        // make sure list of own whiteboards is refreshed
+        queryClient.invalidateQueries({
+          queryKey: [user.id, 'dashboard', 'whiteboards', 'own'],
+        });
+
+        toast.success('Whiteboard renamed successfully', {
+          position: "bottom-center",
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+          theme: "colored",
+          transition: Bounce,
+        });
+
+        closeRenameModal();
+      } catch (err: unknown) {
+        const e = err as AxiosError<{ message?: string; }>;
+
+        console.error(`FAILED TO RENAME WHITEBOARD (${e.code}): ${JSON.stringify(e.response, null, 2)}`);
+        toast.error(`Error renaming whiteboard: ${e.response?.data?.message ?? e.message}`, {
+          position: "bottom-center",
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+          theme: "colored",
+          transition: Bounce,
+        });
+      }
+    },
+    [id, queryClient, user.id, closeRenameModal]
+  );// -- end handleSubmitRenameWhiteboard
+
+  const handleSubmitShareWhiteboard = useCallback(
+    async (data: ShareWhiteboardFormData) => {
+      try {
+        const {
+          userPermissions: updatedPermissions,
+        } = data;
+
+        const userPermissionsFinal = updatedPermissions.map(perm => {
+          if (perm.type === 'user' && (typeof perm.user) === 'object') {
+            // extract object id
+            return ({
+              ...perm,
+              user: perm.user.id,
+            });
+          }
+
+          return perm;
+        });
+
+        // -- make sure we have at least one owner
+        if (! userPermissionsFinal.find(perm => perm.permission === 'own')) {
+          toast.error('Whiteboard must have at least one owner.', {
+            position: "bottom-center",
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+            progress: undefined,
+            theme: "colored",
+            transition: Bounce,
+          });
+
+          return;
+        }
+
+        await api.post(`/whiteboards/${id}/user_permissions`, ({
+          userPermissions: userPermissionsFinal,
+        }));
+
+        toast.success('User permissions updated successfully', {
+          position: "bottom-center",
+          autoClose: 5000,
+          hideProgressBar: false,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+          theme: "colored",
+          transition: Bounce,
+        });
+
+        // make sure list of own whiteboards is refreshed
+        queryClient.invalidateQueries({
+          queryKey: [user.id, 'dashboard', 'whiteboards', 'own'],
+        });
+
+        closeShareModal();
+      } catch (err: unknown) {
+        const e = err as AxiosError<{ error?: string; }>;
+
+        console.error('POST /whiteboards/:id/user_permissions failed:', e);
+        toast.error(`Share request failed: ${e.response?.data?.error ?? e.message}`, {
+          position: "bottom-center",
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+          theme: "colored",
+          transition: Bounce,
+        });
+
+        // -- propagate error to caller so the form can reset its button state
+        throw err;
+      }
+    },
+    [id, queryClient, user.id, closeShareModal]
+  );// -- end handleSubmitShareWhiteboard
 
   const isOwnWhiteboard = userPermissions.find(
     perm => (
@@ -306,9 +436,35 @@ function WhiteboardCard({
       </div>
 
       {/** Modal that opens to rename the whiteboard **/}
-      
+      <RenameModal
+        zIndex={20}
+        className="p-8 rounded-sm"
+      >
+        <RenameWhiteboardForm
+          currentName={name}
+          onCancel={closeRenameModal}
+          onSubmit={handleSubmitRenameWhiteboard}
+        />
+      </RenameModal>
+
       {/** Modal that opens to share the whiteboard **/}
-      
+      <ShareModal zIndex={20}>
+        <div className="flex flex-col">
+          <div className="flex flex-row justify-end">
+            <button
+              onClick={closeShareModal}
+              className="hover:cursor-pointer"
+            >
+              <X />
+            </button>
+          </div>
+
+          <ShareWhiteboardForm
+            initUserPermissions={userPermissions}
+            onSubmit={handleSubmitShareWhiteboard}
+          />
+        </div>
+      </ShareModal>
 
       {/** Modal for whiteboard deletion form **/}
       <DeletionModal

--- a/Frontend/src/components/WhiteboardCard.tsx
+++ b/Frontend/src/components/WhiteboardCard.tsx
@@ -23,7 +23,7 @@ import {
   toast,
 } from 'react-toastify';
 
-import { Trash2 } from 'lucide-react';
+import { FilePen, Share, Trash2 } from 'lucide-react';
 
 // -- local imports
 import api from '@/api/axios';
@@ -102,6 +102,18 @@ function WhiteboardCard({
 
   const [expanded, setExpanded] = useState(false);
 
+  const {
+    Modal: RenameModal,
+    openModal: openRenameModal,
+    closeModal: closeRenameModal,
+  } = useModal();
+
+  const {
+    Modal: ShareModal,
+    openModal: openShareModal,
+    closeModal: closeShareModal
+  } = useModal();
+  
   const {
     Modal: DeletionModal,
     openModal: openDeletionModal,
@@ -187,8 +199,13 @@ function WhiteboardCard({
             src={thumbnail_url || "/images/testThumbnail.png"}
             alt="Whiteboard Thumbnail"
           />
-          <div className="px-2 pt-2 pb-1">
-            <h1 className="text-md text-h2-text font-bold truncate" title={name}>{name}</h1>
+          <div className="px-5 py-3 bg-page-background border-b">
+            <h1 
+              className="text-md text-h2-text font-bold truncate" 
+              title={name}
+            >
+              {name}
+            </h1>
           </div>
         </Link>
 
@@ -250,23 +267,48 @@ function WhiteboardCard({
           </div>
         </div>
 
-        {
-          /** If this is whiteboard is owned by the user, give them the option
-           * to delete it. **/
-          (variant.name === 'own_whiteboard')
-            && (
-              <div className='flex justify-end p-1'>
-                <Button
-                  className='bg-transparent text-destructive'
-                  onClick={openDeletionModal}
-                >
-                  <Trash2 />
-                </Button>
-              </div>
+        
+        <div className='flex justify-center bg-page-background m-2 mt-0 rounded-lg gap-16'>
+          {
+            /** Only owners and editors can edit the whiteboard name **/
+            (variant.name === 'own_whiteboard') && (
+              <Button
+                className='bg-transparent'
+                onClick={openRenameModal}
+                title="Rename whiteboard"
+              >
+                <FilePen />
+              </Button>
+            )
+          }
+          {/* All user permissions can share the whiteboards */}
+          <Button
+            className='bg-transparent'
+            onClick={openShareModal}
+            title="Share whiteboard"
+          >
+            <Share />
+          </Button>
+          {
+            /** Only owners of the whiteboard can delete it **/
+            (variant.name === 'own_whiteboard') && (
+              <Button
+                className='bg-transparent text-destructive'
+                onClick={openDeletionModal}
+                title="Delete whiteboard"
+              >
+                <Trash2 />
+              </Button>
             )
             || null
-        }
+          }
+        </div>
       </div>
+
+      {/** Modal that opens to rename the whiteboard **/}
+      
+      {/** Modal that opens to share the whiteboard **/}
+      
 
       {/** Modal for whiteboard deletion form **/}
       <DeletionModal

--- a/Frontend/src/components/WhiteboardCard.tsx
+++ b/Frontend/src/components/WhiteboardCard.tsx
@@ -23,6 +23,8 @@ import {
   toast,
 } from 'react-toastify';
 
+import { Trash2 } from 'lucide-react';
+
 // -- local imports
 import api from '@/api/axios';
 
@@ -253,12 +255,14 @@ function WhiteboardCard({
            * to delete it. **/
           (variant.name === 'own_whiteboard')
             && (
-              <Button
-                variant="destructive"
-                onClick={openDeletionModal}
-              >
-                Delete
-              </Button>
+              <div className='flex justify-end p-1'>
+                <Button
+                  className='bg-transparent text-destructive'
+                  onClick={openDeletionModal}
+                >
+                  <Trash2 />
+                </Button>
+              </div>
             )
             || null
         }


### PR DESCRIPTION
Whiteboard cards on the dashboard now have icon buttons at the bottom of them for renaming, sharing, and deleting the whiteboard. The previously implemented modal convention is used for the handler forms. Some other minor styling updates are made to the cards as well.