### PR TITLE
Feat/sort whiteboards

### DIFF
--- a/Frontend/src/components/ui/dropdown-menu.tsx
+++ b/Frontend/src/components/ui/dropdown-menu.tsx
@@ -126,7 +126,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:cursor-pointer focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -57,7 +57,14 @@ import CreateWhiteboardModal, {
 } from '@/components/CreateWhiteboardModal';
 import WhiteboardList from '@/components/WhiteboardList';
 import Footer from '@/components/Footer';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { ArrowUpDown } from 'lucide-react';
 

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@
 import {
   useCallback,
   useState,
+  useMemo,
 } from 'react';
 
 import {
@@ -183,17 +184,24 @@ const Dashboard = (): React.JSX.Element => {
     [navigate, location]
   );// -- end handleCreateWhiteboard
 
-  const handleSearchChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(ev.target.value);
-  };
+  const handleSearchChange = useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchQuery(ev.target.value);
+    },
+    []
+  );// -- end handleSearchChange
 
   // -- case-insensitive match of the search query against a whiteboard's name
-  const normalizedQuery = searchQuery.trim().toLowerCase();
-  const matchesSearch = (whiteboard: Whiteboard): boolean =>
-    whiteboard.name.toLowerCase().includes(normalizedQuery);
+  const normalizedQuery = useMemo(
+    () => searchQuery.trim().toLowerCase(),
+    [searchQuery]
+  );
 
   // -- redirect to login on 403 (forbidden)
