### PR TITLE
Refactor/canvas snap lines

### DIFF
--- a/Frontend/src/app.config.ts
+++ b/Frontend/src/app.config.ts
@@ -15,6 +15,10 @@ export const CURRENT_EDITOR_NUM_MILLIS = 5000;
 // shouldn't appear in exported images.
 export const KONVA_NODE_UI_ONLY_KEY = 'is_ui_element';
 
+// -- Key used to identify the Konva group that renders a canvas, so nodes can
+// locate their containing canvas within the stage.
+export const KONVA_NODE_CANVAS_KEY = 'canvas-group';
+
 // -- Color used to indicate the user's client when interacting with objects in
 // the whiteboard (i.e. selected shapes, canvases).
 export const USER_CLIENT_COLOR = '#44ff44';

--- a/Frontend/src/hooks/useSnapping.tsx
+++ b/Frontend/src/hooks/useSnapping.tsx
@@ -1,9 +1,14 @@
 import Konva from "konva";
 
-import React, { 
+import React, {
   useEffect,
-  // useRef 
+  // useRef
 } from "react";
+
+import {
+  KONVA_NODE_CANVAS_KEY,
+  KONVA_NODE_UI_ONLY_KEY,
+} from "@/app.config";
 
 const GUIDELINE_OFFSET = 5;
 
@@ -96,15 +101,22 @@ export class SnappingMonitor {
   }
 
   getLineGuideStops(skipShape: SnapObject): LineGuideStopType {
-    const stage = skipShape.getStage();
-    if (!stage) return { vertical: [], horizontal: [] };
+    const canvasGroup = skipShape.findAncestor(`.${KONVA_NODE_CANVAS_KEY}`) as Konva.Group | null;
+    if (!canvasGroup) return { vertical: [], horizontal: [] };
 
-    // we can snap to stage borders and the center of the stage
-    const vertical = [0, stage.width() / 2, stage.width()];
-    const horizontal = [0, stage.height() / 2, stage.height()];
+    // we can snap to the containing canvas's borders and center, in absolute
+    // coordinates to match the shapes' client rects
+    const transform = canvasGroup.getAbsoluteTransform();
+    const topLeft = transform.point({ x: 0, y: 0 });
+    const bottomRight = transform.point({
+      x: canvasGroup.width(),
+      y: canvasGroup.height()
+    });
+    const vertical = [topLeft.x, (topLeft.x + bottomRight.x) / 2, bottomRight.x];
+    const horizontal = [topLeft.y, (topLeft.y + bottomRight.y) / 2, bottomRight.y];
 
-    // and we snap over edges and center of each object on the canvas
-    stage.find("Shape").forEach((guideItem) => {
+    // and we snap over edges and center of each object on the same canvas
+    canvasGroup.find("Shape").forEach((guideItem) => {
       if (guideItem.getParent() instanceof Konva.Transformer) {
         return;
       }
@@ -115,6 +127,15 @@ export class SnappingMonitor {
       // (e.g. a vector's endpoint anchors and selection highlight), so an
       // object never snaps to its own parts.
       if (guideItem.getParent() === skipShape.getParent()) {
+        return;
+      }
+      // Skip objects inside nested child canvases; their nearest canvas
+      // ancestor is the child canvas, not this one.
+      if (guideItem.findAncestor(`.${KONVA_NODE_CANVAS_KEY}`) !== canvasGroup) {
+        return;
+      }
+      // Skip UI-only elements (canvas border, editor label).
+      if (guideItem.findAncestor(`.${KONVA_NODE_UI_ONLY_KEY}`)) {
         return;
       }
       const box = guideItem.getClientRect();

--- a/Frontend/src/pages/Whiteboard/Canvas.tsx
+++ b/Frontend/src/pages/Whiteboard/Canvas.tsx
@@ -31,6 +31,7 @@ import {
 
 // -- local imports
 import {
+  KONVA_NODE_CANVAS_KEY,
   KONVA_NODE_UI_ONLY_KEY,
 } from '@/app.config';
 
@@ -520,6 +521,7 @@ const Canvas = ({
   return (
     <Group
       ref={groupRef}
+      name={KONVA_NODE_CANVAS_KEY}
       x={originX}
       y={originY}
       width={width}


### PR DESCRIPTION
useSnapping now gathers the grid lines from shapes only within the selected object's canvas. getLineGuideStops first defines the current canvas by locating the nearest ancestor with the newly-added canvas key constant and adds guides for the canvas's center and end lines. Then it goes through each child shape and adds the shape to the guidelines unless the shape is a canvas itself or within a child canvas.