### PR TITLE
Remove undefined returns for handlers

### DIFF
--- a/Frontend/src/dispatchers/editableObjectProps.ts
+++ b/Frontend/src/dispatchers/editableObjectProps.ts
@@ -19,7 +19,7 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   handleUpdateShape: (updatedShape: ShapeType) => void
 ): EditableObjectProps => {
   const handleMouseOver = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    if (!isDraggable) return;
+    if (! isDraggable) return;
 
     ev.cancelBubble = true;
 
@@ -31,7 +31,7 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleMouseOut = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    if (!isDraggable) return;
+    if (! isDraggable) return;
     
     ev.cancelBubble = true;
 
@@ -43,7 +43,7 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleMouseDown = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    if (!isDraggable) return;
+    if (! isDraggable) return;
 
     ev.cancelBubble = true;
 
@@ -55,7 +55,7 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleMouseUp = (ev: Konva.KonvaEventObject<MouseEvent>) => {
-    if (!isDraggable) return;
+    if (! isDraggable) return;
 
     ev.cancelBubble = true;
 
@@ -67,7 +67,7 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleDragEnd = (ev: Konva.KonvaEventObject<DragEvent>) => {
-    if (!isDraggable) return;
+    if (! isDraggable) return;
 
     ev.cancelBubble = true;
 
@@ -79,7 +79,7 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
 
   // transform the targetted box locally in real time without broadcasting
   const handleTransform = (ev: Konva.KonvaEventObject<Event>) => {
-    if (!isDraggable) return;
+    if (! isDraggable) return;
     
     ev.cancelBubble = true;
 

--- a/Frontend/src/dispatchers/editableObjectProps.ts
+++ b/Frontend/src/dispatchers/editableObjectProps.ts
@@ -19,6 +19,8 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   handleUpdateShape: (updatedShape: ShapeType) => void
 ): EditableObjectProps => {
   const handleMouseOver = (ev: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!isDraggable) return;
+
     ev.cancelBubble = true;
 
     const stage = ev.target.getStage();
@@ -29,6 +31,8 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleMouseOut = (ev: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!isDraggable) return;
+    
     ev.cancelBubble = true;
 
     const stage = ev.target.getStage();
@@ -39,6 +43,8 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleMouseDown = (ev: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!isDraggable) return;
+
     ev.cancelBubble = true;
 
     const stage = ev.target.getStage();
@@ -49,6 +55,8 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleMouseUp = (ev: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!isDraggable) return;
+
     ev.cancelBubble = true;
 
     const stage = ev.target.getStage();
@@ -59,6 +67,8 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   const handleDragEnd = (ev: Konva.KonvaEventObject<DragEvent>) => {
+    if (!isDraggable) return;
+
     ev.cancelBubble = true;
 
     const x = ev.target.x();
@@ -69,6 +79,8 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
 
   // transform the targetted box locally in real time without broadcasting
   const handleTransform = (ev: Konva.KonvaEventObject<Event>) => {
+    if (!isDraggable) return;
+    
     ev.cancelBubble = true;
 
     const node = ev.target;
@@ -86,12 +98,12 @@ const editableObjectProps = <ShapeType extends CanvasObjectModel> (
   };
 
   return ({
-    onMouseOver: isDraggable && handleMouseOver || undefined,
-    onMouseOut: isDraggable && handleMouseOut || undefined,
-    onMouseDown: isDraggable && handleMouseDown || undefined,
-    onMouseUp: isDraggable && handleMouseUp || undefined,
-    onDragEnd: isDraggable && handleDragEnd || undefined,
-    onTransform: isDraggable && handleTransform || undefined,
+    onMouseOver: handleMouseOver,
+    onMouseOut: handleMouseOut,
+    onMouseDown: handleMouseDown,
+    onMouseUp: handleMouseUp,
+    onDragEnd: handleDragEnd,
+    onTransform: handleTransform,
   });
 };
 


### PR DESCRIPTION
The EditableObjectProps component was returning undefined handlers when the current tool wasn't 'hand' and in turn stripping off the snapping hook's dragend listener. This faulty behavior can be tested by switching from any other tool to the hand tool then dragging a textbox around and releasing when grid lines appear. The solution implemented in this pr is to make editableObjectProps always return handler functions (gating the isDraggable check inside them) instead of conditionally returning undefined, so react-konva only removes its own handler and the imperative snapping listeners survive.