-  const locationEncoded : string = encodeURIComponent(`${location.pathname}${location.search}`);
+  const locationEncoded : string = useMemo(
+    () => encodeURIComponent(`${location.pathname}${location.search}`),
+    [location.pathname, location.search]
+  );
 
   if (ownWhiteboardsError && ownWhiteboardsError.status === 403) {
     navigate(`/login?redirect=${locationEncoded}`);
@@ -224,37 +232,68 @@ const Dashboard = (): React.JSX.Element => {
   | 'name-z-a'
   ;
 
-  const getCreatedAt = (wb: Whiteboard): number => {
-    const raw = wb.kind === 'temp_whiteboard' ? wb.createdAt : wb.time_created;
-    return new Date(raw).getTime();
-  };
+  const sortWhiteboards = useCallback(
+    (whiteboards: Whiteboard[], sortBy: SortOption,): Whiteboard[] => {
+      const getCreatedAt = (wb: Whiteboard): number => {
+        const raw = wb.kind === 'temp_whiteboard' ? wb.createdAt : wb.time_created;
+        return new Date(raw).getTime();
+      };
 
-  // -- last-modified time, falling back to creation date for whiteboards that
-  // predate the time_last_modified field.
-  const getLastModified = (wb: Whiteboard): number =>
-    wb.time_last_modified
-      ? new Date(wb.time_last_modified).getTime()
-      : getCreatedAt(wb);
+      // -- last-modified time, falling back to creation date for whiteboards that
+      // predate the time_last_modified field.
+      const getLastModified = (wb: Whiteboard): number =>
+          wb.time_last_modified
+            ? new Date(wb.time_last_modified).getTime()
+            : getCreatedAt(wb);
+      const sorted = [...whiteboards];
 
-  const sortWhiteboards = (
-    whiteboards: Whiteboard[],
-    sortBy: SortOption,
-  ): Whiteboard[] => {
-    const sorted = [...whiteboards];
-    switch (sortBy) {
-      case 'modified-new': return sorted.sort((a, b) => getLastModified(b) - getLastModified(a));
-      case 'modified-old': return sorted.sort((a, b) => getLastModified(a) - getLastModified(b));
-      case 'date-new': return sorted.sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
-      case 'date-old': return sorted.sort((a, b) => getCreatedAt(a) - getCreatedAt(b));
-      case 'name-a-z': return sorted.sort((a, b) => a.name.localeCompare(b.name));
-      case 'name-z-a': return sorted.sort((a, b) => b.name.localeCompare(a.name));
-    }
-  };
+      switch (sortBy) {
+        case 'modified-new': return sorted.sort((a, b) => getLastModified(b) - getLastModified(a));
+        case 'modified-old': return sorted.sort((a, b) => getLastModified(a) - getLastModified(b));
+        case 'date-new': return sorted.sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
+        case 'date-old': return sorted.sort((a, b) => getCreatedAt(a) - getCreatedAt(b));
+        case 'name-a-z': return sorted.sort((a, b) => a.name.localeCompare(b.name));
+        case 'name-z-a': return sorted.sort((a, b) => b.name.localeCompare(a.name));
+      }
+    },
+    []
+  );// -- end sortWhiteboards
 
-  const filteredOwnWhiteboards = 
-    ownWhiteboards && sortWhiteboards(ownWhiteboards.filter(matchesSearch), sortBy);
-  const filteredSharedWhiteboards = 
-    sharedWhiteboards && sortWhiteboards(sharedWhiteboards.filter(matchesSearch), sortBy);
+  const matchesSearch = useCallback(
+    (whiteboard: Whiteboard, normalizedQuery: string): boolean =>
+      whiteboard.name.toLowerCase().includes(normalizedQuery),
+    []
+  );// -- end matchesSearch
+
+  const filteredOwnWhiteboards = useMemo(
+    () => {
+      if (! ownWhiteboards) {
+        return [];
+      } else {
+        const filteredWhiteboards = ownWhiteboards.filter(
+          (wb) => matchesSearch(wb, normalizedQuery)
+        );
+
+        return sortWhiteboards(filteredWhiteboards, sortBy);
+      }
+    },
+    [ownWhiteboards, normalizedQuery, sortBy, matchesSearch, sortWhiteboards]
+  );
+
+  const filteredSharedWhiteboards = useMemo(
+    () => {
+      if (! sharedWhiteboards) {
+        return [];
+      } else {
+        const filteredWhiteboards = sharedWhiteboards.filter(
+          (wb) => matchesSearch(wb, normalizedQuery)
+        );
+
+        return sortWhiteboards(filteredWhiteboards, sortBy);
+      }
+    },
+    [sharedWhiteboards, normalizedQuery, sortBy, matchesSearch, sortWhiteboards]
+  );
 
   return (
     <Page
@@ -335,7 +374,7 @@ const Dashboard = (): React.JSX.Element => {
                   return (
                     <WhiteboardList
                       status="ready"
-                      whiteboardsAttribs={filteredOwnWhiteboards || []}
+                      whiteboardsAttribs={filteredOwnWhiteboards}
                     />
                   );
                 }
@@ -362,7 +401,7 @@ const Dashboard = (): React.JSX.Element => {
                   return (
                     <WhiteboardList
                       status="ready"
-                      whiteboardsAttribs={filteredSharedWhiteboards || []}
+                      whiteboardsAttribs={filteredSharedWhiteboards}
                     />
                   );
                 }

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -332,32 +332,32 @@ const Dashboard = (): React.JSX.Element => {
             />
             
             <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="icon"
-                aria-label="Sort whiteboards"
-                title="Sort whiteboards"
-                className="size-10"
-              >
-                <ArrowUpDown className="size-6" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuLabel>Sort by:</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={sortBy}
-                onValueChange={(value) => setSortBy(value as SortOption)}
-              >
-                <DropdownMenuRadioItem value="modified-new">Modified (recent first)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="modified-old">Modified (oldest first)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="date-new">Created (newest first)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="date-old">Created (oldest first)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="name-a-z">Name (A to Z)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="name-z-a">Name (Z to A)</DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  aria-label="Sort whiteboards"
+                  title="Sort whiteboards"
+                  className="size-10"
+                >
+                  <ArrowUpDown className="size-6" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel>Sort by:</DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                  value={sortBy}
+                  onValueChange={(value) => setSortBy(value as SortOption)}
+                >
+                  <DropdownMenuRadioItem value="modified-new">Modified (recent first)</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="modified-old">Modified (oldest first)</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="date-new">Created (newest first)</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="date-old">Created (oldest first)</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="name-a-z">Name (A to Z)</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="name-z-a">Name (Z to A)</DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
 

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -56,18 +56,23 @@ import CreateWhiteboardModal, {
 } from '@/components/CreateWhiteboardModal';
 import WhiteboardList from '@/components/WhiteboardList';
 import Footer from '@/components/Footer';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { ArrowUpDown } from 'lucide-react';
 
 const Dashboard = (): React.JSX.Element => {
   const navigate = useNavigate();
   const location = useLocation();
   const pageTitle = `Your Dashboard | ${APP_NAME}`;
   const user: User | null = useUser().user;
+  const DEFAULT_SORT: SortOption = 'date-new';
 
   if (! user) {
     throw new Error('Dashboard page needs authenticated user');
   }
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<SortOption>(DEFAULT_SORT);
 
   const {
     error: ownWhiteboardsError,
@@ -187,9 +192,6 @@ const Dashboard = (): React.JSX.Element => {
   const matchesSearch = (whiteboard: Whiteboard): boolean =>
     whiteboard.name.toLowerCase().includes(normalizedQuery);
 
-  const filteredOwnWhiteboards = ownWhiteboards?.filter(matchesSearch);
-  const filteredSharedWhiteboards = sharedWhiteboards?.filter(matchesSearch);
-
   // -- redirect to login on 403 (forbidden)
   const locationEncoded : string = encodeURIComponent(`${location.pathname}${location.search}`);
 
@@ -213,6 +215,36 @@ const Dashboard = (): React.JSX.Element => {
     }
   }
 
+  type SortOption = 
+    | 'name-a-z'
+    | 'name-z-a'
+    | 'date-new'
+    | 'date-old'
+  ;
+
+  const getCreatedAt = (wb: Whiteboard): number => {
+    const raw = wb.kind === 'temp_whiteboard' ? wb.createdAt : wb.time_created;
+    return new Date(raw).getTime();
+  };
+
+  const sortWhiteboards = (
+    whiteboards: Whiteboard[],
+    sortBy: SortOption,
+  ): Whiteboard[] => {
+    const sorted = [...whiteboards];
+    switch (sortBy) {
+      case 'name-a-z': return sorted.sort((a, b) => a.name.localeCompare(b.name));
+      case 'name-z-a': return sorted.sort((a, b) => b.name.localeCompare(a.name));
+      case 'date-new': return sorted.sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
+      case 'date-old': return sorted.sort((a, b) => getCreatedAt(a) - getCreatedAt(b));
+    }
+  };
+
+  const filteredOwnWhiteboards = 
+    ownWhiteboards && sortWhiteboards(ownWhiteboards.filter(matchesSearch), sortBy);
+  const filteredSharedWhiteboards = 
+    sharedWhiteboards && sortWhiteboards(sharedWhiteboards.filter(matchesSearch), sortBy);
+
   return (
     <Page
       title={pageTitle}
@@ -231,18 +263,43 @@ const Dashboard = (): React.JSX.Element => {
           <h1 className="col-span-2 text-2xl lg:text-4xl text-h1-text order-1 lg:order-2 text-center truncate">
             Welcome Back, {user.username}!
           </h1>
-          <div className="col-span-1 flex flex-nowrap order-3 flex justify-center sm:justify-end">
+          <div className="col-span-1 flex flex-nowrap order-3 flex justify-center items-center sm:justify-end gap-4">
             <label htmlFor="search" className='hidden'>Search</label>
             <input
               name='search'
-              className='text-nowrap px-4 border rounded-lg'
+              className='text-nowrap px-4 py-2 border rounded-lg'
               value={searchQuery}
               type='text'
               placeholder='Search for whiteboard'
               onChange={handleSearchChange}
             />
-            {/* TODO: This is just a placeholder for now, need to implement sort features */}
-            <button className='text-nowrap hidden'>Sort me</button>
+            
+            <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Sort whiteboards"
+                title="Sort whiteboards"
+                className="size-10"
+              >
+                <ArrowUpDown className="size-6" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>Sort by:</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={sortBy}
+                onValueChange={(value) => setSortBy(value as SortOption)}
+              >
+                <DropdownMenuRadioItem value="name-a-z">Name (A to Z)</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="name-z-a">Name (Z to A)</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="date-new">Date (newest first)</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="date-old">Date (oldest first)</DropdownMenuRadioItem>
+                {/* TODO: need to implement modified times for whiteboards */}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
           </div>
         </div>
 

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -65,7 +65,7 @@ const Dashboard = (): React.JSX.Element => {
   const location = useLocation();
   const pageTitle = `Your Dashboard | ${APP_NAME}`;
   const user: User | null = useUser().user;
-  const DEFAULT_SORT: SortOption = 'date-new';
+  const DEFAULT_SORT: SortOption = 'modified-new';
 
   if (! user) {
     throw new Error('Dashboard page needs authenticated user');
@@ -215,11 +215,13 @@ const Dashboard = (): React.JSX.Element => {
     }
   }
 
-  type SortOption = 
-    | 'name-a-z'
-    | 'name-z-a'
-    | 'date-new'
-    | 'date-old'
+  type SortOption =
+  | 'modified-new'
+  | 'modified-old'
+  | 'date-new'
+  | 'date-old'
+  | 'name-a-z'
+  | 'name-z-a'
   ;
 
   const getCreatedAt = (wb: Whiteboard): number => {
@@ -227,16 +229,25 @@ const Dashboard = (): React.JSX.Element => {
     return new Date(raw).getTime();
   };
 
+  // -- last-modified time, falling back to creation date for whiteboards that
+  // predate the time_last_modified field.
+  const getLastModified = (wb: Whiteboard): number =>
+    wb.time_last_modified
+      ? new Date(wb.time_last_modified).getTime()
+      : getCreatedAt(wb);
+
   const sortWhiteboards = (
     whiteboards: Whiteboard[],
     sortBy: SortOption,
   ): Whiteboard[] => {
     const sorted = [...whiteboards];
     switch (sortBy) {
-      case 'name-a-z': return sorted.sort((a, b) => a.name.localeCompare(b.name));
-      case 'name-z-a': return sorted.sort((a, b) => b.name.localeCompare(a.name));
+      case 'modified-new': return sorted.sort((a, b) => getLastModified(b) - getLastModified(a));
+      case 'modified-old': return sorted.sort((a, b) => getLastModified(a) - getLastModified(b));
       case 'date-new': return sorted.sort((a, b) => getCreatedAt(b) - getCreatedAt(a));
       case 'date-old': return sorted.sort((a, b) => getCreatedAt(a) - getCreatedAt(b));
+      case 'name-a-z': return sorted.sort((a, b) => a.name.localeCompare(b.name));
+      case 'name-z-a': return sorted.sort((a, b) => b.name.localeCompare(a.name));
     }
   };
 
@@ -292,11 +303,12 @@ const Dashboard = (): React.JSX.Element => {
                 value={sortBy}
                 onValueChange={(value) => setSortBy(value as SortOption)}
               >
+                <DropdownMenuRadioItem value="modified-new">Modified (recent first)</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="modified-old">Modified (oldest first)</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="date-new">Created (newest first)</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="date-old">Created (oldest first)</DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="name-a-z">Name (A to Z)</DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="name-z-a">Name (Z to A)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="date-new">Date (newest first)</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="date-old">Date (oldest first)</DropdownMenuRadioItem>
-                {/* TODO: need to implement modified times for whiteboards */}
               </DropdownMenuRadioGroup>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/Frontend/src/types/APIProtocol.ts
+++ b/Frontend/src/types/APIProtocol.ts
@@ -63,6 +63,7 @@ interface WhiteboardBase {
   thumbnail_url: string;
   user_permissions: UserPermission[];
   visibility: 'public' | 'private';
+  time_last_modified?: Date;
   canvases?: Canvas[];
 }
 

--- a/RestAPI/src/controllers/whiteboards.ts
+++ b/RestAPI/src/controllers/whiteboards.ts
@@ -294,6 +294,7 @@ export const handleConvertTempToPerm = async (
           name: 'Trial Whiteboard',
           kind: 'permanent_whiteboard',
           time_created: new Date(),
+          time_last_modified: new Date(),
           user_permissions: updatedPermissions,
         },
         $unset: {
@@ -338,6 +339,7 @@ export const handleChangeWhiteboardName = async (
       {
         $set: {
           name: newName,
+          time_last_modified: new Date(),
         }
       }
     );

--- a/RestAPI/src/models/Whiteboard.ts
+++ b/RestAPI/src/models/Whiteboard.ts
@@ -386,6 +386,7 @@ export interface IWhiteboardModel <UserType, CanvasType> {
   thumbnail_url: string;
   kind: WhiteboardTypeEnum;
   visibility: IWhiteboardVisibilityEnum;
+  time_last_modified: Date;
 
   // -- vector fields: exclude from attribute view
   user_permissions: IWhiteboardUserPermission<UserType>[];
@@ -513,7 +514,8 @@ const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>,
     root_canvas: { type: Schema.Types.ObjectId, ref: "Canvas", required: true },
     thumbnail_url: { type: String, required: false, default: null },
     user_permissions: [whiteboardUserPermissionSchema],
-    visibility: { type: String, required: true, default: 'private' }
+    visibility: { type: String, required: true, default: 'private' },
+    time_last_modified: { type: Date, default: Date.now },
   },
   {
     // -- options

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -306,6 +306,7 @@ export const setSharedUsers = async (
     } else {
       // fully replace old permissions
       whiteboard.set('user_permissions', finalPermissions);
+      whiteboard.set('time_last_modified', new Date());
 
       await whiteboard.save()
         .then(wb => wb.populateAttribs());

--- a/WebSocketServer/src/wss/db.rs
+++ b/WebSocketServer/src/wss/db.rs
@@ -727,6 +727,25 @@ impl MongoDBInterface {
         if let Some(edit_view) = EditMongoDBView::from_edit(edit) {
             let _ = self.edit_coll.insert_one(edit_view).await;
         }
+
+        // -- Bump the whiteboard's last-modified time. One write per edit (not
+        // per diff), stamped with the edit's commit time.
+        let bump_modified_res = self.whiteboard_metadata_coll
+            .update_one(
+                doc! { "_id": *edit.whiteboard() },
+                doc! {
+                    "$set": {
+                        "time_last_modified": mongodb::bson::DateTime::from_millis(
+                            edit.committed_at().timestamp_millis()
+                        )
+                    }
+                },
+            )
+            .await;
+
+        if let Err(e) = bump_modified_res {
+            eprintln!("Failed to bump whiteboard time_last_modified: {}", e);
+        }
     }// -- end pub async fn process_edit
 
     // pub async fn save_notification(&self, notif: &Notification) {

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -1525,6 +1525,14 @@ impl Edit {
         &self.id
     }// -- end pub fn id
 
+    pub fn whiteboard(&self) -> &WhiteboardIdType {
+        &self.whiteboard
+    }// -- end pub fn whiteboard
+
+    pub fn committed_at(&self) -> chrono::DateTime<Utc> {
+        self.committed_at
+    }// -- end pub fn committed_at
+
     pub fn generate_server_messages(&self, author_client_id: &ClientIdType) -> Vec<ServerSocketMessage> {
         use EditKind::*;
 

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -1529,8 +1529,8 @@ impl Edit {
         &self.whiteboard
     }// -- end pub fn whiteboard
 
-    pub fn committed_at(&self) -> chrono::DateTime<Utc> {
-        self.committed_at
+    pub fn committed_at(&self) -> &chrono::DateTime<Utc> {
+        &self.committed_at
     }// -- end pub fn committed_at
 
     pub fn generate_server_messages(&self, author_client_id: &ClientIdType) -> Vec<ServerSocketMessage> {

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -802,6 +802,7 @@ impl Whiteboard {
         &self.canvases_to_canvas_objects
     }// -- end pub fn canvases_to_canvas_objects
 
+    #[allow(unused)]
     pub fn canvases_to_canvas_objects_mut(&mut self) -> &mut collections::OneToMany<CanvasIdType, CanvasObjectIdType> {
         &mut self.canvases_to_canvas_objects
     }// -- end pub fn canvases_to_canvas_objects


### PR DESCRIPTION
Whiteboards can now be sorted via the up/down arrow icon on the dashboard by time last modified, time created, and alphabetically. The time_last_modified field is added to the base whiteboard schema, all existing whiteboards are manually assigned their creation time as time_last_modified. 

time_last_modified is updated during the following actions:
- creation of whiteboard (temp and perm)
- conversion from temp to perm whiteboard
- renaming of whiteboard
- modification to shared users
- wss edits to objects on the whiteboard