### PR TITLE
Refactor/thumbnail idor

### DIFF
--- a/Frontend/src/components/CanvasCard.tsx
+++ b/Frontend/src/components/CanvasCard.tsx
@@ -7,19 +7,10 @@ import {
 } from 'react';
 
 import {
-  useLocation,
-  useNavigate,
-} from 'react-router-dom';
-
-import {
   useSelector,
 } from 'react-redux';
 
 import lodash from 'lodash';
-
-import {
-  type AxiosError,
-} from 'axios';
 
 import Konva from 'konva';
 
@@ -88,6 +79,7 @@ import {
 import {
   selectWhiteboardById,
   selectWhiteboardPermissionByUser,
+  selectPermissionsByUserByWhiteboard,
 } from '@/store/whiteboards/whiteboardsSelectors';
 
 import {
@@ -128,9 +120,6 @@ const CanvasCard = ({
   shapeAttributes,
   onSelectCanvasDimensions,
 }: CanvasCardProps) => {
-  const location = useLocation();
-  const navigate = useNavigate();
-
   const userCacheContext = useContext(UserCacheContext);
 
   if (! userCacheContext) {
@@ -235,6 +224,13 @@ const CanvasCard = ({
     lodash.isEqual
   );
 
+  // -- explicit permission only (no effective 'edit' fallback on public whiteboards); 
+  // gates operations restricted to explicit owners/editors, like thumbnail updates
+  const explicitPermission = useSelector(
+    (state: RootState) => selectPermissionsByUserByWhiteboard(state, whiteboardId)?.[user.id] ?? null,
+    lodash.isEqual
+  );
+
   // -- set up interval to broadcast cursor position
   const stageRef = useRef<Konva.Stage | null>(null);
   const cursorPosRef = useRef<{ x: number; y: number; } | null>(null);
@@ -295,6 +291,9 @@ const CanvasCard = ({
   // Set the whiteboard thumbnail
   useEffect(() => {
     const interval = setInterval(async () => {
+      // -- only explicit owners/editors may update the thumbnail
+      if (explicitPermission !== 'own' && explicitPermission !== 'edit') return;
+
       if (!canvasGroupRefsByIdRef.current) return;
 
       const dataUrl = captureImage(
@@ -303,7 +302,7 @@ const CanvasCard = ({
         thumbnailType,
         thumbnailQuality,
       );
-      
+
       if (!dataUrl) return;
 
       try {
@@ -312,20 +311,13 @@ const CanvasCard = ({
         });
         console.log("Thumbnail captured");
       } catch (err: unknown) {
+        // best-effort background update; failure must not interrupt the session
         console.error("Error updating thumbnail:", err);
-
-        const apiErr = err as AxiosError;
-
-        if (apiErr.status === 403) {
-          const locationEncoded : string = encodeURIComponent(`${location.pathname}${location.search}`);
-
-          navigate(`/login?redirect=${locationEncoded}`);
-        }
       }
     }, waitTime);
 
     return () => clearInterval(interval);
-  }, [whiteboardId, canvasGroupRefsByIdRef, location.pathname, location.search, navigate, rootCanvas.id, waitTime]);
+  }, [whiteboardId, canvasGroupRefsByIdRef, explicitPermission, rootCanvas.id, waitTime]);
 
   // Handle initial scroll to the center of the stage
   const containerRef = useRef<HTMLDivElement>(null);

--- a/RestAPI/src/controllers/whiteboards.ts
+++ b/RestAPI/src/controllers/whiteboards.ts
@@ -438,7 +438,7 @@ export const handlePutThumbnail = async (
 ) => {
   try {
     const { whiteboardId } = req.params;
-    const { thumbnailUrl } = req.body;
+    const { thumbnailUrl, authUser } = req.body;
 
     if (!thumbnailUrl || typeof thumbnailUrl != "string") {
       return res.status(400).json({ message: "thumbnailUrl string is required" })
@@ -456,6 +456,17 @@ export const handlePutThumbnail = async (
     }
 
     const { whiteboard } = resp;
+
+    const hasPermission = whiteboard.user_permissions.some(perm =>
+      perm.type === 'user' &&
+      perm.user &&
+      perm.user._id.toString() === authUser.id.toString() &&
+      (perm.permission === 'own' || perm.permission === 'edit')
+    );
+
+    if (!hasPermission) {
+      return res.status(403).json({ message: "You do not have permission to update the thumbnail of this whiteboard." });
+    }
 
     whiteboard.thumbnail_url = thumbnailUrl;
 

--- a/RestAPI/tests/whiteboards.test.ts
+++ b/RestAPI/tests/whiteboards.test.ts
@@ -1213,5 +1213,235 @@ describe("Whiteboards API", () => {
       .send()
       .expect(403);
   });
+
+  it('should allow a user with "own" permission to update a whiteboard thumbnail', async () => {
+    const userCollection = mongoose.connection.collection('users');
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+    const whiteboard = await whiteboardCollection.findOne({ name: "Project Gamma" });
+    const owner = await userCollection.findOne({ username: 'carol' });
+
+    expect(owner).not.toBeNull();
+    expect(whiteboard).not.toBeNull();
+
+    // to please TypeScript
+    if ((! owner) || (! whiteboard)) {
+      return;
+    }
+
+    const thumbnailUrl = 'data:image/jpeg;base64,b3duZXI=';
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: owner._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Update thumbnail
+    const wbRes = await request(app)
+      .put(`/api/v1/whiteboards/${whiteboard._id.toString()}/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ thumbnailUrl })
+      .expect(200);
+
+    expect(wbRes.body.thumbnail_url).toBe(thumbnailUrl);
+
+    // Ensure the update propagated to the database
+    const whiteboardUpdated = await whiteboardCollection.findOne({ _id: whiteboard._id });
+    expect(whiteboardUpdated?.thumbnail_url).toBe(thumbnailUrl);
+  });// -- end test case
+
+  it('should allow a user with explicit "edit" permission to update a whiteboard thumbnail', async () => {
+    const userCollection = mongoose.connection.collection('users');
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+    const whiteboard = await whiteboardCollection.findOne({ name: "Project Gamma" });
+    const editor = await userCollection.findOne({ username: 'alice' });
+
+    expect(editor).not.toBeNull();
+    expect(whiteboard).not.toBeNull();
+
+    // to please TypeScript
+    if ((! editor) || (! whiteboard)) {
+      return;
+    }
+
+    const thumbnailUrl = 'data:image/jpeg;base64,ZWRpdG9y';
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: editor._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Update thumbnail
+    const wbRes = await request(app)
+      .put(`/api/v1/whiteboards/${whiteboard._id.toString()}/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ thumbnailUrl })
+      .expect(200);
+
+    expect(wbRes.body.thumbnail_url).toBe(thumbnailUrl);
+  });// -- end test case
+
+  it('should not allow a user without permissions to update a whiteboard thumbnail', async () => {
+    const userCollection = mongoose.connection.collection('users');
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+    // Project Gamma is owned by Carol with Alice as editor; Bob has no permissions
+    const whiteboard = await whiteboardCollection.findOne({ name: "Project Gamma" });
+    const nonMember = await userCollection.findOne({ username: 'bob' });
+
+    expect(nonMember).not.toBeNull();
+    expect(whiteboard).not.toBeNull();
+
+    // to please TypeScript
+    if ((! nonMember) || (! whiteboard)) {
+      return;
+    }
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: nonMember._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Try to update thumbnail
+    await request(app)
+      .put(`/api/v1/whiteboards/${whiteboard._id.toString()}/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ thumbnailUrl: 'data:image/jpeg;base64,YXR0YWNrZXI=' })
+      .expect(403);
+
+    // Ensure the thumbnail was not changed in the database
+    const whiteboardUpdated = await whiteboardCollection.findOne({ _id: whiteboard._id });
+    expect(whiteboardUpdated?.thumbnail_url).not.toBe('data:image/jpeg;base64,YXR0YWNrZXI=');
+  });// -- end test case
+
+  it('should not allow a user without explicit permissions to update the thumbnail of a public whiteboard', async () => {
+    const userCollection = mongoose.connection.collection('users');
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+    // Project Public is owned by Bob; Alice has no explicit permissions on it
+    const whiteboard = await whiteboardCollection.findOne({ name: "Project Public" });
+    const nonMember = await userCollection.findOne({ username: 'alice' });
+
+    expect(nonMember).not.toBeNull();
+    expect(whiteboard).not.toBeNull();
+
+    // to please TypeScript
+    if ((! nonMember) || (! whiteboard)) {
+      return;
+    }
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: nonMember._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Try to update thumbnail
+    await request(app)
+      .put(`/api/v1/whiteboards/${whiteboard._id.toString()}/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ thumbnailUrl: 'data:image/jpeg;base64,YXR0YWNrZXI=' })
+      .expect(403);
+
+    // Ensure the thumbnail was not changed in the database
+    const whiteboardUpdated = await whiteboardCollection.findOne({ _id: whiteboard._id });
+    expect(whiteboardUpdated?.thumbnail_url).not.toBe('data:image/jpeg;base64,YXR0YWNrZXI=');
+  });// -- end test case
+
+  it('should not allow a user with "view" permission to update a whiteboard thumbnail', async () => {
+    const userCollection = mongoose.connection.collection('users');
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+    // Project Eta is owned by Eve with Frank as viewer
+    const whiteboard = await whiteboardCollection.findOne({ name: "Project Eta" });
+    const viewer = await userCollection.findOne({ username: 'frank' });
+
+    expect(viewer).not.toBeNull();
+    expect(whiteboard).not.toBeNull();
+
+    // to please TypeScript
+    if ((! viewer) || (! whiteboard)) {
+      return;
+    }
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: viewer._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Try to update thumbnail
+    await request(app)
+      .put(`/api/v1/whiteboards/${whiteboard._id.toString()}/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ thumbnailUrl: 'data:image/jpeg;base64,dmlld2Vy' })
+      .expect(403);
+  });// -- end test case
+
+  it('should reject a thumbnail update without a thumbnailUrl', async () => {
+    const userCollection = mongoose.connection.collection('users');
+    const whiteboardCollection = mongoose.connection.collection('whiteboards');
+
+    const whiteboard = await whiteboardCollection.findOne({ name: "Project Gamma" });
+    const owner = await userCollection.findOne({ username: 'carol' });
+
+    expect(owner).not.toBeNull();
+    expect(whiteboard).not.toBeNull();
+
+    // to please TypeScript
+    if ((! owner) || (! whiteboard)) {
+      return;
+    }
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: owner._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Try to update thumbnail with no thumbnailUrl
+    await request(app)
+      .put(`/api/v1/whiteboards/${whiteboard._id.toString()}/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({})
+      .expect(400);
+  });// -- end test case
+
+  it('should reject a thumbnail update for a malformed whiteboard id', async () => {
+    const userCollection = mongoose.connection.collection('users');
+
+    const owner = await userCollection.findOne({ username: 'carol' });
+
+    expect(owner).not.toBeNull();
+
+    // to please TypeScript
+    if (! owner) {
+      return;
+    }
+
+    // Generate signed JWT
+    const authToken = jwt.sign(
+      { sub: owner._id.toString() },   // sub = subject claim
+      JWT_SECRET,
+      { expiresIn: 999999999 }
+    );
+
+    // -- Try to update thumbnail on a malformed whiteboard id
+    await request(app)
+      .put(`/api/v1/whiteboards/zzzzzzz/thumbnail`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ thumbnailUrl: 'data:image/jpeg;base64,dGVzdA==' })
+      .expect(400);
+  });// -- end test case
 });
 


### PR DESCRIPTION
For non owner or editor users, thumbnail update request is no longer sent on the frontend and doesn't attempt to set it on the backend. Tests are written to check for these cases as well.