### PR TITLE
Bugfix: Prevent Duplicate Web Socket Connections When Navigating Between Pages, Update Whiteboard Name On Change

### DIFF
--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -637,6 +637,14 @@ const WebSocketClientMessengerProvider = ({
         ws.onopen = makeHandleWebSocketOpen(ws, wsUri);
         webSocketRef.current = ws;
       }
+
+      // -- Close web socket connection when page closed
+      return () => {
+        if (webSocketRef.current) {
+          webSocketRef.current.close();
+          webSocketRef.current = null;
+        }
+      };
     },
     [makeHandleWebSocketOpen, whiteboardId]
   );

--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -249,6 +249,19 @@ const WebSocketClientMessengerProvider = ({
               });
             }
             break;
+          case 'update_whiteboard_metadata':
+            {
+              const {
+                name,
+              } = msg;
+
+              if (name) {
+                updateWhiteboard(dispatch, whiteboardId, {
+                  name,
+                });
+              }
+            }
+            break;
           case 'editing_canvas':
             {
               const {

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -230,6 +230,11 @@ export interface ServerMessageSetPermissions {
   permissionsByEmail: Record<string, UserPermissionEnum>;
 }
 
+export interface ServerMessageUpdateWhiteboardMetadata {
+  type: 'update_whiteboard_metadata';
+  name?: string;
+}
+
 // Used to notify clients when a user has started editing a canvas but hasn't
 // performed any edits yet (i.e. when they click and drag to start drawing a
 // shape).
@@ -338,6 +343,7 @@ export type SocketServerMessage =
   | ServerMessageLoginUsers
   | ServerMessageLogoutUsers
   | ServerMessageSetPermissions
+  | ServerMessageUpdateWhiteboardMetadata
   | ServerMessageEditingCanvas
   | ServerMessageSelectedCanvasObject
   | ServerMessageUnselectedCanvasObject

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -102,14 +102,22 @@ async fn main() -> process::ExitCode {
 
                             if let Some(wb_entry) = whiteboards.get_mut(&curr_doc.id) {
                                 let mut wb = wb_entry.whiteboard_ref.lock().await;
+                                let mut messages_to_clients = Vec::<ServerSocketMessage>::new();
 
                                 // -- check that permissions have changed
-                                'check_perm_change: {
+                                'check_relevant_change: {
                                     let wb_meta = wb.metadata();
                                     let n_prev_perms = wb_meta.permissions_by_user_id().len()
                                         + wb_meta.permissions_by_email().len();
 
-                                    if n_prev_perms == curr_doc.metadata.user_permissions.len() {
+                                    if wb_meta.name() != curr_doc.metadata.name {
+                                        messages_to_clients.push(ServerSocketMessage::Broadcast {
+                                            msg: ServerSocketBroadcastMessage::UpdateWhiteboardMetadata {
+                                                name: Some(curr_doc.metadata.name.clone()),
+                                            },
+                                        });
+                                        // -- Proceed to metadata update
+                                    } else if n_prev_perms == curr_doc.metadata.user_permissions.len() {
                                         for perm in curr_doc.metadata.user_permissions.iter() {
                                             match &perm.permission_type {
                                                 wss::models::WhiteboardPermissionType::User {
@@ -118,10 +126,10 @@ async fn main() -> process::ExitCode {
                                                 } => {
                                                     if let Some(prev_perm) = wb_meta.permissions_by_user_id().get(&user_id) {
                                                         if *prev_perm != perm.permission {
-                                                            break 'check_perm_change;
+                                                            break 'check_relevant_change;
                                                         }
                                                     } else {
-                                                        break 'check_perm_change;
+                                                        break 'check_relevant_change;
                                                     }
                                                 },
                                                 wss::models::WhiteboardPermissionType::Email {
@@ -129,10 +137,10 @@ async fn main() -> process::ExitCode {
                                                 } => {
                                                     if let Some(prev_perm) = wb_meta.permissions_by_email().get(email.as_str()) {
                                                         if *prev_perm != perm.permission {
-                                                            break 'check_perm_change;
+                                                            break 'check_relevant_change;
                                                         }
                                                     } else {
-                                                        break 'check_perm_change;
+                                                        break 'check_relevant_change;
                                                     }
                                                 },
                                             };// -- end match
@@ -140,12 +148,23 @@ async fn main() -> process::ExitCode {
 
                                         continue 'next_event;
                                     }
-                                }
+                                }// -- end 'check_relevant_change
 
-                                // -- change metadata
+                                // -- change permissions in metadata
                                 wb.set_permissions(curr_doc.metadata.user_permissions.as_slice());
 
                                 let wb_meta = wb.metadata();
+
+                                messages_to_clients.push(ServerSocketMessage::Broadcast {
+                                    msg: ServerSocketBroadcastMessage::SetPermissions {
+                                        permissions_by_user_id: wb_meta.permissions_by_user_id().iter()
+                                            .map(|(uid, perm)| (uid.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm)))
+                                            .collect(),
+                                        permissions_by_email: wb_meta.permissions_by_email().iter()
+                                            .map(|(email, perm)| (email.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm)))
+                                            .collect(),
+                                    },
+                                });
 
                                 // -- evict users whose permissions have been revoked if the
                                 // whiteboard is private
@@ -155,29 +174,18 @@ async fn main() -> process::ExitCode {
                                     // -- evict users whose permissions have been completely removed
                                     for (user_id, client_id) in clients_by_user_id.iter() {
                                         if ! wb_meta.permissions_by_user_id().contains_key(user_id) {
-                                            let _ = wb_entry
-                                                .broadcaster
-                                                .send(ServerSocketMessage::Evict {
-                                                    evicted_client_id: client_id.clone(),
-                                                    reason: String::from("Access revoked"),
-                                                });
+                                            messages_to_clients.push(ServerSocketMessage::Evict {
+                                                evicted_client_id: client_id.clone(),
+                                                reason: String::from("Access revoked"),
+                                            });
                                         }
-                                    }// -- end for
+                                    }// -- end for user_id, client_id
                                 }
 
                                 // -- broadcast updated permissions to clients
-                                let _ = wb_entry
-                                    .broadcaster
-                                    .send(ServerSocketMessage::Broadcast {
-                                        msg: ServerSocketBroadcastMessage::SetPermissions {
-                                            permissions_by_user_id: wb_meta.permissions_by_user_id().iter()
-                                                .map(|(uid, perm)| (uid.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm)))
-                                                .collect(),
-                                            permissions_by_email: wb_meta.permissions_by_email().iter()
-                                                .map(|(email, perm)| (email.clone(), WhiteboardPermissionEnumClientView::from_permission_enum(&perm)))
-                                                .collect(),
-                                        },
-                                    });
+                                while let Some(msg) = messages_to_clients.pop() {
+                                    let _ = wb_entry.broadcaster.send(msg);
+                                }// -- end for msg
                             }
                         }
                     },

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -155,6 +155,10 @@ pub enum ServerSocketBroadcastMessage {
         permissions_by_user_id: HashMap<UserIdType, WhiteboardPermissionEnumClientView>,
         permissions_by_email: HashMap<String, WhiteboardPermissionEnumClientView>,
     },
+    // -- Update one or more fields in the whiteboard metadata
+    UpdateWhiteboardMetadata {
+        name: Option<String>,
+    },
     SelectedCanvasObject {
         #[serde_as(as = "DisplayFromStr")]
         client_id: ClientIdType,


### PR DESCRIPTION
Previously, when updating a whiteboard from temporary to permanent, the new permanent user's previous web socket connection as a temporary user would persist, and the whiteboard's new name wouldn't update for users other than the creator. This PR fixes both problems, and also fixes the more general error of old client connections persisting after a user has navigated off the whiteboard page (but without refreshing or navigating to a different website).

- **Fixed duplicate client connections when user navigates off and back onto a whiteboard by having WebSocketClientMessengerProvider trigger disconnect in useEffect that initializes the web socket connection.**
- **WebSocketServer notifies clients of whiteboard name change; creates protocol message which can be used to update other whiteboard metadata fields if need be.**
