### PR TITLE
Implement z-index attribute for canvas objects

### DIFF
--- a/Frontend/src/components/AttributeFontSize.tsx
+++ b/Frontend/src/components/AttributeFontSize.tsx
@@ -31,10 +31,10 @@ const FontSizeComponent = ({
     lodash.isEqual
   );
 
-  const [inputValue, setInputValue] = useState(value.toString());
+  const [inputValue, setInputValue] = useState(value?.toString() ?? '');
 
   useEffect(() => {
-    setInputValue(value.toString());
+    setInputValue(value?.toString() ?? '');
   }, [value]);
   
   const onChangeFontSize = useCallback(

--- a/Frontend/src/components/AttributeStrokeWidth.tsx
+++ b/Frontend/src/components/AttributeStrokeWidth.tsx
@@ -32,10 +32,10 @@ const StrokeWidthComponent = ({
     (state: RootState) => selectCanvasObjectsByCanvas(state, canvasId),
     lodash.isEqual
   );
-  const [inputValue, setInputValue] = useState(value.toString());
+  const [inputValue, setInputValue] = useState(value?.toString() ?? '');
 
   useEffect(() => {
-    setInputValue(value.toString());
+    setInputValue(value?.toString() ?? '');
   }, [value]);
 
   const onChangeStrokeWidth = useCallback(

--- a/Frontend/src/components/AttributeZOrder.tsx
+++ b/Frontend/src/components/AttributeZOrder.tsx
@@ -1,0 +1,110 @@
+import {
+  useSelector,
+} from 'react-redux';
+
+import lodash from 'lodash';
+
+import {
+  type RootState,
+} from '@/store';
+
+import {
+  selectCanvasObjectsByCanvas,
+} from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
+import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
+
+import {
+  Button,
+} from '@/components/ui/button';
+
+const ZOrderComponent = ({
+  selectedShapeIds,
+  handleUpdateShapes,
+  canvasId,
+}: AttributeProps) => {
+  const canvasObjectsById = useSelector(
+    (state: RootState) => selectCanvasObjectsByCanvas(state, canvasId),
+    lodash.isEqual
+  );
+
+  // z-order only applies to an existing selection; hide in tool mode, where
+  // dispatchers reuse this attribute list but nothing is selected
+  if (selectedShapeIds.length === 0) {
+    return null;
+  }
+
+  const effectiveZIndex = (id: CanvasObjectIdType): number =>
+    canvasObjectsById?.[id]?.zIndex ?? 0;
+
+  // selection sorted by current stacking order, so relative order is
+  // preserved when multiple shapes are moved at once
+  const sortedSelection = (): CanvasObjectIdType[] =>
+    [...selectedShapeIds].sort((idA, idB) => {
+      const zA = effectiveZIndex(idA);
+      const zB = effectiveZIndex(idB);
+
+      if (zA !== zB) {
+        return zA - zB;
+      }
+
+      return idA < idB ? -1 : (idA > idB ? 1 : 0);
+    });
+
+  const updateZIndexes = (assignZIndex: (allZIndexes: number[], position: number) => number) => {
+    if (! canvasObjectsById || selectedShapeIds.length === 0) {
+      return;
+    }
+
+    const allZIndexes = Object.values(canvasObjectsById).map(obj => obj.zIndex ?? 0);
+
+    handleUpdateShapes(
+      canvasId,
+      canvasObjectsById,
+      Object.fromEntries(sortedSelection().map((id, i) => [
+        id,
+        { zIndex: assignZIndex(allZIndexes, i) },
+      ])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+    );
+  };
+
+  const onBringToFront = () => {
+    updateZIndexes((allZIndexes, i) => Math.max(0, ...allZIndexes) + 1 + i);
+  };
+
+  const onSendToBack = () => {
+    updateZIndexes(
+      (allZIndexes, i) => Math.min(0, ...allZIndexes) - selectedShapeIds.length + i
+    );
+  };
+
+  return (
+    <div className="flex gap-1 mt-1 me-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onBringToFront}
+      >
+        To front
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onSendToBack}
+      >
+        To back
+      </Button>
+    </div>
+  );
+}
+
+const AttributeZOrder: AttributeDefinition = {
+  name: "Order",
+  key: "zIndex",
+  Component: ZOrderComponent,
+}
+
+export default AttributeZOrder;

--- a/Frontend/src/pages/Whiteboard/Canvas.tsx
+++ b/Frontend/src/pages/Whiteboard/Canvas.tsx
@@ -561,9 +561,6 @@ const Canvas = ({
             verticalAlign="bottom"
           />
         )}
-
-        {/** Preview Shape **/}
-        {getPreview()}
       </Group>
 
       {/** Canvas Objects **/}
@@ -591,6 +588,9 @@ const Canvas = ({
           />
         ))
       )}
+
+      {/** Preview Shape **/}
+      {getPreview()}
     </Group>
   );
 };

