### PR TITLE
bugfix/user email enumeration

### DIFF
--- a/RestAPI/src/controllers/users.ts
+++ b/RestAPI/src/controllers/users.ts
@@ -21,6 +21,7 @@ import {
   patchUser,
   deleteUser,
   getSharedWhiteboardsByUser,
+  isUserOwnerCollaborator,
 } from "../services/userService";
 
 import {
@@ -85,7 +86,7 @@ export const handleCreateUser = async (
     try {
       const loginResult = await permanentUserLoginService("username", username, password);
       return res.status(201).json({
-        user: userFinal.toPublicView(),
+        user: userFinal.toSelfView(),
         token: loginResult.token
       });
     } catch (err: any) {
@@ -160,7 +161,7 @@ export const handleConvertTempUser = async (
     try {
       const loginResult = await permanentUserLoginService("username", username, password);
       return res.status(201).json({
-        user: userFinal.toPublicView(),
+        user: userFinal.toSelfView(),
         token: loginResult.token
       });
     } catch (err: any) {
@@ -203,7 +204,7 @@ export const handleCreateTempUser = async (
 
       return res.status(201).json({ 
         ...resp.payload,
-        user: resp.payload.user
+        user: resp.payload.user.toSelfView(),
       });
     default:
       throw new Error(`Unhandled case: ${resp}`);
@@ -232,7 +233,13 @@ export const handleGetUserById = async (
       case 'not_found':
         return res.status(404).json({ message: `User ${targetUserId} not found` });
       case 'ok':
-        return res.status(200).json(resp.user.toAttribView());
+        if (isUserOwnerCollaborator(authUserId, targetUserId)) {
+          // -- Deliver more restricted view
+          return res.status(200).json(resp.user.toWBOwnerView());
+        } else {
+          // -- Deliver more restricted view
+          return res.status(200).json(resp.user.toAttribView());
+        }
       default:
         throw new Error(`Unhandled case: ${resp}`);
     }
@@ -310,7 +317,7 @@ export const handlePatchOwnUser = async (
               }// -- end for whiteboard
             }
 
-            return res.status(201).json(patchUserRes.data);
+            return res.status(201).json(patchUserRes.data.toSelfView());
           }
         }
       }
@@ -363,7 +370,7 @@ export const handleDeleteOwnUser = async (
   if (resp.result === 'err') {
     return res.status(400).json({ message: resp.err });
   } else {
-    return res.status(200).json(resp.data);
+    return res.status(200).json(resp.data.toSelfView());
   }
 };// -- end handleDeleteOwnUser
 

--- a/RestAPI/src/controllers/whiteboards.ts
+++ b/RestAPI/src/controllers/whiteboards.ts
@@ -74,23 +74,30 @@ export const handleGetWhiteboardById = async (
         const isValidUserPerm = (perm: IWhiteboardUserPermissionModel<IUser>): perm is IWhiteboardUserPermissionById <IUser> => {
           return (perm.type === 'user') && (!! perm.user);
         };
-        const validUserIdSet: Record<string, boolean> = Object.fromEntries(
+        const permsByUserId: Record<string, IWhiteboardPermissionEnum> = Object.fromEntries(
             whiteboard.user_permissions.filter(perm => isValidUserPerm(perm)).map(perm => [
-            perm.user.id, true 
+            perm.user.id, perm.permission 
           ])
         );
 
         if (whiteboard.visibility !== 'public') {
           // Private board - require authenticated user with permission
-          if (!userId || !(userId.toString() in validUserIdSet)) {
+          if (!userId || !(userId.toString() in permsByUserId)) {
             return res.status(403).json({
               message: 'You are not authorized to view this resource'
             });
           }
         }
 
-        const wbAttribView = whiteboard.toAttribView();
-        return res.status(200).json(wbAttribView);
+        if (userId && permsByUserId[userId.toHexString()] === 'own') {
+          // -- Return owner view
+          const wbOwnerView = whiteboard.toOwnerView();
+          return res.status(200).json(wbOwnerView);
+        } else {
+          // -- Return attrib view
+          const wbAttribView = whiteboard.toAttribView();
+          return res.status(200).json(wbAttribView);
+        }
     }
     default:
       return res.status(500).json({ message: 'Unexpected error occurred' });
@@ -183,7 +190,7 @@ export const handleCreateWhiteboard = async (
     const whiteboardOut = await whiteboard.save()
       .then(wb => wb.populateFull());
     
-    res.status(201).json(whiteboardOut.toPublicView());
+    res.status(201).json(whiteboardOut.toOwnerView());
   } catch (err: unknown) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('Server Error:', err);
@@ -236,7 +243,7 @@ export const handleCreateTempWhiteboard = async (
     const whiteboardOut = await whiteboard.save()
       .then(wb => wb.populateFull());
     
-    res.status(201).json(whiteboardOut.toPublicView());
+    res.status(201).json(whiteboardOut.toOwnerView());
   } catch (err: unknown) {
     if (process.env.NODE_ENV !== 'production') {
       console.log('Server Error:', err);
@@ -390,7 +397,7 @@ export const handleGetOwnWhiteboards = async (
       const permissionsFiltered = removeDanglingUserPermissions(whiteboard.user_permissions);
 
       whiteboard.user_permissions = permissionsFiltered;
-      return whiteboard;
+      return whiteboard.toOwnerView();
   });
 
   res.status(200).json(ownWhiteboards);
@@ -421,7 +428,7 @@ export const handleShareWhiteboard = async (
 
     switch (result.status) {
       case "success":
-        const wbAttribView = result.whiteboard.toAttribView();
+        const wbAttribView = result.whiteboard.toOwnerView();
 
         return res.status(200).json({
           ...wbAttribView,

--- a/RestAPI/src/models/User.ts
+++ b/RestAPI/src/models/User.ts
@@ -78,9 +78,17 @@ export interface IPermanentUserModel extends IUserModel{
   passwordHashed: string;
 }
 
-// -- define protected fields for later omission from public view
+// -- define protected fields for later omission from protected views
 type PermanentUserProtectedFields =
+  | UserProtectedFields
   | "passwordHashed"
+;
+
+// -- define fields restricted from the general public (i.e. non-whiteboard
+// owners)
+type PermanentUserPublicRestrictedFields =
+  | PermanentUserProtectedFields
+  | "email"
 ;
 
 // === Permanent Data Transfer Objects =========================================
@@ -89,11 +97,19 @@ type PermanentUserProtectedFields =
 export type IPermanentUserDocument = ViewDocument<IPermanentUserModel>;
 
 // -- User, excluding sensitive fields
-export type IPermanentUserPublicView = Omit<IPermanentUserDocument, PermanentUserProtectedFields>;
+export type IPermanentUserPublicView = Omit<IPermanentUserDocument, PermanentUserPublicRestrictedFields>;
 
 // -- Public view, excluding vector attributes
 // -- In this case, there are no vector attributes
 export type IPermanentUserAttribView = IPermanentUserPublicView;
+
+// -- Projection intended for a user to view their own account.
+// Includes all but the most sensitive fields (i.e. the hashed password)
+export type IPermanentUserSelfView = Omit<IPermanentUserDocument, PermanentUserProtectedFields>;
+
+// -- Projection that includes fields only visible to whiteboard owners who have
+// shared a whiteboard with the user (namely, their email address).
+export type IPermanentUserWBOwnerView = Omit<IPermanentUserDocument, PermanentUserProtectedFields>;
 
 export type IPermanentUserVirtual = DocumentVirtualBase;
 
@@ -103,6 +119,10 @@ export type PermanentUserModelType = Model<IPermanentUserDocument, {}, {}, IPerm
 export type IPermanentUser = 
   & IPermanentUserDocument
   & DocumentViewMethods<IPermanentUser, IPermanentUserPublicView, IPermanentUserAttribView>
+  & {
+    toSelfView: () => IPermanentUserSelfView;
+    toWBOwnerView: () => IPermanentUserWBOwnerView;
+  }
   & Document <Types.ObjectId>
 ;
 // -- End IPermanentUser
@@ -124,15 +144,27 @@ export interface ITempUserModel extends IUserModel{
 export type ITempUserDocument = ViewDocument<ITempUserModel>;
 
 // -- User, excluding sensitive fields
-export type TempUserProtectedFields = 
+type TempUserProtectedFields =
   | UserProtectedFields
 ;
 
-export type ITempUserPublicView = Omit<ITempUserDocument, TempUserProtectedFields>;
+// -- define fields restricted from the general public (i.e. non-whiteboard
+// owners)
+type TempUserPublicRestrictedFields =
+  | TempUserProtectedFields
+;
+
+export type ITempUserPublicView = Omit<ITempUserDocument, TempUserPublicRestrictedFields>;
 
 // -- Public view, excluding vector attributes
 // -- In this case, there are no vector attributes
 export type ITempUserAttribView = ITempUserPublicView;
+
+// -- Projection intended for a user to view their own account.
+// Includes all but the most sensitive fields (i.e. the hashed password)
+export type ITempUserSelfView = Omit<ITempUserDocument, TempUserProtectedFields>;
+
+export type ITempUserWBOwnerView = Omit<ITempUserDocument, TempUserProtectedFields>;
 
 export type ITempUserVirtual = DocumentVirtualBase;
 
@@ -142,6 +174,10 @@ export type TempUserModelType = Model<ITempUserDocument, {}, {}, ITempUserVirtua
 export type ITempUser = 
   & ITempUserDocument
   & DocumentViewMethods<ITempUser, ITempUserPublicView, ITempUserAttribView>
+  & {
+    toSelfView: () => ITempUserSelfView;
+    toWBOwnerView: () => ITempUserWBOwnerView;
+  }
   & Document <Types.ObjectId>
 ;
 // -- End ITempUser
@@ -149,6 +185,21 @@ export type ITempUser =
 export type IUserType = 
   | IPermanentUser
   | ITempUser
+;
+
+export type IUserTypePublicView =
+  | IPermanentUserPublicView
+  | ITempUserPublicView
+;
+
+export type IUserTypeAttribView =
+  | IPermanentUserAttribView
+  | ITempUserAttribView
+;
+
+export type IUserTypeWBOwnerView =
+  | IPermanentUserWBOwnerView
+  | ITempUserWBOwnerView
 ;
 
 // === REST Request Body Definitions ===========================================
@@ -194,7 +245,8 @@ export type DeletePermanentUserRequest = AuthorizedRequestBody & DeletePermanent
 const permanentUserToPublicView = (user: IPermanentUser): IPermanentUserPublicView => {
   const {
     _id,
-    passwordHashed,
+    passwordHashed: _passwordHashed,
+    email: _email,
     ...out
   } = user;
 
@@ -203,6 +255,26 @@ const permanentUserToPublicView = (user: IPermanentUser): IPermanentUserPublicVi
 
 // -- identical to toPublicView, in this case
 const permanentUserToAttribView = permanentUserToPublicView;
+
+const permanentUserToSelfView = (user: IPermanentUser): IPermanentUserSelfView => {
+  const {
+    _id,
+    passwordHashed: _passwordHashed,
+    ...out
+  } = user;
+
+  return out;
+};// -- end permanentUserToSelfView
+
+const permanentUserToWBOwnerView = (user: IPermanentUser): IPermanentUserWBOwnerView => {
+  const {
+    _id,
+    passwordHashed: _passwordHashed,
+    ...out
+  } = user;
+
+  return out;
+};// -- end permanentUserToWBOwnerView
 
 // === Data Transfer Mappings ==================================================
 //
@@ -221,6 +293,12 @@ const tempUserToPublicView = (user: ITempUser): ITempUserPublicView => {
 
 // -- identical to toPublicView, in this case
 const tempUserToAttribView = tempUserToPublicView;
+
+// -- identical to toPublicView, in this case
+const tempUserToSelfView = tempUserToPublicView;
+
+// -- identical to toPublicView, in this case
+const tempUserToWBOwnerView = tempUserToPublicView;
 
 // === userSchema ==============================================================
 //
@@ -300,7 +378,13 @@ userSchema.discriminator(
       },// -- end toPublicView
       toAttribView(): IPermanentUserAttribView {
         return permanentUserToAttribView(this.toObject({ virtuals: true }));
-      }// -- end toAttribView
+      },// -- end toAttribView
+      toSelfView(): IPermanentUserSelfView {
+        return permanentUserToSelfView(this.toObject({ virtuals: true }));
+      },// -- end toSelfView
+      toWBOwnerView(): IPermanentUserWBOwnerView {
+        return permanentUserToWBOwnerView(this.toObject({ virtuals: true }));
+      },// -- end toWBOwnerView
     },
   },
 ));
@@ -346,7 +430,13 @@ const tempUserSchema = new Schema<ITempUser, TempUserModelType, {}, {}, ITempUse
       },// -- end toPublicView
       toAttribView(): ITempUserAttribView {
         return tempUserToAttribView(this.toObject({ virtuals: true }));
-      }// -- end toAttribView
+      },// -- end toAttribView
+      toSelfView(): ITempUserSelfView {
+        return tempUserToSelfView(this.toObject({ virtuals: true }));
+      },// -- end toSelfView
+      toWBOwnerView(): ITempUserWBOwnerView {
+        return tempUserToWBOwnerView(this.toObject({ virtuals: true }));
+      },// -- end toWBOwnerView
     },
   }
 );// -- end tempUserSchema

--- a/RestAPI/src/models/Whiteboard.ts
+++ b/RestAPI/src/models/Whiteboard.ts
@@ -13,9 +13,10 @@ import type {
 } from './Model';
 
 import {
-  type IUser,
-  type IUserPublicView,
-  type IUserAttribView,
+  type IUserType,
+  type IUserTypePublicView,
+  type IUserTypeAttribView,
+  type IUserTypeWBOwnerView,
 } from './User';
 
 export type WhiteboardIdType = Types.ObjectId;
@@ -154,7 +155,10 @@ export interface ICanvasDocument <UserType> extends ICanvasModel <UserType> {
 // -- Canvas as Mongo document
 export type ICanvas <UserType> =
   & ICanvasDocument <UserType>
-  & DocumentViewMethods<ICanvas <IUser>, ICanvasPublicView, ICanvasAttribView>
+  & DocumentViewMethods<ICanvas <IUserType>, ICanvasPublicView, ICanvasAttribView>
+  & {
+    toWBOwnerView: () => ICanvasWBOwnerView;
+  }
   & Document <Types.ObjectId>
 ;
 
@@ -163,7 +167,7 @@ export interface ICanvasVirtual <ChildCanvasType, ShapeType> extends DocumentVir
   shapes: ShapeType[];
 }
 
-export type ICanvasFull = ICanvas<IUser> & ICanvasVirtual<ICanvas <IShape>, IShape>;
+export type ICanvasFull = ICanvas<IUserType> & ICanvasVirtual<ICanvas <IShape>, IShape>;
 
 export type CanvasModelType = Model<ICanvasDocument <Types.ObjectId>, {}, {}, ICanvasVirtual <Types.ObjectId, Types.ObjectId>>;
 
@@ -181,9 +185,14 @@ const CANVAS_VECTOR_FIELDS = [
 //
 // =============================================================================
 
-export type ICanvasPublicView = ViewDocument <ICanvasDocument <IUserPublicView> & ICanvasVirtual<ICanvasPublicView, IShapePublicView>>;
+export type ICanvasPublicView = ViewDocument <ICanvasDocument <IUserTypePublicView> & ICanvasVirtual<ICanvasPublicView, IShapePublicView>>;
 
 export type ICanvasAttribView = Omit<ICanvasPublicView, CanvasVectorFields>;
+
+export type ICanvasWBOwnerView = Omit<
+  ViewDocument <ICanvasDocument <IUserTypeWBOwnerView> & ICanvasVirtual<ICanvasAttribView, IShapeAttribView>>,
+  CanvasVectorFields
+>;
 
 const CANVAS_POP_FIELDS_ATTRIBS = [
   'allowed_users',
@@ -224,10 +233,10 @@ export const canvasSchema = new Schema<ICanvas <Types.ObjectId>, CanvasModelType
     },
     // -- instance methods
     methods: {
-      async populateAttribs(): Promise<ICanvas <IUser>> {
+      async populateAttribs(): Promise<ICanvas <IUserType>> {
         return await this.populate(CANVAS_POP_FIELDS_ATTRIBS);
       },
-      async populateFull(): Promise<ICanvas <IUser>> {
+      async populateFull(): Promise<ICanvas <IUserType>> {
         return await this.populate(CANVAS_POP_FIELDS_FULL);
       },
       toPublicView(): ICanvasPublicView {
@@ -241,11 +250,11 @@ export const canvasSchema = new Schema<ICanvas <Types.ObjectId>, CanvasModelType
 
         return ({
           ...fields,
-          allowed_users: (this as unknown as ICanvas <IUser>)
+          allowed_users: (this as unknown as ICanvas <IUserType>)
             .allowed_users.map(user => user.toPublicView()),
-          child_canvases: (this as unknown as ICanvas <IUser> & ICanvasVirtual<ICanvas <IShape>, IShape>)
+          child_canvases: (this as unknown as ICanvas <IUserType> & ICanvasVirtual<ICanvas <IShape>, IShape>)
             .child_canvases.map(canvas => canvas.toPublicView()),
-          shapes: (this as unknown as ICanvas <IUser> & ICanvasVirtual<ICanvas <IShape>, IShape>)
+          shapes: (this as unknown as ICanvas <IUserType> & ICanvasVirtual<ICanvas <IShape>, IShape>)
             .shapes.map(shape => shape.toPublicView()),
         });
       },
@@ -260,8 +269,23 @@ export const canvasSchema = new Schema<ICanvas <Types.ObjectId>, CanvasModelType
 
         return ({
           ...fields,
-          allowed_users: (this as unknown as ICanvas <IUser>)
+          allowed_users: (this as unknown as ICanvas <IUserType>)
             .allowed_users.map(user => user.toAttribView()),
+        });
+      },
+      toWBOwnerView(): ICanvasWBOwnerView {
+        const obj = this.toObject({ virtuals: true });
+
+        const {
+          allowed_users,
+          shapes,
+          ...fields
+        } = obj;
+
+        return ({
+          ...fields,
+          allowed_users: (this as unknown as ICanvas <IUserType>)
+            .allowed_users.map(user => user.toWBOwnerView()),
         });
       }
     },
@@ -340,9 +364,11 @@ export type IWhiteboardUserPermissionModel <UserType> =
   | IWhiteboardUserPermissionByEmail
 ;
 
-export type IWhiteboardUserPermissionPublicView = IWhiteboardUserPermissionModel<IUserPublicView>;
+export type IWhiteboardUserPermissionPublicView = IWhiteboardUserPermissionModel<IUserTypePublicView>;
 
-export type IWhiteboardUserPermissionAttribView = IWhiteboardUserPermissionModel<IUserAttribView>;
+export type IWhiteboardUserPermissionAttribView = IWhiteboardUserPermissionModel<IUserTypeAttribView>;
+
+export type IWhiteboardUserPermissionWBOwnerView = IWhiteboardUserPermissionModel<IUserTypeWBOwnerView>;
 
 export type IWhiteboardUserPermission <UserType> =
   & IWhiteboardUserPermissionModel<UserType>
@@ -351,6 +377,9 @@ export type IWhiteboardUserPermission <UserType> =
     IWhiteboardUserPermissionPublicView,
     IWhiteboardUserPermissionAttribView
   >
+  & {
+    toWBOwnerView: () => IWhiteboardUserPermissionWBOwnerView;
+  }
   & Document<Types.ObjectId>
 ;
 
@@ -364,6 +393,13 @@ const whiteboardUserPermissionSchema = new Schema<IWhiteboardUserPermission <Typ
     discriminatorKey: 'type',
   }
 );
+
+export type IWhiteboardUserPermissionSchema <UserType> = Model<IWhiteboardUserPermission <UserType>>;
+
+export const WhiteboardUserPermission = model<
+  IWhiteboardUserPermission <Types.ObjectId>,
+  IWhiteboardUserPermissionSchema <Types.ObjectId>
+>("WhiteboardUserPermission", whiteboardUserPermissionSchema, "whiteboardUserPermissions");
 
 export type WhiteboardTypeEnum =
   | "permanent_whiteboard"
@@ -400,17 +436,28 @@ type WhiteboardVectorFields =
 
 export type IWhiteboardDocument <UserType, CanvasType> = IWhiteboardModel <UserType, CanvasType>;
 
-export type IWhiteboardPublicView = ViewDocument<IWhiteboardDocument <IUser, ICanvas<IUser>>>;
+export type IWhiteboardPublicView = ViewDocument<
+  IWhiteboardDocument <IUserTypePublicView, ICanvas<IUserTypePublicView>>
+>;
 
-export type IWhiteboardAttribView = Omit<IWhiteboardPublicView, WhiteboardVectorFields>;
+export type IWhiteboardAttribView = ViewDocument<
+  IWhiteboardDocument <IUserTypeAttribView, ICanvas<IUserTypeAttribView>>
+>;
+
+export type IWhiteboardOwnerView = ViewDocument<
+  IWhiteboardDocument <IUserTypeWBOwnerView, ICanvas<IUserTypeWBOwnerView>>
+>;
 
 export type IWhiteboard <UserType, CanvasType> =
   & IWhiteboardDocument <UserType, CanvasType>
-  & DocumentViewMethods<IWhiteboard <IUser, ICanvas<IUser>>, IWhiteboardPublicView, IWhiteboardAttribView>
+  & DocumentViewMethods<IWhiteboard <IUserType, ICanvas<IUserType>>, IWhiteboardPublicView, IWhiteboardAttribView>
+  & {
+    toOwnerView: () => IWhiteboardOwnerView;
+  }
   & Document <Types.ObjectId>
 ;
 
-export type IWhiteboardFull = IWhiteboard<IUser, ICanvas<IUser>>;
+export type IWhiteboardFull = IWhiteboard<IUserType, ICanvas<IUserType>>;
 // -- End IWhiteboard
 
 
@@ -429,10 +476,18 @@ type PermanentWhiteboardProtectedFields = "";
 
 export type IPermanentWhiteboardDocument <UserType, CanvasType> = ViewDocument<IPermanentWhiteboardModel <UserType, CanvasType>>;
 
-export type IPermanentWhiteboardPublicView <UserType, CanvasType> = Omit<IPermanentWhiteboardDocument <UserType, CanvasType>, PermanentWhiteboardProtectedFields>;
+export type IPermanentWhiteboardPublicView = Omit<IPermanentWhiteboardDocument <IUserTypePublicView, ICanvasPublicView>, PermanentWhiteboardProtectedFields>;
 
 // -- Public view, excluding vector attributes
-export type IPermanentWhiteboardAttribView <UserType, CanvasType> = Omit<IPermanentWhiteboardPublicView <UserType, CanvasType>, WhiteboardVectorFields>;
+export type IPermanentWhiteboardAttribView = Omit<
+  IPermanentWhiteboardDocument <IUserTypeAttribView, ICanvasAttribView>,
+  PermanentWhiteboardProtectedFields | WhiteboardVectorFields
+>;
+
+export type IPermanentWhiteboardOwnerView = Omit<
+  IPermanentWhiteboardDocument <IUserTypeWBOwnerView, ICanvasWBOwnerView>,
+  PermanentWhiteboardProtectedFields | WhiteboardVectorFields
+>;
 
 export type IPermanentWhiteboardVirtual = DocumentVirtualBase;
 
@@ -441,11 +496,16 @@ export type PermanentWhiteboardModelType <UserType, CanvasType> = Model<IPermane
 // -- User as a Mongo document
 export type IPermanentWhiteboard <UserType, CanvasType> = 
   & IPermanentWhiteboardDocument <UserType, CanvasType>
-  & DocumentViewMethods<IPermanentWhiteboard <UserType, CanvasType>, IPermanentWhiteboardPublicView <UserType, CanvasType>, IPermanentWhiteboardAttribView <UserType, CanvasType>>
+  & DocumentViewMethods<
+    IPermanentWhiteboard <UserType, CanvasType>,
+    IPermanentWhiteboardPublicView, IPermanentWhiteboardAttribView
+  >
+  & {
+    toOwnerView: () => IPermanentWhiteboardOwnerView;
+  }
   & Document <Types.ObjectId>
 ;
 // -- End IPermanentWhiteboard
-
 
 // === ITempWhiteboard ====================================================================
 //  
@@ -462,10 +522,18 @@ type TempWhiteboardProtectedFields = "";
 
 export type ITempWhiteboardDocument <UserType, CanvasType> = ViewDocument<ITempWhiteboardModel <UserType, CanvasType>>;
 
-export type ITempWhiteboardPublicView <UserType, CanvasType> = Omit<ITempWhiteboardDocument <UserType, CanvasType>, TempWhiteboardProtectedFields>;
+export type ITempWhiteboardPublicView = Omit<ITempWhiteboardDocument <IUserTypePublicView, ICanvasPublicView>, TempWhiteboardProtectedFields>;
 
 // -- Public view, excluding vector attributes
-export type ITempWhiteboardAttribView <UserType, CanvasType> = Omit<ITempWhiteboardPublicView <UserType, CanvasType>, WhiteboardVectorFields>;
+export type ITempWhiteboardAttribView = Omit<
+  ITempWhiteboardDocument <IUserTypeAttribView, ICanvasAttribView>,
+  TempWhiteboardProtectedFields | WhiteboardVectorFields
+>;
+
+export type ITempWhiteboardOwnerView = Omit<
+  ITempWhiteboardDocument <IUserTypeWBOwnerView, ICanvasWBOwnerView>,
+  TempWhiteboardProtectedFields | WhiteboardVectorFields
+>;
 
 export type ITempWhiteboardVirtual = DocumentVirtualBase;
 
@@ -474,7 +542,10 @@ export type TempWhiteboardModelType <UserType, CanvasType> = Model<ITempWhiteboa
 // -- User as a Mongo document
 export type ITempWhiteboard <UserType, CanvasType> = 
   & ITempWhiteboardDocument <UserType, CanvasType>
-  & DocumentViewMethods<ITempWhiteboard <UserType, CanvasType>, ITempWhiteboardPublicView <UserType, CanvasType>, ITempWhiteboardAttribView <UserType, CanvasType>>
+  & DocumentViewMethods<ITempWhiteboard <UserType, CanvasType>, ITempWhiteboardPublicView, ITempWhiteboardAttribView>
+  & {
+    toOwnerView: () => ITempWhiteboardOwnerView;
+  }
   & Document <Types.ObjectId>
 ;
 // -- End ITempWhiteboard
@@ -503,9 +574,9 @@ const WHITEBOARD_POP_FIELDS_FULL = [
 //
 // =============================================================================
 export interface IWhiteboardSchema <UserType, CanvasType> extends Model<IWhiteboard<UserType, CanvasType>> {
-  findFull: (options: Record<string, any>) => Promise<IWhiteboard <IUser, ICanvas<IUser>>[]>;
-  findAttribs: (options: Record<string, any>) => Promise<IWhiteboard<IUser, ICanvas<IUser>>[]>;
-  findSharedUsersByWhiteboardId: (whiteboardId: Types.ObjectId) => Promise<IWhiteboardUserPermission<IUser>[] | null>;
+  findFull: (options: Record<string, any>) => Promise<IWhiteboard <IUserType, ICanvas<IUserType>>[]>;
+  findAttribs: (options: Record<string, any>) => Promise<IWhiteboard<IUserType, ICanvas<IUserType>>[]>;
+  findSharedUsersByWhiteboardId: (whiteboardId: Types.ObjectId) => Promise<IWhiteboardUserPermission<IUserType>[] | null>;
 }
 
 const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>, IWhiteboardSchema<Types.ObjectId, Types.ObjectId>>(
@@ -539,13 +610,13 @@ const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>,
     },
     // -- instance methods
     methods: {
-      async populateAttribs(): Promise<IWhiteboard <IUser, ICanvas<IUser>>> {
+      async populateAttribs(): Promise<IWhiteboard <IUserType, ICanvas<IUserType>>> {
         await this.populate(WHITEBOARD_POP_FIELDS_ATTRIBS);
-        return this as unknown as IWhiteboard <IUser, ICanvas<IUser>>;
+        return this as unknown as IWhiteboard <IUserType, ICanvas<IUserType>>;
       },
-      async populateFull(): Promise<IWhiteboard <IUser, ICanvas<IUser>>> {
+      async populateFull(): Promise<IWhiteboard <IUserType, ICanvas<IUserType>>> {
         await this.populate(WHITEBOARD_POP_FIELDS_FULL);
-        return this as unknown as IWhiteboard <IUser, ICanvas<IUser>>;
+        return this as unknown as IWhiteboard <IUserType, ICanvas<IUserType>>;
       },
       toPublicView() {
         const obj = this.toObject({ virtuals: true });
@@ -557,7 +628,7 @@ const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>,
 
         return ({
           ...fields,
-          user_permissions: (this as unknown as IWhiteboard <IUser, ICanvas<IUser>>)
+          user_permissions: (this as unknown as IWhiteboard <IUserType, ICanvas<IUserType>>)
             .user_permissions
             .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
             .map(perm => perm.toPublicView()),
@@ -573,12 +644,28 @@ const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>,
 
         return ({
           ...fields,
-          user_permissions: (this as unknown as IWhiteboard <IUser, ICanvas<IUser>>)
+          user_permissions: (this as unknown as IWhiteboard <IUserType, ICanvas<IUserType>>)
             .user_permissions
             .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
             .map(perm => perm.toAttribView()),
         });
-      }
+      },
+      toOwnerView() {
+        const obj = this.toObject({ virtuals: true });
+        const {
+          _id,
+          user_permissions: _user_permissions,
+          ...fields
+        } = obj;
+
+        return ({
+          ...fields,
+          user_permissions: (this as unknown as IWhiteboard <IUserType, ICanvas<IUserType>>)
+            .user_permissions
+            .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
+            .map(perm => perm.toWBOwnerView()),
+        });
+      },
     },
     // -- static methods
     statics: {
@@ -591,8 +678,8 @@ const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>,
           .select(WHITEBOARD_VECTOR_FIELDS.map(field => `-${field}`).join(' '))
           .populate(WHITEBOARD_POP_FIELDS_ATTRIBS);
       },
-      async findSharedUsersByWhiteboardId(whiteboardId: Types.ObjectId): Promise<IWhiteboardUserPermission<IUser>[] | null> {
-        const res : Partial<IWhiteboard <IUser, ICanvas<IUser>>> | null = await this.findById(whiteboardId)
+      async findSharedUsersByWhiteboardId(whiteboardId: Types.ObjectId): Promise<IWhiteboardUserPermission<IUserType>[] | null> {
+        const res : Partial<IWhiteboard <IUserType, ICanvas<IUserType>>> | null = await this.findById(whiteboardId)
           .select("user_permissions")
           .then(wb => wb?.populateAttribs() || null);
 
@@ -612,9 +699,9 @@ const whiteboardSchema = new Schema<IWhiteboard<Types.ObjectId, Types.ObjectId>,
 //
 // ============================================================================================
 export interface IPermanentWhiteboardSchema <UserType, CanvasType> extends Model<IPermanentWhiteboard<UserType, CanvasType>> {
-  findFull: (options: Record<string, any>) => Promise<IPermanentWhiteboard <IUser, ICanvas<IUser>>[]>;
-  findAttribs: (options: Record<string, any>) => Promise<IPermanentWhiteboard<IUser, ICanvas<IUser>>[]>;
-  findSharedUsersByWhiteboardId: (whiteboardId: Types.ObjectId) => Promise<IWhiteboardUserPermission<IUser>[] | null>;
+  findFull: (options: Record<string, any>) => Promise<IPermanentWhiteboard <IUserType, ICanvas<IUserType>>[]>;
+  findAttribs: (options: Record<string, any>) => Promise<IPermanentWhiteboard<IUserType, ICanvas<IUserType>>[]>;
+  findSharedUsersByWhiteboardId: (whiteboardId: Types.ObjectId) => Promise<IWhiteboardUserPermission<IUserType>[] | null>;
 }
 
 const permanentWhiteboardSchema = new Schema<IPermanentWhiteboard<Types.ObjectId, Types.ObjectId>, IPermanentWhiteboardSchema<Types.ObjectId, Types.ObjectId>>(
@@ -636,13 +723,13 @@ const permanentWhiteboardSchema = new Schema<IPermanentWhiteboard<Types.ObjectId
     },
     // -- instance methods
     methods: {
-      async populateAttribs(): Promise<IPermanentWhiteboard <IUser, ICanvas<IUser>>> {
+      async populateAttribs(): Promise<IPermanentWhiteboard <IUserType, ICanvas<IUserType>>> {
         await this.populate(WHITEBOARD_POP_FIELDS_ATTRIBS);
-        return this as unknown as IPermanentWhiteboard <IUser, ICanvas<IUser>>;
+        return this as unknown as IPermanentWhiteboard <IUserType, ICanvas<IUserType>>;
       },
-      async populateFull(): Promise<IPermanentWhiteboard <IUser, ICanvas<IUser>>> {
+      async populateFull(): Promise<IPermanentWhiteboard <IUserType, ICanvas<IUserType>>> {
         await this.populate(WHITEBOARD_POP_FIELDS_FULL);
-        return this as unknown as IPermanentWhiteboard <IUser, ICanvas<IUser>>;
+        return this as unknown as IPermanentWhiteboard <IUserType, ICanvas<IUserType>>;
       },
       toPublicView() {
         const obj = this.toObject({ virtuals: true });
@@ -654,7 +741,7 @@ const permanentWhiteboardSchema = new Schema<IPermanentWhiteboard<Types.ObjectId
 
         return ({
           ...fields,
-          user_permissions: (this as unknown as IPermanentWhiteboard <IUser, ICanvas<IUser>>)
+          user_permissions: (this as unknown as IPermanentWhiteboard <IUserType, ICanvas<IUserType>>)
             .user_permissions
             .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
             .map(perm => perm.toPublicView()),
@@ -670,10 +757,26 @@ const permanentWhiteboardSchema = new Schema<IPermanentWhiteboard<Types.ObjectId
 
         return ({
           ...fields,
-          user_permissions: (this as unknown as IPermanentWhiteboard <IUser, ICanvas<IUser>>)
+          user_permissions: (this as unknown as IPermanentWhiteboard <IUserType, ICanvas<IUserType>>)
             .user_permissions
             .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
             .map(perm => perm.toAttribView()),
+        });
+      },
+      toOwnerView() {
+        const obj = this.toObject({ virtuals: true });
+        const {
+          _id,
+          user_permissions: _user_permissions,
+          ...fields
+        } = obj;
+
+        return ({
+          ...fields,
+          user_permissions: (this as unknown as IPermanentWhiteboard <IUserType, ICanvas<IUserType>>)
+            .user_permissions
+            .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
+            .map(perm => perm.toWBOwnerView()),
         });
       }
     },
@@ -688,7 +791,7 @@ const permanentWhiteboardSchema = new Schema<IPermanentWhiteboard<Types.ObjectId
           .select(WHITEBOARD_VECTOR_FIELDS.map(field => `-${field}`).join(' '))
           .populate(WHITEBOARD_POP_FIELDS_ATTRIBS);
       },
-      async findSharedUsersByWhiteboardId(whiteboardId: Types.ObjectId): Promise<IWhiteboardUserPermission<IUser>[] | null> {
+      async findSharedUsersByWhiteboardId(whiteboardId: Types.ObjectId): Promise<IWhiteboardUserPermission<IUserType>[] | null> {
         const res = await this.findById(whiteboardId)
           .select("user_permissions")
           .then(wb => wb?.populateAttribs() || null) as IWhiteboardFull | null;
@@ -711,9 +814,9 @@ whiteboardSchema.discriminator('permanent_whiteboard', permanentWhiteboardSchema
 //
 // ============================================================================================
 export interface ITempWhiteboardSchema <UserType, CanvasType> extends Model<ITempWhiteboard<UserType, CanvasType>> {
-  findFull: (options: Record<string, any>) => Promise<ITempWhiteboard <IUser, ICanvas<IUser>>[]>;
-  findAttribs: (options: Record<string, any>) => Promise<ITempWhiteboard<IUser, ICanvas<IUser>>[]>;
-  findSharedUsersByWhiteboardId: (whiteboardId: Types.ObjectId) => Promise<IWhiteboardUserPermission<IUser>[] | null>;
+  findFull: (options: Record<string, any>) => Promise<ITempWhiteboard <IUserType, ICanvas<IUserType>>[]>;
+  findAttribs: (options: Record<string, any>) => Promise<ITempWhiteboard<IUserType, ICanvas<IUserType>>[]>;
+  findSharedUsersByWhiteboardId: (whiteboardId: Types.ObjectId) => Promise<IWhiteboardUserPermission<IUserType>[] | null>;
 }
 
 const tempWhiteboardSchema = new Schema<ITempWhiteboard<Types.ObjectId, Types.ObjectId>, ITempWhiteboardSchema<Types.ObjectId, Types.ObjectId>>(
@@ -738,13 +841,13 @@ const tempWhiteboardSchema = new Schema<ITempWhiteboard<Types.ObjectId, Types.Ob
     },
     // -- instance methods
     methods: {
-      async populateAttribs(): Promise<ITempWhiteboard <IUser, ICanvas<IUser>>> {
+      async populateAttribs(): Promise<ITempWhiteboard <IUserType, ICanvas<IUserType>>> {
         await this.populate(WHITEBOARD_POP_FIELDS_ATTRIBS);
-        return this as unknown as ITempWhiteboard <IUser, ICanvas<IUser>>;
+        return this as unknown as ITempWhiteboard <IUserType, ICanvas<IUserType>>;
       },
-      async populateFull(): Promise<ITempWhiteboard <IUser, ICanvas<IUser>>> {
+      async populateFull(): Promise<ITempWhiteboard <IUserType, ICanvas<IUserType>>> {
         await this.populate(WHITEBOARD_POP_FIELDS_FULL);
-        return this as unknown as ITempWhiteboard <IUser, ICanvas<IUser>>;
+        return this as unknown as ITempWhiteboard <IUserType, ICanvas<IUserType>>;
       },
       toPublicView() {
         const obj = this.toObject({ virtuals: true });
@@ -756,7 +859,7 @@ const tempWhiteboardSchema = new Schema<ITempWhiteboard<Types.ObjectId, Types.Ob
 
         return ({
           ...fields,
-          user_permissions: (this as unknown as ITempWhiteboard <IUser, ICanvas<IUser>>)
+          user_permissions: (this as unknown as ITempWhiteboard <IUserType, ICanvas<IUserType>>)
             .user_permissions
             .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
             .map(perm => perm.toPublicView()),
@@ -772,10 +875,26 @@ const tempWhiteboardSchema = new Schema<ITempWhiteboard<Types.ObjectId, Types.Ob
 
         return ({
           ...fields,
-          user_permissions: (this as unknown as ITempWhiteboard <IUser, ICanvas<IUser>>)
+          user_permissions: (this as unknown as ITempWhiteboard <IUserType, ICanvas<IUserType>>)
             .user_permissions
             .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
             .map(perm => perm.toAttribView()),
+        });
+      },
+      toOwnerView() {
+        const obj = this.toObject({ virtuals: true });
+        const {
+          _id,
+          user_permissions: _user_permissions,
+          ...fields
+        } = obj;
+
+        return ({
+          ...fields,
+          user_permissions: (this as unknown as ITempWhiteboard <IUserType, ICanvas<IUserType>>)
+            .user_permissions
+            .filter(perm => ((perm.type !== 'user') || ((!! perm.user) && (!! perm.user.id))))
+            .map(perm => perm.toWBOwnerView()),
         });
       }
     },
@@ -790,7 +909,7 @@ const tempWhiteboardSchema = new Schema<ITempWhiteboard<Types.ObjectId, Types.Ob
           .select(WHITEBOARD_VECTOR_FIELDS.map(field => `-${field}`).join(' '))
           .populate(WHITEBOARD_POP_FIELDS_ATTRIBS);
       },
-      async findSharedUsersByWhiteboardId(whiteboardId: Types.ObjectId): Promise<IWhiteboardUserPermission<IUser>[] | null> {
+      async findSharedUsersByWhiteboardId(whiteboardId: Types.ObjectId): Promise<IWhiteboardUserPermission<IUserType>[] | null> {
         const res = await this.findById(whiteboardId)
           .select("user_permissions")
           .then(wb => wb?.populateAttribs() || null) as IWhiteboardFull | null;
@@ -824,17 +943,17 @@ sharedUsersArraySchema?.discriminator('user', new Schema<IWhiteboardUserPermissi
     },
     // -- instance methods
     methods: {
-      async populateAttribs(): Promise<IWhiteboardUserPermissionById<IUser>> {
+      async populateAttribs(): Promise<IWhiteboardUserPermissionById<IUserType>> {
         return await this.populate([
           'user',
         ]);
       },
-      async populateFull(): Promise<IWhiteboardUserPermissionById<IUser>> {
+      async populateFull(): Promise<IWhiteboardUserPermissionById<IUserType>> {
         return await this.populate([
           'user',
         ]);
       },
-      toAttribView(): IWhiteboardUserPermissionById<IUserAttribView> {
+      toAttribView(): IWhiteboardUserPermissionById<IUserTypeAttribView> {
         const obj = this.toObject({ virtuals: true });
         const {
           user: _user,
@@ -843,10 +962,10 @@ sharedUsersArraySchema?.discriminator('user', new Schema<IWhiteboardUserPermissi
 
         return ({
           ...fields,
-          user: (this as unknown as IWhiteboardUserPermissionById<IUser>).user.toAttribView(),
+          user: (this as unknown as IWhiteboardUserPermissionById<IUserType>).user.toAttribView(),
         });
       },
-      toPublicView(): IWhiteboardUserPermissionById<IUserPublicView> {
+      toPublicView(): IWhiteboardUserPermissionById<IUserTypePublicView> {
         const obj = this.toObject({ virtuals: true });
         const {
           user: _user,
@@ -855,7 +974,19 @@ sharedUsersArraySchema?.discriminator('user', new Schema<IWhiteboardUserPermissi
 
         return ({
           ...fields,
-          user: (this as unknown as IWhiteboardUserPermissionById<IUser>).user.toPublicView(),
+          user: (this as unknown as IWhiteboardUserPermissionById<IUserType>).user.toPublicView(),
+        });
+      },
+      toWBOwnerView(): IWhiteboardUserPermissionById<IUserTypePublicView> {
+        const obj = this.toObject({ virtuals: true });
+        const {
+          user: _user,
+          ...fields
+        } = obj;
+
+        return ({
+          ...fields,
+          user: (this as unknown as IWhiteboardUserPermissionById<IUserType>).user.toWBOwnerView(),
         });
       },
     },
@@ -886,6 +1017,9 @@ sharedUsersArraySchema?.discriminator('email', new Schema<IWhiteboardUserPermiss
         return this.toObject({ virtuals: true });
       },
       toPublicView(): IWhiteboardUserPermissionByEmail {
+        return this.toObject({ virtuals: true });
+      },
+      toWBOwnerView(): IWhiteboardUserPermissionByEmail {
         return this.toObject({ virtuals: true });
       },
     },

--- a/RestAPI/src/services/loginService.ts
+++ b/RestAPI/src/services/loginService.ts
@@ -12,7 +12,7 @@ import {
 // -- local imports
 import {
   isIPermanentUser,
-  ITempUserPublicView,
+  ITempUser,
   type IUserType,
   User,
 } from '../models/User';
@@ -87,7 +87,7 @@ export type CreateTempUserRes =
   | { 
       status: 'ok'; 
       payload: { 
-        user: ITempUserPublicView, 
+        user: ITempUser, 
         accessToken: string, 
         refreshToken: string 
       }; 
@@ -167,7 +167,7 @@ export const tempUserLoginService = async (): Promise<CreateTempUserRes> => {
     return {
       status: 'ok',
       payload: {
-        user: saved.toPublicView() as ITempUserPublicView,
+        user: saved as ITempUser,
         accessToken,
         refreshToken
       }  

--- a/RestAPI/src/services/userService.ts
+++ b/RestAPI/src/services/userService.ts
@@ -14,7 +14,6 @@ import {
   User,
   PatchPermanentUserData,
   type IUserPublicView,
-  type IPermanentUserPublicView,
   type IUserType,
   IPermanentUser,
 } from "../models/User";
@@ -55,7 +54,7 @@ export const getUserById = async (userId: Types.ObjectId): Promise<GetUserByIdRe
 
 export interface PatchPermanentUserOkResult {
   type: 'ok';
-  data: IPermanentUserPublicView;
+  data: IPermanentUser;
 }
 
 export interface PatchPermanentUserErrorResult {
@@ -65,7 +64,10 @@ export interface PatchPermanentUserErrorResult {
 
 export type PatchPermanentUserResult = PatchPermanentUserOkResult | PatchPermanentUserErrorResult;
 
-export const patchUser = async (user: IPermanentUser, patchData: PatchPermanentUserData): Promise<PatchPermanentUserResult> => {
+export const patchUser = async (
+  user: IPermanentUser,
+  patchData: PatchPermanentUserData
+): Promise<PatchPermanentUserResult> => {
   try {
     const patchDataLocal = { ...patchData };
     const passwordHashed = patchDataLocal.password ? 
@@ -85,7 +87,7 @@ export const patchUser = async (user: IPermanentUser, patchData: PatchPermanentU
 
     return ({
       type: 'ok',
-      data: userModified.toPublicView()
+      data: userModified,
     });
   } catch (err: any) {
     return ({

--- a/RestAPI/src/services/userService.ts
+++ b/RestAPI/src/services/userService.ts
@@ -1,5 +1,7 @@
 // -- std imports
-import { Types } from "mongoose";
+import {
+  Types,
+} from "mongoose";
 
 // -- third-party imports
 import bcrypt from "bcrypt";
@@ -13,7 +15,6 @@ import type {
 import {
   User,
   PatchPermanentUserData,
-  type IUserPublicView,
   type IUserType,
   IPermanentUser,
 } from "../models/User";
@@ -51,6 +52,41 @@ export const getUserById = async (userId: Types.ObjectId): Promise<GetUserByIdRe
     });
   }
 };// end getUser
+
+// === isUserOwnerCollaborator =================================================
+//
+// Determines whether a certain user owns a whiteboard which is shared with
+// another specified user. Important for determining whether the owning user can
+// see certain protected fields in the other user's account (namely, their email
+// address).
+//
+// =============================================================================
+export const isUserOwnerCollaborator = (
+  ownerId: Types.ObjectId,
+  collaboratorId: Types.ObjectId
+): boolean => {
+  // -- Query for at least one whiteboard for which both users have some
+  // permission
+  const res = Whiteboard.findOne({
+    "user_permissions": {
+      '$all': [
+        {
+          '$elemMatch': {
+            'user': ownerId,
+            'permission': 'own',
+          }
+        },
+        {
+          '$elemMatch': {
+            'user': collaboratorId,
+          }
+        },
+      ]
+    }
+  });
+
+  return !!res;
+};// -- end areUsersCollaborators
 
 export interface PatchPermanentUserOkResult {
   type: 'ok';
@@ -97,7 +133,9 @@ export const patchUser = async (
   }
 };// -- end patchUser
 
-export const deleteUser = async (userId: Types.ObjectId): Promise<Result<IUserPublicView, string>> => {
+export const deleteUser = async (
+  userId: Types.ObjectId
+): Promise<Result<IUserType, string>> => {
   try {
     const deletedUser = await User.findOne({ _id: userId });
 
@@ -111,7 +149,7 @@ export const deleteUser = async (userId: Types.ObjectId): Promise<Result<IUserPu
 
       return ({
         result: 'ok',
-        data: deletedUser.toPublicView()
+        data: deletedUser,
       });
     }
   } catch (err: any) {

--- a/RestAPI/src/services/whiteboardService.ts
+++ b/RestAPI/src/services/whiteboardService.ts
@@ -7,8 +7,8 @@ import {
   Whiteboard,
   Canvas,
   Shape,
+  type IWhiteboard,
   type IWhiteboardFull,
-  type IWhiteboardAttribView,
   type WhiteboardIdType,
   type IWhiteboardUserPermission,
   type IWhiteboardUserPermissionModel,
@@ -26,7 +26,7 @@ import {
 } from '../models/User';
 
 export type GetWhiteboardRes = 
-  | { status: 'ok'; whiteboard: IWhiteboardFull; }
+  | { status: 'ok'; whiteboard: IWhiteboard <IUser, ICanvas <IUser>>; }
   | { status: 'invalid_id'; }
   | { status: 'not_found'; }
   | { status: 'server_error'; message: string; }
@@ -129,7 +129,7 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
         // whiteboard
         whiteboard.set('user_permissions', sharedUsers);
         whiteboard = await whiteboard.save()
-          .then(wb => wb.populateAttribs());
+          .then(wb => wb.populateFull());
 
         if (! whiteboard) {
           throw new Error(`Whiteboard ${whiteboardId} not properly (re-)fetched`);
@@ -152,13 +152,15 @@ export const getWhiteboardById = async (whiteboardId: string): Promise<GetWhiteb
   }
 };// -- end getWhiteboardById
 
-export const getWhiteboardsByOwner = async (ownerId: Types.ObjectId): Promise<IWhiteboardAttribView[]> => {
+export const getWhiteboardsByOwner = async (
+  ownerId: Types.ObjectId
+): Promise<IWhiteboard <IUser, ICanvas <IUser>>[]> => {
   const owner = await User.findOne({
     '_id': ownerId,
   });
 
   if (! owner) {
-    return [] as IWhiteboardAttribView[];
+    return [];
   }
 
   const userIdQueries = (owner.kind === 'permanent') ?
@@ -179,7 +181,7 @@ export const getWhiteboardsByOwner = async (ownerId: Types.ObjectId): Promise<IW
     },
   };
 
-  return await Whiteboard.findAttribs(query) as IWhiteboardAttribView[];
+  return await Whiteboard.findFull(query) as IWhiteboard <IUser, ICanvas <IUser>>[];
 };// -- end getWhiteboardsByOwner
 
 export type GetSharedUsersByWhiteboardRes =

--- a/RestAPI/tests/whiteboards.test.ts
+++ b/RestAPI/tests/whiteboards.test.ts
@@ -55,14 +55,13 @@ afterAll(disconnectFromDatabase);
 // id, email, and username, but exclude the hashed password.
 //
 // =============================================================================
-const validateUser = (user: IUser, fieldValues: {} | any[]) => {
+const validateUser = (user: IUser, view: 'owner' | 'public', fieldValues: {} | any[]) => {
   expect(user).toHaveProperty('id');
   expect(user).toHaveProperty('username');
 
-  if (user.kind === 'permanent') {
+  if (view === 'owner' && user.kind === 'permanent') {
     expect(user).toHaveProperty('email');
-  }
-  else if (user.kind === 'temp') {
+  } else if (user.kind === 'temp') {
     expect(user).toHaveProperty("createdAt");
   }
 
@@ -75,6 +74,7 @@ const validateUser = (user: IUser, fieldValues: {} | any[]) => {
 
 const validateWhiteboardAttribView = (
   whiteboard: IWhiteboardAttribView,
+  view: 'owner' | 'public',
   fieldValues: Record<string, any>
 ) => {
   expect(whiteboard).toHaveProperty('id');
@@ -105,7 +105,7 @@ const validateWhiteboardAttribView = (
     switch (perm.type) {
       case 'user':
         expect(perm).toHaveProperty('user');
-        validateUser(perm.user as unknown as IUser, {});
+        validateUser(perm.user as unknown as IUser, view, {});
         break;
       case 'email':
         expect(perm).toHaveProperty('email');
@@ -177,7 +177,7 @@ describe("Whiteboards API", () => {
       .send()
       .expect(200);
 
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'owner', {
       user_permissions: [
         {
           type: 'user',
@@ -233,7 +233,7 @@ describe("Whiteboards API", () => {
     ];
 
     for (const i_wb in whiteboardsExpect) {
-      validateWhiteboardAttribView(wbRes.body[i_wb], whiteboardsExpect[i_wb]);
+      validateWhiteboardAttribView(wbRes.body[i_wb], 'owner', whiteboardsExpect[i_wb]);
     }// -- end for i_wb
   });
 
@@ -281,7 +281,7 @@ describe("Whiteboards API", () => {
       .expect(201);
 
     // Verify response body
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'owner', {
       name: "Alice's Whiteboard",
       kind: "permanent_whiteboard"
     });
@@ -309,7 +309,7 @@ describe("Whiteboards API", () => {
       })
       .expect(201);
 
-    validateWhiteboardAttribView(res.body, {
+    validateWhiteboardAttribView(res.body, 'owner', {
       name: "Temporary Session",
       kind: "temp_whiteboard"
     });
@@ -384,7 +384,7 @@ describe("Whiteboards API", () => {
       .expect(201);
 
     // Verify response body
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'owner', {
       name: "Alice's Shared Whiteboard",
       user_permissions: collaboratorPermissionsExpect,
     });
@@ -438,7 +438,7 @@ describe("Whiteboards API", () => {
       })
       .expect(200);
 
-      validateWhiteboardAttribView(wbRes.body, {
+      validateWhiteboardAttribView(wbRes.body, 'owner', {
         user_permissions: [
           {
             type: 'user',
@@ -647,7 +647,7 @@ describe("Whiteboards API", () => {
       })
       .expect(200);
 
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'owner', {
       user_permissions: userPermissionsExpect,
     });
   });
@@ -729,7 +729,7 @@ describe("Whiteboards API", () => {
       })
       .expect(200);
 
-    validateWhiteboardAttribView(wbRes.body, {});
+    validateWhiteboardAttribView(wbRes.body, 'owner', {});
 
     // -- shared users
     expect(wbRes.body.user_permissions.length).toBe(userPermissionsExpect.length);
@@ -817,7 +817,7 @@ describe("Whiteboards API", () => {
       .send()
       .expect(200);
 
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'owner', {
       user_permissions: [
         {
           type: 'user',
@@ -1131,7 +1131,7 @@ describe("Whiteboards API", () => {
       .send()
       .expect(200);
 
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'public', {
       name: "Project Public",
       kind: "permanent_whiteboard",
     });
@@ -1163,7 +1163,7 @@ describe("Whiteboards API", () => {
       .send()
       .expect(200);
 
-    validateWhiteboardAttribView(wbRes.body, {
+    validateWhiteboardAttribView(wbRes.body, 'public', {
       name: "Project Public",
       kind: "permanent_whiteboard",
     });


### PR DESCRIPTION
Prevent users' email addresses from being revealed to unauthorized users. Email addresses should only be revealed if both users are collaborating on a whiteboard together.

- **patchUser returns a full IPermanentUser object in its payload instead of a public view.**
- **Created UserTypeOwnerView to hide users' email addresses from other users' rest API calls, unless the querying user owns a whiteboard in which the user is a collaborator.**
