### PR TITLE
Bugfix: Owner Permission on Public Whiteboards

### DIFF
--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -696,9 +696,14 @@ impl WhiteboardMetadata {
 
     pub fn permission_for_user(&self, user_id: &UserIdType) -> Option<WhiteboardPermissionEnum> {
         if self.visibility == WhiteboardVisibilityEnum::Public {
-            return Some(WhiteboardPermissionEnum::Edit);
+            // -- Owners have owner permission, all others have edit permission
+            match self.permissions_by_user_id.get(user_id) {
+                Some(WhiteboardPermissionEnum::Own) => Some(WhiteboardPermissionEnum::Own),
+                _ => Some(WhiteboardPermissionEnum::Edit),
+            }// -- end match self.permissions_by_user_id.get(user_id)
+        } else {
+            self.permissions_by_user_id.get(user_id).copied()
         }
-        self.permissions_by_user_id.get(user_id).copied()
     }
 }
 

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -828,7 +828,9 @@ pub async fn handle_authenticated_client_message<'a>(
 
                     // -- make sure client is either a whiteboard owner or already has edit access
                     // to the canvas
+                    eprintln!("!! CHECKING WHITEBOARD PERMISSIONS");
                     if ! matches!(whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id), Some(WhiteboardPermissionEnum::Own)) {
+                        eprintln!("!! NO OWNER PERMISSION; CHECKING CANVAS PERMISSIONS");
                         let canvas : &Canvas = whiteboard.canvases().get(&canvas_id).unwrap();
 
                         if let Some(curr_allowed_users) = canvas.allowed_users() {

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -828,9 +828,7 @@ pub async fn handle_authenticated_client_message<'a>(
 
                     // -- make sure client is either a whiteboard owner or already has edit access
                     // to the canvas
-                    eprintln!("!! CHECKING WHITEBOARD PERMISSIONS");
                     if ! matches!(whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id), Some(WhiteboardPermissionEnum::Own)) {
-                        eprintln!("!! NO OWNER PERMISSION; CHECKING CANVAS PERMISSIONS");
                         let canvas : &Canvas = whiteboard.canvases().get(&canvas_id).unwrap();
 
                         if let Some(curr_allowed_users) = canvas.allowed_users() {

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -830,7 +830,6 @@ pub async fn handle_authenticated_client_message<'a>(
                     // to the canvas
                     eprintln!("!! CHECKING WHITEBOARD PERMISSIONS");
                     if ! matches!(whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id), Some(WhiteboardPermissionEnum::Own)) {
-                        eprintln!("!! YOUR WHITEBOARD PERMISSION: {:?}", whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id));
                         eprintln!("!! NO OWNER PERMISSION; CHECKING CANVAS PERMISSIONS");
                         let canvas : &Canvas = whiteboard.canvases().get(&canvas_id).unwrap();
 

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -828,7 +828,7 @@ pub async fn handle_authenticated_client_message<'a>(
 
                     // -- make sure client is either a whiteboard owner or already has edit access
                     // to the canvas
-                    if ! matches!(client_state.user_whiteboard_permission, WhiteboardPermissionEnum::Own) {
+                    if ! matches!(whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id), Some(WhiteboardPermissionEnum::Own)) {
                         let canvas : &Canvas = whiteboard.canvases().get(&canvas_id).unwrap();
 
                         if let Some(curr_allowed_users) = canvas.allowed_users() {

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -830,6 +830,7 @@ pub async fn handle_authenticated_client_message<'a>(
                     // to the canvas
                     eprintln!("!! CHECKING WHITEBOARD PERMISSIONS");
                     if ! matches!(whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id), Some(WhiteboardPermissionEnum::Own)) {
+                        eprintln!("!! YOUR WHITEBOARD PERMISSION: {:?}", whiteboard.metadata().permission_for_user(&client_state.user_summary.user_id));
                         eprintln!("!! NO OWNER PERMISSION; CHECKING CANVAS PERMISSIONS");
                         let canvas : &Canvas = whiteboard.canvases().get(&canvas_id).unwrap();
 


### PR DESCRIPTION
Fixed a bug preventing whiteboard owners from being given effective owner permission on their public whiteboards (all users were being given effective editor permission).

- **Updated permission check in UpdateAllowedUsers handler in web socker server so new whiteboard owners can edit any canvas' allowed users list.**
- **Added debug logging to web socket server message handler.**
- **More debug logging in web socket server.**
- **Revert "More debug logging in web socket server."**
- **Revert "Added debug logging to web socket server message handler."**
- **Whiteboard::permission_for_user gives owners effective owner permission, all other users effective edit permission.**