--- a/Frontend/src/pages/Whiteboard/Canvas.tsx
+++ b/Frontend/src/pages/Whiteboard/Canvas.tsx
@@ -71,6 +71,7 @@ import {
 
 import {
   selectCanvasObjectIdsByCanvas,
+  selectMaxZIndexByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
 import {
@@ -220,10 +221,16 @@ const Canvas = ({
   const addShapes = useCallback(
     (canvasObjects: CanvasObjectModel[]) => {
       if (clientMessenger) {
+        // stamp new shapes above everything already on the canvas
+        const maxZIndex = selectMaxZIndexByCanvas(store.getState(), canvasId);
+
         clientMessenger.sendCreateCanvasObjects({
           type: 'create_canvas_objects',
           canvasId,
-          canvasObjects
+          canvasObjects: canvasObjects.map((obj, i) => ({
+            ...obj,
+            zIndex: maxZIndex + 1 + i,
+          }))
         });
 
         // Switch to hand tool after shape creation

--- a/Frontend/src/pages/Whiteboard/CanvasCard.tsx
+++ b/Frontend/src/pages/Whiteboard/CanvasCard.tsx
@@ -96,6 +96,7 @@ import {
 import {
   selectSelectedCanvasObjectsByWhiteboard,
   selectCanvasObjectById,
+  selectMaxZIndexByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
 import {
@@ -547,6 +548,11 @@ const CanvasCard = ({
           if (! selectedCanvasAttribs) return;
 
           const createdObjectAttribs : CanvasObjectModel = JSON.parse(currentObjectData);
+
+          // -- paste on top of everything already on the canvas, discarding
+          // any zIndex copied from the source object
+          createdObjectAttribs.zIndex
+            = selectMaxZIndexByCanvas(currState, selectedCanvasId) + 1;
 
           // -- set created object position
           switch (createdObjectAttribs.type) {

--- a/Frontend/src/store/canvasObjects/canvasObjectsSelectors.ts
+++ b/Frontend/src/store/canvasObjects/canvasObjectsSelectors.ts
@@ -46,6 +46,9 @@ export const selectCanvasObjectsByCanvas = (
   }
 };
 
+// Returns object IDs in render order: ascending zIndex, with ties broken by
+// object ID (ObjectIds are chronologically ordered, so ties keep creation
+// order and stay deterministic across clients).
 export const selectCanvasObjectIdsByCanvas = (
   state: RootState,
   canvasId: CanvasIdType,
@@ -58,9 +61,41 @@ export const selectCanvasObjectIdsByCanvas = (
   if (objectIds === null) {
     return null;
   } else {
-    return Object.keys(objectIds);
+    return Object.keys(objectIds).sort((idA, idB) => {
+      const zA = state.canvasObjects[idA]?.zIndex ?? 0;
+      const zB = state.canvasObjects[idB]?.zIndex ?? 0;
+
+      if (zA !== zB) {
+        return zA - zB;
+      }
+
+      return idA < idB ? -1 : (idA > idB ? 1 : 0);
+    });
   }
 };// -- end selectCanvasObjectIdsByCanvas
+
+// === selectMaxZIndexByCanvas =================================================
+//
+// Returns the highest zIndex among a canvas' objects, or 0 if the canvas has
+// no objects. Used to stamp new shapes so they render on top.
+//
+// =============================================================================
+export const selectMaxZIndexByCanvas = (
+  state: RootState,
+  canvasId: CanvasIdType,
+): number => {
+  const objectIds: Record<CanvasObjectIdType, CanvasObjectIdType> | null
+    = state.canvasObjectsByCanvas.canvasObjectsByCanvas[canvasId] || null;
+
+  if (objectIds === null) {
+    return 0;
+  }
+
+  return Object.keys(objectIds).reduce(
+    (max, objId) => Math.max(max, state.canvasObjects[objId]?.zIndex ?? 0),
+    0
+  );
+};// -- end selectMaxZIndexByCanvas
 
 export const selectCanvasObjectsByWhiteboard = (
   state: RootState,

--- a/Frontend/src/types/Attribute.ts
+++ b/Frontend/src/types/Attribute.ts
@@ -31,6 +31,7 @@ import AttributeStrokeColor from "@/components/AttributeStrokeColor";
 import AttributeFillColor from "@/components/AttributeFillColor";
 import AttributeFontSize from "@/components/AttributeFontSize";
 import AttributeFontColor from "@/components/AttributeFontColor";
+import AttributeZOrder from "@/components/AttributeZOrder";
 
 export type AttributeType =
   | "number"
@@ -72,7 +73,8 @@ export interface AttributeProps {
     updates: Record<CanvasObjectIdType, Partial<CanvasObjectModel>>,
   ) => unknown;
   canvasId: string;
-  value: Attribute['value'];
+  // -- undefined for attributes absent on older shapes (e.g. zIndex)
+  value: Attribute['value'] | undefined;
   className: string;
 }
 
@@ -91,19 +93,23 @@ export const shapeAttributes: Record<ShapeType, AttributeDefinition[]> = {
     AttributeStrokeWidth,
     AttributeStrokeColor,
     AttributeFillColor,
+    AttributeZOrder,
   ],
   ellipse: [
     AttributeStrokeWidth,
     AttributeStrokeColor,
     AttributeFillColor,
+    AttributeZOrder,
   ],
   text: [
     AttributeFontSize,
     AttributeFontColor,
+    AttributeZOrder,
   ],
   vector: [
     AttributeStrokeWidth,
     AttributeStrokeColor,
+    AttributeZOrder,
   ],
 }
 

--- a/Frontend/src/types/CanvasObjectModel.ts
+++ b/Frontend/src/types/CanvasObjectModel.ts
@@ -20,6 +20,8 @@ export type CanvasObjectIdType = string;
 export interface CanvasObjectBase {
   strokeColor: ShapeColor;
   strokeWidth: number;
+  // -- optional: objects created before z-ordering have no zIndex (treated as 0)
+  zIndex?: number;
 }
 
 export interface ShapeModelAttributes {
@@ -29,6 +31,7 @@ export interface ShapeModelAttributes {
   fillColor: ShapeColor;
   fontSize: number;
   color: ShapeColor;
+  zIndex?: number;
 }
 
 export type ShapeModelBase = CanvasObjectBase & ShapeModelAttributes;

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -42,6 +42,9 @@ pub enum CanvasObjectModel {
         stroke_color: String,
         fill_color: String,
         rotation: f64,
+        // -- default covers documents/messages predating z-ordering
+        #[serde(default)]
+        z_index: f64,
     },
     Ellipse {
         x: f64,
@@ -52,11 +55,15 @@ pub enum CanvasObjectModel {
         stroke_color: String,
         fill_color: String,
         rotation: f64,
+        #[serde(default)]
+        z_index: f64,
     },
     Vector {
         points: Vec<f64>,
         stroke_width: f64,
         stroke_color: String,
+        #[serde(default)]
+        z_index: f64,
     },
     Text {
         text: String,
@@ -67,6 +74,8 @@ pub enum CanvasObjectModel {
         width: f64,
         height: f64,
         rotation: f64,
+        #[serde(default)]
+        z_index: f64,
     },
 }
 

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -1540,6 +1540,7 @@ mod unit_tests {
                 stroke_color: String::from("#333333"),
                 fill_color: String::from("#ff0000"),
                 rotation: 0.0,
+                z_index: 0.0,
             },
             CanvasObjectModel::Rect {
                 x: 200.0,
@@ -1550,6 +1551,7 @@ mod unit_tests {
                 stroke_color: String::from("#333333"),
                 fill_color: String::from("#ff0000"),
                 rotation: 0.0,
+                z_index: 0.0,
             },
             CanvasObjectModel::Rect {
                 x: 300.0,
@@ -1560,6 +1562,7 @@ mod unit_tests {
                 stroke_color: String::from("#333333"),
                 fill_color: String::from("#ff0000"),
                 rotation: 0.0,
+                z_index: 0.0,
             },
         ];
         let client_msg_s = format!(
@@ -1707,6 +1710,7 @@ mod unit_tests {
                                         stroke_color,
                                         fill_color,
                                         rotation,
+                                        z_index,
                                     },
                                     CanvasObjectModel::Rect {
                                         x: x_exp,
@@ -1717,6 +1721,7 @@ mod unit_tests {
                                         stroke_color: stroke_color_exp,
                                         fill_color: fill_color_exp,
                                         rotation: rotation_exp,
+                                        z_index: z_index_exp,
                                     },
                                 ) => {
                                     if (x - x_exp).abs() > f64_prec {
@@ -1761,6 +1766,12 @@ mod unit_tests {
                                             rotation, rotation_exp
                                         );
                                     }
+                                    if (z_index - z_index_exp).abs() > f64_prec {
+                                        panic!(
+                                            "Expected canvas_object z_index = {}; got {}",
+                                            z_index, z_index_exp
+                                        );
+                                    }
                                 }
                                 (_, _) => panic!("Expected Rect; got {:?}", canvas_object),
                             };
@@ -1803,6 +1814,7 @@ mod unit_tests {
                     stroke_color: String::from("#333333"),
                     fill_color: String::from("#ff0000"),
                     rotation: 0.0,
+                    z_index: 0.0,
                 },
             ),
             (
@@ -1816,6 +1828,7 @@ mod unit_tests {
                     stroke_color: String::from("#333333"),
                     fill_color: String::from("#ff0000"),
                     rotation: 0.0,
+                    z_index: 0.0,
                 },
             ),
             (
@@ -1829,6 +1842,7 @@ mod unit_tests {
                     stroke_color: String::from("#333333"),
                     fill_color: String::from("#ff0000"),
                     rotation: 0.0,
+                    z_index: 0.0,
                 },
             ),
         ];


### PR DESCRIPTION
All canvas objects have a z-index field which gives the user the ability to send them to the front or back of the other shapes. 