### PR TITLE
Feature: multi select

### DIFF
--- a/Frontend/src/app.config.ts
+++ b/Frontend/src/app.config.ts
@@ -52,7 +52,7 @@ export const WB_CARD_COLLABORATORS_DISPLAY_LIMIT = 3;
 export const MAX_TITLE_LENGTH = 64;
 
 // -- Name of current copied canvas object in localStorage
-export const LS_KEY_COPIED_CANVAS_OBJECT = 'copied_canvas_object';
+export const LS_KEY_COPIED_CANVAS_OBJECTS = 'copied_canvas_objects';
 
 // -- Default (starting) zoom level of the whiteboard editor
 export const DEFAULT_WB_ZOOM = 1.0;

--- a/Frontend/src/components/EditableShape.tsx
+++ b/Frontend/src/components/EditableShape.tsx
@@ -24,6 +24,7 @@ import {
 // Local imports
 import {
   type RootState,
+  store,
 } from '@/store';
 
 import {
@@ -33,6 +34,10 @@ import {
 import {
   selectSelectorByCanvasObject,
 } from '@/store/activeUsers/activeUsersSelectors';
+
+import {
+  selectSelectedCanvasObjectsByWhiteboard,
+} from '@/store/canvasObjects/canvasObjectsSelectors';
 
 import {
   selectUserHasAccessToCanvas,
@@ -52,6 +57,8 @@ import {
 } from "@/types/CanvasObjectModel";
 
 import editableObjectProps from "@/dispatchers/editableObjectProps";
+
+import WhiteboardContext from '@/context/WhiteboardContext';
 
 import {
   ClientMessengerContext,
@@ -101,6 +108,16 @@ const EditableShape = <ShapeType extends ShapeModel> ({
     clientMessenger,
   } = clientMessengerContext;
 
+  const whiteboardContext = useContext(WhiteboardContext);
+
+  if (! whiteboardContext) {
+    throw new Error('No WhiteboardContext provided');
+  }
+
+  const {
+    whiteboardId,
+  } = whiteboardContext;
+
   const {
     user,
   } = useUser();
@@ -147,19 +164,32 @@ const EditableShape = <ShapeType extends ShapeModel> ({
     trRef.current.nodes(editor ? [shapeRef.current] : []);
   }, [editor]);
 
-  const handleSelect = useCallback(
+  const handleSingleSelect = useCallback(
     (ev: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
       ev.cancelBubble = true;
 
-      if (! editor) {
+      if (clientMessenger && (! editor)) {
+        const currState = store.getState();
+        const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
+          currState, whiteboardId, clientId
+        );
+
+        // -- Unselect any previously selected objects
+        if (selectedCanvasObjects.length > 0) {
+          clientMessenger.sendUnselectedCanvasObjects({
+            type: 'unselected_canvas_objects',
+            canvasObjectIds: selectedCanvasObjects,
+          });
+        }
+
         // -- Identify the current user as the current selector
-        clientMessenger?.sendSelectedCanvasObject({
-          type: 'selected_canvas_object',
-          canvasObjectId: id,
+        clientMessenger.sendSelectedCanvasObjects({
+          type: 'selected_canvas_objects',
+          canvasObjectIds: [id],
         });
       }
     },
-    [id, clientMessenger, editor]
+    [id, whiteboardId, clientId, clientMessenger, editor]
   );
 
   // Override onDragEnd to reselect at end
@@ -179,7 +209,7 @@ const EditableShape = <ShapeType extends ShapeModel> ({
 
   const shapeEditableProps = {
     ...editableProps,
-    onDragStart: handleSelect,
+    onDragStart: handleSingleSelect,
     onDragEnd: shapeOnDragEnd,
   };
 
@@ -189,8 +219,8 @@ const EditableShape = <ShapeType extends ShapeModel> ({
         id,
         ref: shapeRef,
         draggable: isDraggable,
-        onClick: handleSelect,
-        onTap: handleSelect,
+        onClick: handleSingleSelect,
+        onTap: handleSingleSelect,
         onTransformEnd,
         ...shapeEditableProps,
       })}

--- a/Frontend/src/components/EditableShape.tsx
+++ b/Frontend/src/components/EditableShape.tsx
@@ -213,7 +213,7 @@ const EditableShape = <ShapeType extends ShapeModel> ({
         );
 
         // -- Control key signals unselect target
-        if (e.evt.ctrlKey) {
+        if (e.evt.ctrlKey || e.evt.metaKey) {
           if (editor?.clientId === clientId) {
             // -- Identify the current user as the current selector
             clientMessenger.sendUnselectedCanvasObjects({

--- a/Frontend/src/components/EditableShape.tsx
+++ b/Frontend/src/components/EditableShape.tsx
@@ -165,28 +165,42 @@ const EditableShape = <ShapeType extends ShapeModel> ({
   }, [editor]);
 
   const handleSingleSelect = useCallback(
-    (ev: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
-      ev.cancelBubble = true;
+    (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+      e.cancelBubble = true;
 
-      if (clientMessenger && (! editor)) {
+      if (clientMessenger) {
         const currState = store.getState();
         const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
           currState, whiteboardId, clientId
         );
 
-        // -- Unselect any previously selected objects
-        if (selectedCanvasObjects.length > 0) {
-          clientMessenger.sendUnselectedCanvasObjects({
-            type: 'unselected_canvas_objects',
-            canvasObjectIds: selectedCanvasObjects,
+        // -- Control key signals unselect target
+        if (e.evt.ctrlKey) {
+          if (editor?.clientId === clientId) {
+            // -- Identify the current user as the current selector
+            clientMessenger.sendUnselectedCanvasObjects({
+              type: 'unselected_canvas_objects',
+              canvasObjectIds: [id],
+            });
+          }
+        } else if (! editor) {
+          // -- Shift key indicates multi select
+          if (! e.evt.shiftKey) {
+            // -- Unselect any previously selected objects
+            if (selectedCanvasObjects.length > 0) {
+              clientMessenger.sendUnselectedCanvasObjects({
+                type: 'unselected_canvas_objects',
+                canvasObjectIds: selectedCanvasObjects,
+              });
+            }
+          }
+
+          // -- Identify the current user as the current selector
+          clientMessenger.sendSelectedCanvasObjects({
+            type: 'selected_canvas_objects',
+            canvasObjectIds: [id],
           });
         }
-
-        // -- Identify the current user as the current selector
-        clientMessenger.sendSelectedCanvasObjects({
-          type: 'selected_canvas_objects',
-          canvasObjectIds: [id],
-        });
       }
     },
     [id, whiteboardId, clientId, clientMessenger, editor]

--- a/Frontend/src/components/EditableShape.tsx
+++ b/Frontend/src/components/EditableShape.tsx
@@ -36,16 +36,22 @@ import {
 } from '@/store/activeUsers/activeUsersSelectors';
 
 import {
+  selectCanvasObjectById,
   selectSelectedCanvasObjectsByWhiteboard,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
 import {
+  selectSelectedCanvasByWhiteboard,
   selectUserHasAccessToCanvas,
 } from '@/store/canvases/canvasesSelectors';
 
 import type { 
   EditableObjectProps 
 } from "@/dispatchers/editableObjectProps";
+
+import {
+  type EventCoords,
+} from '@/types/EventCoords';
 
 import {
   type CanvasIdType,
@@ -116,6 +122,8 @@ const EditableShape = <ShapeType extends ShapeModel> ({
 
   const {
     whiteboardId,
+    canvasObjectRefsByIdRef,
+    selectedObjectRefsByIdRef,
   } = whiteboardContext;
 
   const {
@@ -131,6 +139,10 @@ const EditableShape = <ShapeType extends ShapeModel> ({
     lodash.isEqual
   );
 
+  if (! clientId) {
+    throw new Error('No clientId provided');
+  }
+
   const editor = useSelector(
     (state: RootState) => selectSelectorByCanvasObject(state, id),
     lodash.isEqual
@@ -145,6 +157,18 @@ const EditableShape = <ShapeType extends ShapeModel> ({
 
   useSnapping(shapeRef, snappingMonitor, trRef);
 
+  // -- Register canvas object ref
+  useEffect(
+    () => {
+      canvasObjectRefsByIdRef.current[id] = shapeRef;
+
+      return () => {
+        delete canvasObjectRefsByIdRef.current[id];
+      };
+    },
+    [id, canvasObjectRefsByIdRef]
+  );
+
   const anchorDragBoundFunc = useCallback(
     (oldPos: Konva.Vector2d, newPos: Konva.Vector2d) =>
       trRef.current
@@ -157,6 +181,24 @@ const EditableShape = <ShapeType extends ShapeModel> ({
     () => userHasCanvasAccess && (editor?.clientId === clientId),
     [userHasCanvasAccess, editor, clientId]
   );// -- end const isSelected
+
+  // -- Register/unregister shape in selected objects ref
+  useEffect(
+    () => {
+      if (isSelected) {
+        selectedObjectRefsByIdRef.current[id] = shapeRef;
+      } else if (id in selectedObjectRefsByIdRef.current) {
+        delete selectedObjectRefsByIdRef.current[id];
+      }
+
+      return () => {
+        if (id in selectedObjectRefsByIdRef.current) {
+          delete selectedObjectRefsByIdRef.current[id];
+        }
+      };
+    },
+    [id, isSelected, selectedObjectRefsByIdRef]
+  );
 
   // Transformer attach/detach
   useEffect(() => {
@@ -204,27 +246,116 @@ const EditableShape = <ShapeType extends ShapeModel> ({
       }
     },
     [id, whiteboardId, clientId, clientMessenger, editor]
-  );
+  );// -- end handleSingleSelect
 
   // Override onDragEnd to reselect at end
   const editableProps = editableObjectProps(shapeModel, isDraggable, onUpdateObject);
-  const {
-    onDragEnd,
-  } = editableProps;
 
-  const shapeOnDragEnd = useCallback(
-    (ev: Konva.KonvaEventObject<DragEvent>) => {
-      if (onDragEnd) {
-        onDragEnd(ev);
-      }
+  // -- Record initial x and y coordinates on drag start to calculate total
+  // movement on drag end.
+  const dragStartCoordsRef = useRef<EventCoords>({
+    x: shapeModel.x,
+    y: shapeModel.y,
+  });
+
+  const handleDragStart = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      handleSingleSelect(e);
+      dragStartCoordsRef.current.x = e.evt.x;
+      dragStartCoordsRef.current.y = e.evt.y;
     },
-    [onDragEnd]
-  );
+    [handleSingleSelect, dragStartCoordsRef]
+  );// -- end handleDragStart
+
+  const handleDragEnd = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      if (! clientMessenger) return;
+
+      const currState : RootState = store.getState();
+      const canvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
+      if (! canvasId) return;
+
+      const {
+        x: prevX,
+        y: prevY,
+      } = dragStartCoordsRef.current;
+      const currX = e.currentTarget.x();
+      const currY = e.currentTarget.y();
+      const moveX = currX - prevX;
+      const moveY = currY - prevY;
+
+      const selectedObjectRefsById = selectedObjectRefsByIdRef.current;
+      const updatedObjects = Object.fromEntries(Object.entries(selectedObjectRefsById).map(
+        ([objId, objRef]) => {
+          if (! objRef.current) return null;
+
+          const prevObj = selectCanvasObjectById(currState, objId);
+          if (! prevObj) return null;
+
+          switch (prevObj.type) {
+            case 'rect':
+            case 'ellipse':
+            case 'text':
+            {
+              const objUpdate = ({
+                ...prevObj,
+                x: prevObj.x + moveX,
+                y: prevObj.y + moveY,
+              });
+
+              return [objId, objUpdate];
+            }
+            case 'vector':
+            {
+              const updatedPoints = prevObj.points.map((val, i) => {
+                if (i % 2 === 0) {
+                  return val + moveX;
+                } else {
+                  return val + moveY;
+                }
+              });
+              const objUpdate = ({
+                ...prevObj,
+                points: updatedPoints,
+              });
+
+              return [objId, objUpdate];
+            }
+            default:
+              throw new Error('ERROR: unrecognized object type');
+          }// -- end switch (prevObj.type)
+        }
+      ).filter(entry => !! entry));
+
+      clientMessenger.sendUpdateCanvasObjects({
+        type: 'update_canvas_objects',
+        canvasId,
+        canvasObjects: updatedObjects,
+      });
+    },
+    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef]
+  );// -- end handleDragEnd
+
+  const handleDragMove = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      for (const [objId, objRef] of Object.entries(selectedObjectRefsByIdRef.current)) {
+        if (objId === id) continue;
+        if (! objRef.current) continue;
+
+        const obj = objRef.current;
+
+        obj.x(obj.x() + e.evt.movementX);
+        obj.y(obj.y() + e.evt.movementY);
+      }// -- end 
+    },
+    [id, selectedObjectRefsByIdRef]
+  );// -- end handleDragMove
 
   const shapeEditableProps = {
     ...editableProps,
-    onDragStart: handleSingleSelect,
-    onDragEnd: shapeOnDragEnd,
+    onDragStart: handleDragStart,
+    onDragMove: handleDragMove,
+    onDragEnd: handleDragEnd,
   };
 
   return (

--- a/Frontend/src/components/EditableShape.tsx
+++ b/Frontend/src/components/EditableShape.tsx
@@ -50,10 +50,6 @@ import type {
 } from "@/dispatchers/editableObjectProps";
 
 import {
-  type EventCoords,
-} from '@/types/EventCoords';
-
-import {
   type CanvasIdType,
 } from '@/types/WebSocketProtocol';
 
@@ -251,22 +247,6 @@ const EditableShape = <ShapeType extends ShapeModel> ({
   // Override onDragEnd to reselect at end
   const editableProps = editableObjectProps(shapeModel, isDraggable, onUpdateObject);
 
-  // -- Record initial x and y coordinates on drag start to calculate total
-  // movement on drag end.
-  const dragStartCoordsRef = useRef<EventCoords>({
-    x: shapeModel.x,
-    y: shapeModel.y,
-  });
-
-  const handleDragStart = useCallback(
-    (e: Konva.KonvaEventObject<DragEvent>) => {
-      handleSingleSelect(e);
-      dragStartCoordsRef.current.x = e.evt.x;
-      dragStartCoordsRef.current.y = e.evt.y;
-    },
-    [handleSingleSelect, dragStartCoordsRef]
-  );// -- end handleDragStart
-
   const handleDragEnd = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>) => {
       if (! clientMessenger) return;
@@ -275,14 +255,8 @@ const EditableShape = <ShapeType extends ShapeModel> ({
       const canvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
       if (! canvasId) return;
 
-      const {
-        x: prevX,
-        y: prevY,
-      } = dragStartCoordsRef.current;
-      const currX = e.currentTarget.x();
-      const currY = e.currentTarget.y();
-      const moveX = currX - prevX;
-      const moveY = currY - prevY;
+      const translateX = e.currentTarget.x() - shapeModel.x;
+      const translateY = e.currentTarget.y() - shapeModel.y;
 
       const selectedObjectRefsById = selectedObjectRefsByIdRef.current;
       const updatedObjects = Object.fromEntries(Object.entries(selectedObjectRefsById).map(
@@ -299,24 +273,23 @@ const EditableShape = <ShapeType extends ShapeModel> ({
             {
               const objUpdate = ({
                 ...prevObj,
-                x: prevObj.x + moveX,
-                y: prevObj.y + moveY,
+                x: prevObj.x + translateX,
+                y: prevObj.y + translateY,
               });
 
               return [objId, objUpdate];
             }
             case 'vector':
             {
-              const updatedPoints = prevObj.points.map((val, i) => {
-                if (i % 2 === 0) {
-                  return val + moveX;
-                } else {
-                  return val + moveY;
-                }
-              });
               const objUpdate = ({
                 ...prevObj,
-                points: updatedPoints,
+                points: prevObj.points.map((val, i) => {
+                  if (i % 2 === 0) {
+                    return val + translateX;
+                  } else {
+                    return val + translateY;
+                  }
+                }),
               });
 
               return [objId, objUpdate];
@@ -333,27 +306,56 @@ const EditableShape = <ShapeType extends ShapeModel> ({
         canvasObjects: updatedObjects,
       });
     },
-    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef]
+    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef, shapeModel.x, shapeModel.y]
   );// -- end handleDragEnd
 
   const handleDragMove = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>) => {
+      const currState : RootState = store.getState();
+      const translateX = e.currentTarget.x() - shapeModel.x;
+      const translateY = e.currentTarget.y() - shapeModel.y;
+
       for (const [objId, objRef] of Object.entries(selectedObjectRefsByIdRef.current)) {
         if (objId === id) continue;
         if (! objRef.current) continue;
 
         const obj = objRef.current;
+        const prevObj = selectCanvasObjectById(currState, objId);
+        if (! prevObj) continue;
 
-        obj.x(obj.x() + e.evt.movementX);
-        obj.y(obj.y() + e.evt.movementY);
+        switch (prevObj.type) {
+          case 'rect':
+          case 'ellipse':
+          case 'text':
+          {
+            obj.x(prevObj.x + translateX);
+            obj.y(prevObj.y + translateY);
+          }
+          break;
+          case 'vector':
+          {
+            const vec = obj as Konva.Line;
+            const pointsUpdate = prevObj.points.map((val, i) => {
+              if (i % 2 === 0) {
+                return val + translateX;
+              } else {
+                return val + translateY;
+              }
+            });
+
+            vec.points(pointsUpdate);
+          }
+          break;
+          default:
+            throw new Error('Unrecognized object type');
+        }// -- end switch (prevObj.type)
       }// -- end 
     },
-    [id, selectedObjectRefsByIdRef]
+    [id, selectedObjectRefsByIdRef, shapeModel.x, shapeModel.y]
   );// -- end handleDragMove
 
   const shapeEditableProps = {
     ...editableProps,
-    onDragStart: handleDragStart,
     onDragMove: handleDragMove,
     onDragEnd: handleDragEnd,
   };
@@ -365,6 +367,7 @@ const EditableShape = <ShapeType extends ShapeModel> ({
         ref: shapeRef,
         draggable: isDraggable,
         onClick: handleSingleSelect,
+        onDragStart: handleSingleSelect,
         onTap: handleSingleSelect,
         onTransformEnd,
         ...shapeEditableProps,

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -22,10 +22,6 @@ import {
 } from 'react-redux';
 
 import {
-  type EventCoords,
-} from '@/types/EventCoords';
-
-import {
   type RootState,
   store,
 } from '@/store';
@@ -268,19 +264,6 @@ const EditableText = ({
     [id, whiteboardId, clientId, clientMessenger, editor]
   );// -- end handleSingleSelect
 
-  // -- Record initial x and y coordinates on drag start to calculate total
-  // movement on drag end.
-  const dragStartCoordsRef = useRef<EventCoords>({ x, y });
-
-  const handleDragStart = useCallback(
-    (e: Konva.KonvaEventObject<DragEvent>) => {
-      handleSingleSelect(e);
-      dragStartCoordsRef.current.x = e.evt.x;
-      dragStartCoordsRef.current.y = e.evt.y;
-    },
-    [handleSingleSelect, dragStartCoordsRef]
-  );// -- end handleDragStart
-
   const handleDragEnd = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>) => {
       if (! clientMessenger) return;
@@ -289,14 +272,8 @@ const EditableText = ({
       const canvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
       if (! canvasId) return;
 
-      const {
-        x: prevX,
-        y: prevY,
-      } = dragStartCoordsRef.current;
-      const currX = e.currentTarget.x();
-      const currY = e.currentTarget.y();
-      const moveX = currX - prevX;
-      const moveY = currY - prevY;
+      const translateX = e.currentTarget.x() - x;
+      const translateY = e.currentTarget.y() - y;
 
       const selectedObjectRefsById = selectedObjectRefsByIdRef.current;
       const updatedObjects = Object.fromEntries(Object.entries(selectedObjectRefsById).map(
@@ -313,24 +290,23 @@ const EditableText = ({
             {
               const objUpdate = ({
                 ...prevObj,
-                x: prevObj.x + moveX,
-                y: prevObj.y + moveY,
+                x: prevObj.x + translateX,
+                y: prevObj.y + translateY,
               });
 
               return [objId, objUpdate];
             }
             case 'vector':
             {
-              const updatedPoints = prevObj.points.map((val, i) => {
-                if (i % 2 === 0) {
-                  return val + moveX;
-                } else {
-                  return val + moveY;
-                }
-              });
               const objUpdate = ({
                 ...prevObj,
-                points: updatedPoints,
+                points: prevObj.points.map((val, i) => {
+                  if (i % 2 === 0) {
+                    return val + translateX;
+                  } else {
+                    return val + translateY;
+                  }
+                }),
               });
 
               return [objId, objUpdate];
@@ -347,22 +323,52 @@ const EditableText = ({
         canvasObjects: updatedObjects,
       });
     },
-    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef]
+    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef, x, y]
   );// -- end handleDragEnd
 
   const handleDragMove = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>) => {
+      const currState : RootState = store.getState();
+      const translateX = e.currentTarget.x() - x;
+      const translateY = e.currentTarget.y() - y;
+
       for (const [objId, objRef] of Object.entries(selectedObjectRefsByIdRef.current)) {
         if (objId === id) continue;
         if (! objRef.current) continue;
 
         const obj = objRef.current;
+        const prevObj = selectCanvasObjectById(currState, objId);
+        if (! prevObj) continue;
 
-        obj.x(obj.x() + e.evt.movementX);
-        obj.y(obj.y() + e.evt.movementY);
+        switch (prevObj.type) {
+          case 'rect':
+          case 'ellipse':
+          case 'text':
+          {
+            obj.x(prevObj.x + translateX);
+            obj.y(prevObj.y + translateY);
+          }
+          break;
+          case 'vector':
+          {
+            const vec = obj as Konva.Line;
+            const pointsUpdate = prevObj.points.map((val, i) => {
+              if (i % 2 === 0) {
+                return val + translateX;
+              } else {
+                return val + translateY;
+              }
+            });
+
+            vec.points(pointsUpdate);
+          }
+          break;
+          default:
+            throw new Error('Unrecognized object type');
+        }// -- end switch (prevObj.type)
       }// -- end 
     },
-    [id, selectedObjectRefsByIdRef]
+    [id, selectedObjectRefsByIdRef, x, y]
   );// -- end handleDragMove
 
   const handleTextDblClick = useCallback((e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
@@ -435,7 +441,7 @@ const EditableText = ({
         onDblTap={handleTextDblClick}
         listening={!isEditing && draggable}
         visible={!isEditing}
-        onDragStart={handleDragStart}
+        onDragStart={handleSingleSelect}
         onDragMove={handleDragMove}
         onDragEnd={handleDragEnd}
         onMouseUp={onMouseUp}

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -22,6 +22,10 @@ import {
 } from 'react-redux';
 
 import {
+  type EventCoords,
+} from '@/types/EventCoords';
+
+import {
   type RootState,
   store,
 } from '@/store';
@@ -35,8 +39,13 @@ import {
 } from '@/store/activeUsers/activeUsersSelectors';
 
 import {
+  selectCanvasObjectById,
   selectSelectedCanvasObjectsByWhiteboard,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import {
+  selectSelectedCanvasByWhiteboard,
+} from '@/store/canvases/canvasesSelectors';
 
 import {
   selectUserHasAccessToCanvas,
@@ -109,7 +118,6 @@ const EditableText = ({
   onMouseOut,
   onMouseDown,
   onMouseUp,
-  onDragEnd,
   onTransform,
 }: EditableTextProps) => {
   const [isEditing, setIsEditing] = useState<boolean>(false);
@@ -136,6 +144,8 @@ const EditableText = ({
 
   const {
     whiteboardId,
+    canvasObjectRefsByIdRef,
+    selectedObjectRefsByIdRef,
   } = whiteboardContext;
 
   const {
@@ -153,6 +163,18 @@ const EditableText = ({
 
   useSnapping(textRef, snappingMonitor, trRef);
 
+  // -- Register canvas object ref
+  useEffect(
+    () => {
+      canvasObjectRefsByIdRef.current[id] = textRef;
+
+      return () => {
+        delete canvasObjectRefsByIdRef.current[id];
+      };
+    },
+    [id, canvasObjectRefsByIdRef]
+  );// -- end registering canvas object ref
+
   const anchorDragBoundFunc = useCallback(
     (oldPos: Konva.Vector2d, newPos: Konva.Vector2d) =>
       trRef.current
@@ -166,6 +188,10 @@ const EditableText = ({
     lodash.isEqual
   );
 
+  if (! clientId) {
+    throw new Error('No clientId provided');
+  }
+
   const editor = useSelector(
     (state: RootState) => selectSelectorByCanvasObject(state, id),
     lodash.isEqual
@@ -175,6 +201,24 @@ const EditableText = ({
     () => userHasCanvasAccess && (editor?.clientId === clientId),
     [userHasCanvasAccess, editor, clientId]
   );// -- end const isSelected
+
+  // -- Register/unregister shape in selected objects ref
+  useEffect(
+    () => {
+      if (isSelected) {
+        selectedObjectRefsByIdRef.current[id] = textRef;
+      } else if (id in selectedObjectRefsByIdRef.current) {
+        delete selectedObjectRefsByIdRef.current[id];
+      }
+
+      return () => {
+        if (id in selectedObjectRefsByIdRef.current) {
+          delete selectedObjectRefsByIdRef.current[id];
+        }
+      };
+    },
+    [id, isSelected, selectedObjectRefsByIdRef]
+  );
 
   // attach Transformer for editing when selected
   useEffect(() => {
@@ -223,6 +267,103 @@ const EditableText = ({
     },
     [id, whiteboardId, clientId, clientMessenger, editor]
   );// -- end handleSingleSelect
+
+  // -- Record initial x and y coordinates on drag start to calculate total
+  // movement on drag end.
+  const dragStartCoordsRef = useRef<EventCoords>({ x, y });
+
+  const handleDragStart = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      handleSingleSelect(e);
+      dragStartCoordsRef.current.x = e.evt.x;
+      dragStartCoordsRef.current.y = e.evt.y;
+    },
+    [handleSingleSelect, dragStartCoordsRef]
+  );// -- end handleDragStart
+
+  const handleDragEnd = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      if (! clientMessenger) return;
+
+      const currState : RootState = store.getState();
+      const canvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
+      if (! canvasId) return;
+
+      const {
+        x: prevX,
+        y: prevY,
+      } = dragStartCoordsRef.current;
+      const currX = e.currentTarget.x();
+      const currY = e.currentTarget.y();
+      const moveX = currX - prevX;
+      const moveY = currY - prevY;
+
+      const selectedObjectRefsById = selectedObjectRefsByIdRef.current;
+      const updatedObjects = Object.fromEntries(Object.entries(selectedObjectRefsById).map(
+        ([objId, objRef]) => {
+          if (! objRef.current) return null;
+
+          const prevObj = selectCanvasObjectById(currState, objId);
+          if (! prevObj) return null;
+
+          switch (prevObj.type) {
+            case 'rect':
+            case 'ellipse':
+            case 'text':
+            {
+              const objUpdate = ({
+                ...prevObj,
+                x: prevObj.x + moveX,
+                y: prevObj.y + moveY,
+              });
+
+              return [objId, objUpdate];
+            }
+            case 'vector':
+            {
+              const updatedPoints = prevObj.points.map((val, i) => {
+                if (i % 2 === 0) {
+                  return val + moveX;
+                } else {
+                  return val + moveY;
+                }
+              });
+              const objUpdate = ({
+                ...prevObj,
+                points: updatedPoints,
+              });
+
+              return [objId, objUpdate];
+            }
+            default:
+              throw new Error('ERROR: unrecognized object type');
+          }// -- end switch (prevObj.type)
+        }
+      ).filter(entry => !! entry));
+
+      clientMessenger.sendUpdateCanvasObjects({
+        type: 'update_canvas_objects',
+        canvasId,
+        canvasObjects: updatedObjects,
+      });
+    },
+    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef]
+  );// -- end handleDragEnd
+
+  const handleDragMove = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      for (const [objId, objRef] of Object.entries(selectedObjectRefsByIdRef.current)) {
+        if (objId === id) continue;
+        if (! objRef.current) continue;
+
+        const obj = objRef.current;
+
+        obj.x(obj.x() + e.evt.movementX);
+        obj.y(obj.y() + e.evt.movementY);
+      }// -- end 
+    },
+    [id, selectedObjectRefsByIdRef]
+  );// -- end handleDragMove
 
   const handleTextDblClick = useCallback((e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
     if (!draggable) return;
@@ -294,8 +435,9 @@ const EditableText = ({
         onDblTap={handleTextDblClick}
         listening={!isEditing && draggable}
         visible={!isEditing}
-        onDragStart={handleSingleSelect}
-        onDragEnd={onDragEnd}
+        onDragStart={handleDragStart}
+        onDragMove={handleDragMove}
+        onDragEnd={handleDragEnd}
         onMouseUp={onMouseUp}
         onMouseDown={onMouseDown}
         onMouseOut={onMouseOut}
@@ -333,6 +475,6 @@ const EditableText = ({
       )}
     </ Group>
   );
-}
+};// -- end EditableText
 
 export default EditableText;

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -23,6 +23,7 @@ import {
 
 import {
   type RootState,
+  store,
 } from '@/store';
 
 import {
@@ -34,12 +35,18 @@ import {
 } from '@/store/activeUsers/activeUsersSelectors';
 
 import {
+  selectSelectedCanvasObjectsByWhiteboard,
+} from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import {
   selectUserHasAccessToCanvas,
 } from '@/store/canvases/canvasesSelectors';
 
 import {
   ClientMessengerContext,
 } from '@/context/ClientMessengerContext';
+
+import WhiteboardContext from '@/context/WhiteboardContext';
 
 import TextEditor from "./TextEditor";
 
@@ -121,6 +128,16 @@ const EditableText = ({
     clientMessenger,
   } = clientMessengerContext;
 
+  const whiteboardContext = useContext(WhiteboardContext);
+
+  if (! whiteboardContext) {
+    throw new Error('No WhiteboardContext provided');
+  }
+
+  const {
+    whiteboardId,
+  } = whiteboardContext;
+
   const {
     user,
   } = useUser();
@@ -165,16 +182,33 @@ const EditableText = ({
     trRef.current.nodes(editor ? [textRef.current] : []);
   }, [editor]);
   
-  const handleSelect = useCallback((ev: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
-    ev.cancelBubble = true;
+  const handleSingleSelect = useCallback(
+    (ev: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+      ev.cancelBubble = true;
 
-    if (! editor) {
-      clientMessenger?.sendSelectedCanvasObjects({
-        type: 'selected_canvas_objects',
-        canvasObjectIds: [id],
-      });
-    }
-  }, [editor, clientMessenger, id]);
+      if (clientMessenger && (! editor)) {
+        const currState = store.getState();
+        const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
+          currState, whiteboardId, clientId
+        );
+
+        // -- Unselect any previously selected objects
+        if (selectedCanvasObjects.length > 0) {
+          clientMessenger.sendUnselectedCanvasObjects({
+            type: 'unselected_canvas_objects',
+            canvasObjectIds: selectedCanvasObjects,
+          });
+        }
+
+        // -- Identify the current user as the current selector
+        clientMessenger.sendSelectedCanvasObjects({
+          type: 'selected_canvas_objects',
+          canvasObjectIds: [id],
+        });
+      }
+    },
+    [id, whiteboardId, clientId, clientMessenger, editor]
+  );// -- end handleSingleSelect
 
   const handleTextDblClick = useCallback((e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
     if (!draggable) return;
@@ -240,13 +274,13 @@ const EditableText = ({
         height={height}
         rotation={rotation}
         draggable={draggable}
-        onClick={handleSelect}
-        onTap={handleSelect}
+        onClick={handleSingleSelect}
+        onTap={handleSingleSelect}
         onDblClick={handleTextDblClick}
         onDblTap={handleTextDblClick}
         listening={!isEditing && draggable}
         visible={!isEditing}
-        onDragStart={handleSelect}
+        onDragStart={handleSingleSelect}
         onDragEnd={onDragEnd}
         onMouseUp={onMouseUp}
         onMouseDown={onMouseDown}

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -169,9 +169,9 @@ const EditableText = ({
     ev.cancelBubble = true;
 
     if (! editor) {
-      clientMessenger?.sendSelectedCanvasObject({
-        type: 'selected_canvas_object',
-        canvasObjectId: id,
+      clientMessenger?.sendSelectedCanvasObjects({
+        type: 'selected_canvas_objects',
+        canvasObjectIds: [id],
       });
     }
   }, [editor, clientMessenger, id]);

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -233,7 +233,7 @@ const EditableText = ({
         );
 
         // -- Control key signals unselect target
-        if (e.evt.ctrlKey) {
+        if (e.evt.ctrlKey || e.evt.metaKey) {
           if (editor?.clientId === clientId) {
             // -- Identify the current user as the current selector
             clientMessenger.sendUnselectedCanvasObjects({

--- a/Frontend/src/components/EditableText.tsx
+++ b/Frontend/src/components/EditableText.tsx
@@ -183,28 +183,42 @@ const EditableText = ({
   }, [editor]);
   
   const handleSingleSelect = useCallback(
-    (ev: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
-      ev.cancelBubble = true;
+    (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+      e.cancelBubble = true;
 
-      if (clientMessenger && (! editor)) {
+      if (clientMessenger) {
         const currState = store.getState();
         const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
           currState, whiteboardId, clientId
         );
 
-        // -- Unselect any previously selected objects
-        if (selectedCanvasObjects.length > 0) {
-          clientMessenger.sendUnselectedCanvasObjects({
-            type: 'unselected_canvas_objects',
-            canvasObjectIds: selectedCanvasObjects,
+        // -- Control key signals unselect target
+        if (e.evt.ctrlKey) {
+          if (editor?.clientId === clientId) {
+            // -- Identify the current user as the current selector
+            clientMessenger.sendUnselectedCanvasObjects({
+              type: 'unselected_canvas_objects',
+              canvasObjectIds: [id],
+            });
+          }
+        } else if (! editor) {
+          // -- Shift key indicates multi select
+          if (! e.evt.shiftKey) {
+            // -- Unselect any previously selected objects
+            if (selectedCanvasObjects.length > 0) {
+              clientMessenger.sendUnselectedCanvasObjects({
+                type: 'unselected_canvas_objects',
+                canvasObjectIds: selectedCanvasObjects,
+              });
+            }
+          }
+
+          // -- Identify the current user as the current selector
+          clientMessenger.sendSelectedCanvasObjects({
+            type: 'selected_canvas_objects',
+            canvasObjectIds: [id],
           });
         }
-
-        // -- Identify the current user as the current selector
-        clientMessenger.sendSelectedCanvasObjects({
-          type: 'selected_canvas_objects',
-          canvasObjectIds: [id],
-        });
       }
     },
     [id, whiteboardId, clientId, clientMessenger, editor]

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -130,9 +130,9 @@ const EditableVector = <VectorType extends VectorModel>({
       e.cancelBubble = true;
 
       if (! editor) {
-        clientMessenger?.sendSelectedCanvasObject({
-          type: 'selected_canvas_object',
-          canvasObjectId: id,
+        clientMessenger?.sendSelectedCanvasObjects({
+          type: 'selected_canvas_objects',
+          canvasObjectIds: [id],
         });
       }
     },

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -19,6 +19,7 @@ import {
 
 import {
   type RootState,
+  store,
 } from '@/store';
 
 import {
@@ -34,12 +35,18 @@ import {
 } from '@/store/canvases/canvasesSelectors';
 
 import {
+  selectSelectedCanvasObjectsByWhiteboard,
+} from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import {
   useUser,
 } from '@/hooks/useUser';
 
 import {
   ClientMessengerContext,
 } from '@/context/ClientMessengerContext';
+
+import WhiteboardContext from '@/context/WhiteboardContext';
 
 import {
   type CanvasObjectIdType,
@@ -90,6 +97,16 @@ const EditableVector = <VectorType extends VectorModel>({
     clientMessenger,
   } = clientMessengerContext;
 
+  const whiteboardContext = useContext(WhiteboardContext);
+
+  if (! whiteboardContext) {
+    throw new Error('No WhiteboardContext provided');
+  }
+
+  const {
+    whiteboardId,
+  } = whiteboardContext;
+
   const {
     user,
   } = useUser();
@@ -125,18 +142,32 @@ const EditableVector = <VectorType extends VectorModel>({
     [draggable, isSelected, editor]
   );
 
-  const handleSelect = useCallback(
+  const handleSingleSelect = useCallback(
     (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
       e.cancelBubble = true;
 
-      if (! editor) {
-        clientMessenger?.sendSelectedCanvasObjects({
+      if (clientMessenger && (! editor)) {
+        const currState = store.getState();
+        const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
+          currState, whiteboardId, clientId
+        );
+
+        // -- Unselect any previously selected objects
+        if (selectedCanvasObjects.length > 0) {
+          clientMessenger.sendUnselectedCanvasObjects({
+            type: 'unselected_canvas_objects',
+            canvasObjectIds: selectedCanvasObjects,
+          });
+        }
+
+        // -- Identify the current user as the current selector
+        clientMessenger.sendSelectedCanvasObjects({
           type: 'selected_canvas_objects',
           canvasObjectIds: [id],
         });
       }
     },
-    [id, clientMessenger, editor]
+    [id, whiteboardId, clientId, clientMessenger, editor]
   );
 
   const handleAnchorDragMove = useCallback(
@@ -214,7 +245,7 @@ const EditableVector = <VectorType extends VectorModel>({
   // Override the onDragEnd handler for vectors to change points rather than x, y
   const vectorEditableProps = {
     ...editableObjectProps(model, isDraggable, onUpdateObject),
-    onDragStart: handleSelect,
+    onDragStart: handleSingleSelect,
     onDragEnd: handleVectorDragEnd,
   };
 
@@ -236,8 +267,8 @@ const EditableVector = <VectorType extends VectorModel>({
         id,
         ref: vectorRef,
         draggable: isDraggable,
-        onClick: handleSelect,
-        onTap: handleSelect,
+        onClick: handleSingleSelect,
+        onTap: handleSingleSelect,
         hitStrokeWidth: 20,
         ...vectorEditableProps,
       })}

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -32,9 +32,11 @@ import {
 
 import {
   selectUserHasAccessToCanvas,
+  selectSelectedCanvasByWhiteboard,
 } from '@/store/canvases/canvasesSelectors';
 
 import {
+  selectCanvasObjectById,
   selectSelectedCanvasObjectsByWhiteboard,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
@@ -174,6 +176,14 @@ const EditableVector = <VectorType extends VectorModel>({
     [draggable, isSelected, editor]
   );
 
+  // -- Ensure localPoints changes whenever the model's points change
+  useEffect(
+    () => {
+      setLocalPoints(model.points);
+    },
+    [model.points, setLocalPoints]
+  );// -- end useEffect
+
   const handleSingleSelect = useCallback(
     (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
       e.cancelBubble = true;
@@ -259,43 +269,149 @@ const EditableVector = <VectorType extends VectorModel>({
     [localPoints, onUpdateObject, model, snappingMonitor]
   );
 
-  const handleVectorDragEnd = useCallback(
-    (ev: Konva.KonvaEventObject<DragEvent>) => {
-      const node = ev.target;
-      const dx = node.x();
-      const dy = node.y();
-
-      const updatedPoints = model.points.map((p, i) =>
-        i % 2 === 0 ? p + dx : p + dy
-      );
-
-      // Prevent flicker by updating localPoints before broadcasting
-      setLocalPoints(updatedPoints);
-      vectorRef.current?.setAttrs({ points: updatedPoints });
-      node.position({ x: 0, y: 0 });
-
-      const update : VectorType = {
-        ...model,
-        points: updatedPoints,
-      };
-
-      onUpdateObject(update);
-    },
-    [onUpdateObject, model, setLocalPoints]
-  );
-
   useEffect(() => {
     setLocalPoints(model.points);
   }, [model.points]);
 
+  const childStrokeWidth = (children.props.strokeWidth as number | undefined) ?? 2;
+
+  // -- Reset x and y offsets whenever the model points change
+  useEffect(
+    () => {
+      console.log('!! RESET VECTOR NODE COORDS');
+      if (! vectorRef.current) return;
+
+      const vector = vectorRef.current;
+      console.log(`vector.x = ${vector.x()}, vector.y = ${vector.y()}`);
+
+      vector.x(0);
+      vector.y(0);
+    },
+    [vectorRef.current, model.points]
+  );// -- end useEffect
+
+  const handleDragStart = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      handleSingleSelect(e);
+    },
+    [handleSingleSelect]
+  );// -- end handleDragStart
+
+  const handleDragEnd = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      if (! clientMessenger) return;
+
+      const currState : RootState = store.getState();
+      const canvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
+      if (! canvasId) return;
+
+      const translateX = e.currentTarget.x();
+      const translateY = e.currentTarget.y();
+
+      const selectedObjectRefsById = selectedObjectRefsByIdRef.current;
+      const updatedObjects = Object.fromEntries(Object.entries(selectedObjectRefsById).map(
+        ([objId, objRef]) => {
+          if (! objRef.current) return null;
+
+          const prevObj = selectCanvasObjectById(currState, objId);
+          if (! prevObj) return null;
+
+          switch (prevObj.type) {
+            case 'rect':
+            case 'ellipse':
+            case 'text':
+            {
+              const objUpdate = ({
+                ...prevObj,
+                x: prevObj.x + translateX,
+                y: prevObj.y + translateY,
+              });
+
+              return [objId, objUpdate];
+            }
+            case 'vector':
+            {
+              const objUpdate = ({
+                ...prevObj,
+                points: prevObj.points.map((val, i) => {
+                  if (i % 2 === 0) {
+                    return val + translateX;
+                  } else {
+                    return val + translateY;
+                  }
+                }),
+              });
+
+              return [objId, objUpdate];
+            }
+            default:
+              throw new Error('ERROR: unrecognized object type');
+          }// -- end switch (prevObj.type)
+        }
+      ).filter(entry => !! entry));
+
+      clientMessenger.sendUpdateCanvasObjects({
+        type: 'update_canvas_objects',
+        canvasId,
+        canvasObjects: updatedObjects,
+      });
+    },
+    [whiteboardId, clientMessenger, selectedObjectRefsByIdRef]
+  );// -- end handleDragEnd
+
+  const handleDragMove = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      const currState : RootState = store.getState();
+
+      const translateX = e.currentTarget.x();
+      const translateY = e.currentTarget.y();
+
+      for (const [objId, objRef] of Object.entries(selectedObjectRefsByIdRef.current)) {
+        if (objId === id) continue;
+        if (! objRef.current) continue;
+
+        const obj = objRef.current;
+        const prevObj = selectCanvasObjectById(currState, objId);
+        if (! prevObj) continue;
+
+        switch (prevObj.type) {
+          case 'rect':
+          case 'ellipse':
+          case 'text':
+          {
+            obj.x(prevObj.x + translateX);
+            obj.y(prevObj.y + translateY);
+          }
+          break;
+          case 'vector':
+          {
+            const vec = obj as Konva.Line;
+            const pointsUpdate = prevObj.points.map((val, i) => {
+              if (i % 2 === 0) {
+                return val + translateX;
+              } else {
+                return val + translateY;
+              }
+            });
+
+            vec.points(pointsUpdate);
+          }
+          break;
+          default:
+            throw new Error('Unrecognized object type');
+        }// -- end switch (prevObj.type)
+      }// -- end 
+    },
+    [id, selectedObjectRefsByIdRef]
+  );// -- end handleDragMove
+
   // Override the onDragEnd handler for vectors to change points rather than x, y
   const vectorEditableProps = {
     ...editableObjectProps(model, isDraggable, onUpdateObject),
-    onDragStart: handleSingleSelect,
-    onDragEnd: handleVectorDragEnd,
+    ondragstart: handleDragStart,
+    onDragMove: handleDragMove,
+    onDragEnd: handleDragEnd,
   };
-
-  const childStrokeWidth = (children.props.strokeWidth as number | undefined) ?? 2;
 
   return (
     <Group>
@@ -315,6 +431,7 @@ const EditableVector = <VectorType extends VectorModel>({
         draggable: isDraggable,
         onClick: handleSingleSelect,
         onTap: handleSingleSelect,
+        onDragStart: handleSingleSelect,
         hitStrokeWidth: 20,
         ...vectorEditableProps,
       })}
@@ -363,6 +480,6 @@ const EditableVector = <VectorType extends VectorModel>({
       )}
     </Group>
   );
-};
+};// -- end EditableVector
 
 export default EditableVector;

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -195,7 +195,7 @@ const EditableVector = <VectorType extends VectorModel>({
         );
 
         // -- Control key signals unselect target
-        if (e.evt.ctrlKey) {
+        if (e.evt.ctrlKey || e.evt.metaKey) {
           if (editor?.clientId === clientId) {
             // -- Identify the current user as the current selector
             clientMessenger.sendUnselectedCanvasObjects({

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -146,25 +146,39 @@ const EditableVector = <VectorType extends VectorModel>({
     (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
       e.cancelBubble = true;
 
-      if (clientMessenger && (! editor)) {
+      if (clientMessenger) {
         const currState = store.getState();
         const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
           currState, whiteboardId, clientId
         );
 
-        // -- Unselect any previously selected objects
-        if (selectedCanvasObjects.length > 0) {
-          clientMessenger.sendUnselectedCanvasObjects({
-            type: 'unselected_canvas_objects',
-            canvasObjectIds: selectedCanvasObjects,
+        // -- Control key signals unselect target
+        if (e.evt.ctrlKey) {
+          if (editor?.clientId === clientId) {
+            // -- Identify the current user as the current selector
+            clientMessenger.sendUnselectedCanvasObjects({
+              type: 'unselected_canvas_objects',
+              canvasObjectIds: [id],
+            });
+          }
+        } else if (! editor) {
+          // -- Shift key indicates multi select
+          if (! e.evt.shiftKey) {
+            // -- Unselect any previously selected objects
+            if (selectedCanvasObjects.length > 0) {
+              clientMessenger.sendUnselectedCanvasObjects({
+                type: 'unselected_canvas_objects',
+                canvasObjectIds: selectedCanvasObjects,
+              });
+            }
+          }
+
+          // -- Identify the current user as the current selector
+          clientMessenger.sendSelectedCanvasObjects({
+            type: 'selected_canvas_objects',
+            canvasObjectIds: [id],
           });
         }
-
-        // -- Identify the current user as the current selector
-        clientMessenger.sendSelectedCanvasObjects({
-          type: 'selected_canvas_objects',
-          canvasObjectIds: [id],
-        });
       }
     },
     [id, whiteboardId, clientId, clientMessenger, editor]

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -278,16 +278,14 @@ const EditableVector = <VectorType extends VectorModel>({
   // -- Reset x and y offsets whenever the model points change
   useEffect(
     () => {
-      console.log('!! RESET VECTOR NODE COORDS');
       if (! vectorRef.current) return;
 
       const vector = vectorRef.current;
-      console.log(`vector.x = ${vector.x()}, vector.y = ${vector.y()}`);
 
       vector.x(0);
       vector.y(0);
     },
-    [vectorRef.current, model.points]
+    [model.points]
   );// -- end useEffect
 
   const handleDragStart = useCallback(

--- a/Frontend/src/components/EditableVector.tsx
+++ b/Frontend/src/components/EditableVector.tsx
@@ -105,6 +105,8 @@ const EditableVector = <VectorType extends VectorModel>({
 
   const {
     whiteboardId,
+    canvasObjectRefsByIdRef,
+    selectedObjectRefsByIdRef,
   } = whiteboardContext;
 
   const {
@@ -132,10 +134,40 @@ const EditableVector = <VectorType extends VectorModel>({
     lodash.isEqual
   );
 
+  // -- Register canvas object ref
+  useEffect(
+    () => {
+      canvasObjectRefsByIdRef.current[id] = vectorRef;
+
+      return () => {
+        delete canvasObjectRefsByIdRef.current[id];
+      };
+    },
+    [id, canvasObjectRefsByIdRef]
+  );// -- end registering canvas object ref
+
   const isSelected : boolean = useMemo(
     () => userHasCanvasAccess && (editor?.clientId === clientId),
     [userHasCanvasAccess, editor, clientId]
   );// -- end const isSelected
+
+  // -- Register/unregister shape in selected objects ref
+  useEffect(
+    () => {
+      if (isSelected) {
+        selectedObjectRefsByIdRef.current[id] = vectorRef;
+      } else if (id in selectedObjectRefsByIdRef.current) {
+        delete selectedObjectRefsByIdRef.current[id];
+      }
+
+      return () => {
+        if (id in selectedObjectRefsByIdRef.current) {
+          delete selectedObjectRefsByIdRef.current[id];
+        }
+      };
+    },
+    [id, isSelected, selectedObjectRefsByIdRef]
+  );
 
   const isDraggable : boolean = useMemo(
     () => draggable && (isSelected || (! editor)),

--- a/Frontend/src/components/Tool.ts
+++ b/Frontend/src/components/Tool.ts
@@ -6,6 +6,7 @@ import {
   Circle,
   ALargeSmall,
   SquarePlus,
+  BoxSelect,
 } from 'lucide-react';
 
 export type ToolChoice =
@@ -15,6 +16,7 @@ export type ToolChoice =
   | 'vector' 
   | 'text'
   | 'create_canvas'
+  | 'select'
 ;
 
 const getToolChoiceLabel = (toolChoice: ToolChoice): LucideIcon => {
@@ -31,6 +33,8 @@ const getToolChoiceLabel = (toolChoice: ToolChoice): LucideIcon => {
       return ALargeSmall;
     case 'create_canvas':
       return SquarePlus;
+    case 'select':
+      return BoxSelect;
     default:
       throw new Error(`Unrecognized tool choice: ${toolChoice}`);
   }// end switch (toolChoice)
@@ -50,6 +54,8 @@ export const getTooltip = (toolChoice: ToolChoice): string => {
       return "Add Text";
     case 'create_canvas':
       return "Create a new Canvas";
+    case 'select':
+      return "Select Shape(s)";
     default:
       throw new Error(`Unrecognized tool choice: ${toolChoice}`);
   }

--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -94,6 +94,7 @@ import {
   setActiveUsersByWhiteboard,
   addActiveUsersByWhiteboard,
   removeSelectorsByCanvasObject,
+  removeCanvasObjectsBySelector,
   removeActiveUsers,
   setSelectorsByCanvasObject,
   setNotifications,
@@ -234,6 +235,7 @@ const WebSocketClientMessengerProvider = ({
 
               // -- remove logged out users
               removeActiveUsers(dispatch, clients);
+              removeCanvasObjectsBySelector(dispatch, clients);
             } 
             break;
           case 'set_permissions':
@@ -289,25 +291,28 @@ const WebSocketClientMessengerProvider = ({
               );
             }
             break;
-          case 'selected_canvas_object':
+          case 'selected_canvas_objects':
             {
               const {
                 clientId,
-                canvasObjectId,
+                canvasObjectIds,
               } = msg;
 
               // -- Set selector
-              setSelectorsByCanvasObject(dispatch, { [canvasObjectId]: clientId });
+              setSelectorsByCanvasObject(
+                dispatch,
+                Object.fromEntries(canvasObjectIds.map(objId => [objId, clientId]))
+              );
             }
             break;
-          case 'unselected_canvas_object':
+          case 'unselected_canvas_objects':
             {
               const {
-                canvasObjectId,
+                canvasObjectIds,
               } = msg;
 
               // -- Remove client color from canvas object
-              removeSelectorsByCanvasObject(dispatch, [canvasObjectId]);
+              removeSelectorsByCanvasObject(dispatch, canvasObjectIds);
             }
             break;
           case 'create_canvas_objects':

--- a/Frontend/src/context/WhiteboardContext.tsx
+++ b/Frontend/src/context/WhiteboardContext.tsx
@@ -30,7 +30,11 @@ export interface WhiteboardContextType {
       updates: Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
   ) => unknown;
   whiteboardId: WhiteboardIdType;
-  // -- view/edit/own permission - determines which actions to enable/disable
+  // -- Contains ref to stage containing root canvas, located in pages/Whiteboard/CanvasCard
+  stageRef: RefObject<Konva.Stage | null>;
+  // -- Contains mapping of canvas object IDs to Konva objects
+  canvasObjectRefsByIdRef: RefObject<Record<CanvasObjectIdType, RefObject<Konva.Shape | null>>>;
+  selectedObjectRefsByIdRef: RefObject<Record<CanvasObjectIdType, RefObject<Konva.Shape | null>>>;
   currentDispatcherRef: RefObject<OperationDispatcher | null>;
   // -- tracks refs to Canvas groups (Konva Groups serve as frames for each Canvas)
   canvasGroupRefsByIdRef: RefObject<Record<CanvasIdType, RefObject<Konva.Group | null>>>;
@@ -43,14 +47,20 @@ const WhiteboardContext = createContext<WhiteboardContextType | undefined>(undef
 const WhiteboardProvider = ({
   handleUpdateShapes,
   whiteboardId,
-  children,
+  stageRef,
+  canvasObjectRefsByIdRef,
+  selectedObjectRefsByIdRef,
   currentDispatcherRef,
   canvasGroupRefsByIdRef,
+  children,
 }: PropsWithChildren<WhiteboardProvidersProps>): React.JSX.Element => {
   return (
     <WhiteboardContext.Provider value={{
       handleUpdateShapes,
       whiteboardId,
+      stageRef,
+      canvasObjectRefsByIdRef,
+      selectedObjectRefsByIdRef,
       currentDispatcherRef,
       canvasGroupRefsByIdRef,
     }}>

--- a/Frontend/src/dispatchers/useSelectDispatcher.tsx
+++ b/Frontend/src/dispatchers/useSelectDispatcher.tsx
@@ -48,6 +48,10 @@ import {
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
 import {
+  updateWhiteboard,
+} from '@/controllers';
+
+import {
   ClientMessengerContext,
 } from '@/context/ClientMessengerContext';
 
@@ -222,9 +226,14 @@ const useSelectDispatcher = (): OperationDispatcher => {
       if (pos && mouseDownCoords) {
         handleSelectShapes(mouseDownCoords, pos);
         setMouseDownCoords(null);
+
+        // Switch to hand tool after selecting shapes
+        updateWhiteboard(store.dispatch, whiteboardId, {
+          currentTool: "hand",
+        });
       }
     },
-    [handleSelectShapes, mouseDownCoords]
+    [whiteboardId, handleSelectShapes, mouseDownCoords]
   );// -- end handlePointerUp
 
   const handleCancel = useCallback(

--- a/Frontend/src/dispatchers/useSelectDispatcher.tsx
+++ b/Frontend/src/dispatchers/useSelectDispatcher.tsx
@@ -48,8 +48,8 @@ import {
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
 import {
-  setSelectorsByCanvasObject,
-} from '@/controllers';
+  ClientMessengerContext,
+} from '@/context/ClientMessengerContext';
 
 import WhiteboardContext from '@/context/WhiteboardContext';
 
@@ -80,6 +80,16 @@ const useSelectDispatcher = (): OperationDispatcher => {
   const {
     whiteboardId,
   } = whiteboardContext;
+
+  const clientMessengerContext = useContext(ClientMessengerContext);
+
+  if (! clientMessengerContext) {
+    throw new Error('No ClientMessengerContext provided');
+  }
+
+  const {
+    clientMessenger,
+  } = clientMessengerContext;
 
   const clientId = useSelector(
     (state: RootState) => selectClientId(state),
@@ -119,90 +129,90 @@ const useSelectDispatcher = (): OperationDispatcher => {
 
   const handleSelectShapes = useCallback(
     (originCoords: EventCoords, finalCoords: EventCoords) => {
-      const currState : RootState = store.getState();
-      const selectedCanvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
+      if (clientMessenger) {
+        const currState : RootState = store.getState();
+        const selectedCanvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
 
-      if (! selectedCanvasId) return;
+        if (! selectedCanvasId) return;
 
-      const canvasObjects = selectCanvasObjectsByCanvas(currState, selectedCanvasId);
-      if (! canvasObjects) return;
+        const canvasObjects = selectCanvasObjectsByCanvas(currState, selectedCanvasId);
+        if (! canvasObjects) return;
 
-      const { x: originX, y: originY } = originCoords;
-      const { x: finalX, y: finalY } = finalCoords;
+        const { x: originX, y: originY } = originCoords;
+        const { x: finalX, y: finalY } = finalCoords;
 
-      const [minX, maxX] = (originX < finalX) ?
-        [originX, finalX]
-        : [finalX, originX]
-      ;
+        const [minX, maxX] = (originX < finalX) ?
+          [originX, finalX]
+          : [finalX, originX]
+        ;
 
-      const [minY, maxY] = (originY < finalY) ?
-        [originY, finalY]
-        : [finalY, originY]
-      ;
+        const [minY, maxY] = (originY < finalY) ?
+          [originY, finalY]
+          : [finalY, originY]
+        ;
 
-      // -- Locate all shapes between the origin and the final coordinates
-      const selectedCanvasObjectIds : CanvasObjectIdType[] = [];
+        // -- Locate all shapes between the origin and the final coordinates
+        const selectedCanvasObjectIds : CanvasObjectIdType[] = [];
 
-      for (const [objId, obj] of Object.entries(canvasObjects)) {
-        switch (obj.type) {
-          case 'rect':
-          case 'text':
-          {
-            const { x: objX, y: objY } = obj;
+        for (const [objId, obj] of Object.entries(canvasObjects)) {
+          switch (obj.type) {
+            case 'rect':
+            case 'text':
+            {
+              const { x: objX, y: objY } = obj;
 
-            if (objX < minX) continue;
-            if (objX > maxX) continue;
-            if (objY < minY) continue;
-            if (objY > maxY) continue;
-
-            selectedCanvasObjectIds.push(objId);
-          }
-          break;
-          case 'ellipse':
-          {
-            const { x: objX, y: objY } = obj;
-
-            if (objX < minX) continue;
-            if (objX > maxX) continue;
-            if (objY < minY) continue;
-            if (objY > maxY) continue;
-
-            selectedCanvasObjectIds.push(objId);
-          }
-          break;
-          case 'vector':
-          {
-            const { points } = obj;
-            const [xA, yA, xB, yB] = points;
-            const coords = [
-              [xA, yA],
-              [xB, yB],
-            ];
-
-            for (const [pointX, pointY] of coords) {
-              if (pointX < minX) continue;
-              if (pointX > maxX) continue;
-              if (pointY < minY) continue;
-              if (pointY > maxY) continue;
+              if (objX < minX) continue;
+              if (objX > maxX) continue;
+              if (objY < minY) continue;
+              if (objY > maxY) continue;
 
               selectedCanvasObjectIds.push(objId);
-              break;
-            }// -- end for (const [pointX, pointY] of coords)
-          }
-          break;
-          default:
-            throw new Error('ERROR: unrecognized object type');
-        }// -- end switch (obj.type)
-      }// -- end for obj
+            }
+            break;
+            case 'ellipse':
+            {
+              const { x: objX, y: objY } = obj;
 
-      setSelectorsByCanvasObject(
-        store.dispatch,
-        Object.fromEntries(
-          selectedCanvasObjectIds.map(objId => [objId, clientId])
-        )
-      );
+              if (objX < minX) continue;
+              if (objX > maxX) continue;
+              if (objY < minY) continue;
+              if (objY > maxY) continue;
+
+              selectedCanvasObjectIds.push(objId);
+            }
+            break;
+            case 'vector':
+            {
+              const { points } = obj;
+              const [xA, yA, xB, yB] = points;
+              const coords = [
+                [xA, yA],
+                [xB, yB],
+              ];
+
+              for (const [pointX, pointY] of coords) {
+                if (pointX < minX) continue;
+                if (pointX > maxX) continue;
+                if (pointY < minY) continue;
+                if (pointY > maxY) continue;
+
+                selectedCanvasObjectIds.push(objId);
+                break;
+              }// -- end for (const [pointX, pointY] of coords)
+            }
+            break;
+            default:
+              throw new Error('ERROR: unrecognized object type');
+          }// -- end switch (obj.type)
+        }// -- end for obj
+
+        clientMessenger.sendSelectedCanvasObjects({
+          type: 'selected_canvas_objects',
+          canvasObjectIds: selectedCanvasObjectIds,
+        });
+      }
     },
-    [whiteboardId, clientId]
+    [whiteboardId, clientMessenger]
   );// -- end handleSelectShapes
 
   const handlePointerUp = useCallback(
@@ -259,7 +269,7 @@ const useSelectDispatcher = (): OperationDispatcher => {
       if (mouseDownCoords) {
         return 'Drag to enclose the shapes to select, then release';
       } else {
-        return 'Click to select shapes on this canvas.';
+        return 'Click and drag to select shapes on this canvas.';
       }
     },
     [mouseDownCoords]

--- a/Frontend/src/dispatchers/useSelectDispatcher.tsx
+++ b/Frontend/src/dispatchers/useSelectDispatcher.tsx
@@ -1,0 +1,279 @@
+// === useSelectDispatcher.tsx =================================================
+//
+// Allows selecting multiple objects in a canvas in a selection box.
+//
+// =============================================================================
+
+import {
+  useState,
+  useCallback,
+  useContext,
+} from 'react';
+
+import {
+  useSelector,
+} from 'react-redux';
+
+import lodash from 'lodash';
+
+import Konva from 'konva';
+
+import {
+  Rect,
+} from 'react-konva';
+
+import {
+  type CanvasObjectIdType,
+} from '@/types/CanvasObjectModel';
+
+import {
+  type AttributeDefinition,
+} from '@/types/Attribute';
+
+import {
+  type RootState,
+  store,
+} from '@/store';
+
+import {
+  selectClientId,
+} from '@/store/client/clientSelectors';
+
+import {
+  selectSelectedCanvasByWhiteboard,
+} from '@/store/canvases/canvasesSelectors';
+
+import {
+  selectCanvasObjectsByCanvas,
+} from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import {
+  setSelectorsByCanvasObject,
+} from '@/controllers';
+
+import WhiteboardContext from '@/context/WhiteboardContext';
+
+import {
+  type OperationDispatcher,
+} from '@/types/OperationDispatcher';
+
+import {
+  type EventCoords,
+} from '@/types/EventCoords';
+
+// === useSelectDispatcher =====================================================
+// 
+// Dispatcher for the Select tool. Preview displays selection box, which is used
+// to select multiple objects.
+//
+// =============================================================================
+const useSelectDispatcher = (): OperationDispatcher => {
+  const [mouseDownCoords, setMouseDownCoords] = useState<EventCoords | null>(null);
+  const [mouseCoords, setMouseCoords] = useState<EventCoords | null>(null);
+
+  const whiteboardContext = useContext(WhiteboardContext);
+
+  if (! whiteboardContext) {
+    throw new Error('No WhiteboardContext provided');
+  }
+
+  const {
+    whiteboardId,
+  } = whiteboardContext;
+
+  const clientId = useSelector(
+    (state: RootState) => selectClientId(state),
+    lodash.isEqual
+  );
+
+  if (! clientId) throw new Error('No clientId provided to SelectDispatcher');
+
+  const handlePointerDown = useCallback(
+    (ev: Konva.KonvaEventObject<MouseEvent>) => {
+      const pos = ev.currentTarget.getRelativePointerPosition();
+
+      if (pos) {
+        const { x, y } = pos;
+
+        setMouseDownCoords({ x, y });
+        setMouseCoords({ x, y });
+      }
+    },
+    []
+  );// -- end handlePointerDown
+
+  const handlePointerMove = useCallback(
+    (ev: Konva.KonvaEventObject<MouseEvent>) => {
+      if (mouseDownCoords) {
+        const pos = ev.currentTarget.getRelativePointerPosition();
+
+        if (pos) {
+          const { x, y } = pos;
+
+          setMouseCoords({ x, y });
+        }
+      }
+    },
+    [mouseDownCoords]
+  );// -- end handlePointerMove
+
+  const handleSelectShapes = useCallback(
+    (originCoords: EventCoords, finalCoords: EventCoords) => {
+      const currState : RootState = store.getState();
+      const selectedCanvasId = selectSelectedCanvasByWhiteboard(currState, whiteboardId);
+
+      if (! selectedCanvasId) return;
+
+      const canvasObjects = selectCanvasObjectsByCanvas(currState, selectedCanvasId);
+      if (! canvasObjects) return;
+
+      const { x: originX, y: originY } = originCoords;
+      const { x: finalX, y: finalY } = finalCoords;
+
+      const [minX, maxX] = (originX < finalX) ?
+        [originX, finalX]
+        : [finalX, originX]
+      ;
+
+      const [minY, maxY] = (originY < finalY) ?
+        [originY, finalY]
+        : [finalY, originY]
+      ;
+
+      // -- Locate all shapes between the origin and the final coordinates
+      const selectedCanvasObjectIds : CanvasObjectIdType[] = [];
+
+      for (const [objId, obj] of Object.entries(canvasObjects)) {
+        switch (obj.type) {
+          case 'rect':
+          case 'text':
+          {
+            const { x: objX, y: objY } = obj;
+
+            if (objX < minX) continue;
+            if (objX > maxX) continue;
+            if (objY < minY) continue;
+            if (objY > maxY) continue;
+
+            selectedCanvasObjectIds.push(objId);
+          }
+          break;
+          case 'ellipse':
+          {
+            const { x: objX, y: objY } = obj;
+
+            if (objX < minX) continue;
+            if (objX > maxX) continue;
+            if (objY < minY) continue;
+            if (objY > maxY) continue;
+
+            selectedCanvasObjectIds.push(objId);
+          }
+          break;
+          case 'vector':
+          {
+            const { points } = obj;
+            const [xA, yA, xB, yB] = points;
+            const coords = [
+              [xA, yA],
+              [xB, yB],
+            ];
+
+            for (const [pointX, pointY] of coords) {
+              if (pointX < minX) continue;
+              if (pointX > maxX) continue;
+              if (pointY < minY) continue;
+              if (pointY > maxY) continue;
+
+              selectedCanvasObjectIds.push(objId);
+              break;
+            }// -- end for (const [pointX, pointY] of coords)
+          }
+          break;
+          default:
+            throw new Error('ERROR: unrecognized object type');
+        }// -- end switch (obj.type)
+      }// -- end for obj
+
+      setSelectorsByCanvasObject(
+        store.dispatch,
+        Object.fromEntries(
+          selectedCanvasObjectIds.map(objId => [objId, clientId])
+        )
+      );
+    },
+    [whiteboardId, clientId]
+  );// -- end handleSelectShapes
+
+  const handlePointerUp = useCallback(
+    (ev: Konva.KonvaEventObject<MouseEvent>) => {
+      const pos = ev.currentTarget.getRelativePointerPosition();
+
+      if (pos && mouseDownCoords) {
+        handleSelectShapes(mouseDownCoords, pos);
+        setMouseDownCoords(null);
+      }
+    },
+    [handleSelectShapes, mouseDownCoords]
+  );// -- end handlePointerUp
+
+  const handleCancel = useCallback(
+    () => {
+      setMouseDownCoords(null);
+    },// -- end handleCance,
+    []
+  );// -- end handleCancel
+
+  const getPreview = useCallback(
+    (): React.JSX.Element | null => {
+      if (mouseDownCoords && mouseCoords) {
+        const { x: xA, y: yA } = mouseDownCoords;
+        const { x: xB, y: yB } = mouseCoords;
+
+        return (
+          <Rect
+            x={Math.min(xA, xB)}
+            y={Math.min(yA, yB)}
+            width={Math.abs(xA - xB)}
+            height={Math.abs(yA - yB)}
+            stroke="black"
+            dash={[10, 10]}
+          />
+        );
+      } else {
+        return null;
+      }
+    },
+    [mouseCoords, mouseDownCoords]
+  );// -- end getPreview
+
+  const getAttributes = useCallback(
+    (): AttributeDefinition[] => {
+      return [];
+    },
+    []
+  );// -- end getAttributes
+
+  const getTooltipText = useCallback(
+    () => {
+      if (mouseDownCoords) {
+        return 'Drag to enclose the shapes to select, then release';
+      } else {
+        return 'Click to select shapes on this canvas.';
+      }
+    },
+    [mouseDownCoords]
+  );// -- end getTooltipText
+
+  return ({
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handleCancel,
+    getPreview,
+    getAttributes,
+    getTooltipText,
+  });
+};
+
+export default useSelectDispatcher;

--- a/Frontend/src/pages/Whiteboard/Canvas.tsx
+++ b/Frontend/src/pages/Whiteboard/Canvas.tsx
@@ -122,6 +122,7 @@ import useVectorDispatcher from '@/dispatchers/useVectorDispatcher';
 import useHandDispatcher from '@/dispatchers/useHandDispatcher';
 import useTextDispatcher from '@/dispatchers/useTextDispatcher';
 import useCreateCanvasDispatcher from '@/dispatchers/useCreateCanvasDispatcher';
+import useSelectDispatcher from '@/dispatchers/useSelectDispatcher';
 
 export interface CanvasProps {
   id: CanvasIdType;
@@ -300,6 +301,8 @@ const Canvas = ({
     },
   });
 
+  const selectDispatcher = useSelectDispatcher();
+
   const getDispatcher: (tool: ToolChoice) => OperationDispatcher = useCallback(
     (tool: ToolChoice) => {
       if (! userHasAccess) {
@@ -318,6 +321,8 @@ const Canvas = ({
             return textDispatcher;
           case 'create_canvas':
             return createCanvasDispatcher;
+          case 'select':
+            return selectDispatcher;
           default:
             return defaultDispatcher;
         }// -- end switch (currentTool)
@@ -331,6 +336,7 @@ const Canvas = ({
       vectorDispatcher,
       textDispatcher,
       createCanvasDispatcher,
+      selectDispatcher,
       defaultDispatcher,
       inaccessibleDispatcher,
     ]

--- a/Frontend/src/pages/Whiteboard/CanvasCard.tsx
+++ b/Frontend/src/pages/Whiteboard/CanvasCard.tsx
@@ -244,6 +244,10 @@ const CanvasCard = ({
     lodash.isEqual
   );
 
+  if (! clientId) {
+    throw new Error('No clientId provided');
+  }
+
   const allowedUserIds = useSelector(
     (state: RootState) => selectAllowedUsersByCanvas(state, selectedCanvasId ?? ''),
     lodash.isEqual
@@ -561,8 +565,16 @@ const CanvasCard = ({
               break;
             case 'Escape':
             case 'Esc':
+            {
               currentDispatcherRef.current?.handleCancel();
-              break;
+
+              // -- Unselect all selected objects
+              clientMessenger?.sendUnselectedCanvasObjects({
+                type: 'unselected_canvas_objects',
+                canvasObjectIds: selectedCanvasObjects,
+              });
+            }
+            break;
             case 'z':
               // -- undo edit
               if (ev.ctrlKey || ev.metaKey) {

--- a/Frontend/src/pages/Whiteboard/CanvasCard.tsx
+++ b/Frontend/src/pages/Whiteboard/CanvasCard.tsx
@@ -28,7 +28,7 @@ import {
 // -- local imports
 import {
   WB_ZOOM_FACTOR,
-  LS_KEY_COPIED_CANVAS_OBJECT,
+  LS_KEY_COPIED_CANVAS_OBJECTS,
 } from '@/app.config';
 
 import Canvas from "@/pages/Whiteboard/Canvas";
@@ -443,21 +443,103 @@ const CanvasCard = ({
 
         const handleCopyObject = () => {
           const currState = store.getState();
-          const selectedCanvasObjects = selectSelectedCanvasObjectsByWhiteboard(
+          const selectedCanvasObjectIds = selectSelectedCanvasObjectsByWhiteboard(
             currState, whiteboardId, clientId
           );
 
-          if (selectedCanvasObjects.length > 0) {
-            // -- copy only first shape to localStorage
-            const targetObjectId = selectedCanvasObjects[0];
-            const targetObject = selectCanvasObjectById(currState, targetObjectId);
+          if (selectedCanvasObjectIds.length < 1) return;
 
-            if (targetObject) {
-              const targetObjectData = JSON.stringify(targetObject);
+          const targetObjects : CanvasObjectModel[] = selectedCanvasObjectIds.map(
+            objId => selectCanvasObjectById(currState, objId)
+          ).filter((obj : CanvasObjectModel | null) => !! obj);
 
-              localStorage.setItem(LS_KEY_COPIED_CANVAS_OBJECT, targetObjectData);
+          if (targetObjects.length < 1) return;
+
+          // -- Re-calculate all coordinates relative to the minimum x and y
+          // coordinates
+          const [minX, minY, minZ] = targetObjects.reduce(
+            ([currMinX, currMinY, currMinZ], currObj) => {
+              switch (currObj.type) {
+                case 'rect':
+                case 'text':
+                case 'ellipse':
+                  return [
+                    Math.min(currMinX, currObj.x),
+                    Math.min(currMinY, currObj.y),
+                    Math.min(
+                      currMinZ,
+                      currObj.zIndex === undefined ? currMinZ : currObj.zIndex
+                    ),
+                  ];
+                case 'vector':
+                {
+                  const minZ = currObj.zIndex === undefined ? currMinZ : currObj.zIndex;
+                  let minX = currMinX;
+                  let minY = currMinY;
+
+                  for (let i = 0; i < currObj.points.length; ++i) {
+                    if (i % 2 === 0) {
+                      minX = Math.min(minX, currObj.points[i]);
+                    } else {
+                      minY = Math.min(minY, currObj.points[i]);
+                    }
+                  }// -- end for i
+
+                  return [minX, minY, minZ];
+                }
+                default:
+                  throw new Error('Unhandled object type');
+              }// -- end switch (currObj.type)
+            },
+            [width, height, Number.MAX_VALUE]
+          );// -- end const [minX, minY]
+
+          // -- Re-assign x and y values plus z indices
+          const createdObjects = targetObjects.map(targetObject => {
+            const createdObject = { ...targetObject };
+
+            if (createdObject.zIndex === undefined) {
+              createdObject.zIndex = 0;
+            } else {
+              createdObject.zIndex -= minZ;
             }
-          }
+            
+            // -- Reset x and y values
+            switch (createdObject.type) {
+              case 'rect':
+              case 'ellipse':
+              case 'text':
+              {
+                createdObject.x -= minX;
+                createdObject.y -= minY;
+              }
+              break;
+              case 'vector':
+              {
+                const points = [...createdObject.points];
+
+                for (let i = 0; i < points.length; ++i) {
+                  if (i % 2 === 0) {
+                    points[i] -= minX;
+                  } else {
+                    points[i] -= minY;
+                  }
+                }// -- end for i
+
+                createdObject.points = points;
+              }
+              break;
+              default:
+                throw new Error('Unhandled createdObjectect type');
+            }// -- end switch (createdObject.type)
+
+            return createdObject;
+          });
+
+          localStorage.setItem(
+            LS_KEY_COPIED_CANVAS_OBJECTS,
+            JSON.stringify(createdObjects)
+          );
         };// -- end handleCopyObject
 
         // handle keypresses within container
@@ -499,7 +581,7 @@ const CanvasCard = ({
         // -- Handle copying objects
         const handleCopy = () => {
           handleCopyObject();
-          toast.success('Object copied to clipboard');
+          toast.success('Object(s) copied to clipboard');
         };// -- end handleCopy
 
         container.addEventListener('copy', handleCopy);
@@ -517,7 +599,7 @@ const CanvasCard = ({
             clientMessenger.sendDeleteCanvasObjects({
               type: 'delete_canvas_objects',
               canvasId: selectedCanvasId,
-              canvasObjectIds: [selectedCanvasObjects[0]],
+              canvasObjectIds: selectedCanvasObjects,
             });
             toast.success('Object cut to clipboard');
           }
@@ -533,7 +615,7 @@ const CanvasCard = ({
           if (! clientMessenger) return;
           if (! selectedCanvasId) return;
 
-          const currentObjectData = localStorage.getItem(LS_KEY_COPIED_CANVAS_OBJECT);
+          const currentObjectData = localStorage.getItem(LS_KEY_COPIED_CANVAS_OBJECTS);
           if (! currentObjectData) return;
 
           const selectedCanvasRef = canvasGroupRefsByIdRef.current[selectedCanvasId];
@@ -545,50 +627,58 @@ const CanvasCard = ({
           const selectedCanvasAttribs = selectCanvasById(currState, selectedCanvasId);
           if (! selectedCanvasAttribs) return;
 
-          const createdObjectAttribs : CanvasObjectModel = JSON.parse(currentObjectData);
+          const createdObjectAttribs : CanvasObjectModel[] = JSON.parse(currentObjectData);
+          if ((! Array.isArray(createdObjectAttribs)) || (createdObjectAttribs.length < 1)) return;
 
           // -- paste on top of everything already on the canvas, discarding
           // any zIndex copied from the source object
-          createdObjectAttribs.zIndex
-            = selectMaxZIndexByCanvas(currState, selectedCanvasId) + 1;
+          const zIndexBase = selectMaxZIndexByCanvas(currState, selectedCanvasId) + 1;
 
           // -- set created object position
-          switch (createdObjectAttribs.type) {
-            case 'rect':
-            case 'text':
-            case 'ellipse':
-              createdObjectAttribs.x = selectedCanvasPointerPos.x;
-              createdObjectAttribs.y = selectedCanvasPointerPos.y;
-              break;
-            case 'vector':
-              {
-                if (createdObjectAttribs.points.length !== 4) return;
-                const [xA, yA, xB, yB] = createdObjectAttribs.points;
-                // -- C = leftmost point
-                const xC : number = selectedCanvasPointerPos.x;
-                const yC : number = selectedCanvasPointerPos.y;
-                let xD : number;
-                let yD : number;
+          for (const attribs of createdObjectAttribs) {
+            if (attribs.zIndex === undefined) {
+              attribs.zIndex = zIndexBase;
+            } else {
+              attribs.zIndex += zIndexBase;
+            }
 
-                if (xA < xB) {
-                  xD = xC + (xB - xA);
-                  yD = yC + (yB - yA);
-                } else {
-                  xD = xC + (xA - xB);
-                  yD = yC + (yA - yB);
+            switch (attribs.type) {
+              case 'rect':
+              case 'text':
+              case 'ellipse':
+                attribs.x += selectedCanvasPointerPos.x;
+                attribs.y += selectedCanvasPointerPos.y;
+                break;
+              case 'vector':
+                {
+                  for (let i = 0; i < attribs.points.length; ++i) {
+                    if (i % 2 === 0) {
+                      attribs.points[i] += selectedCanvasPointerPos.x;
+                    } else {
+                      attribs.points[i] += selectedCanvasPointerPos.y;
+                    }
+                  }// -- end for i
                 }
+                break;
+              default:
+                throw new Error(`Unrecognized canvas object data: ${JSON.stringify(attribs)}`);
+            }// -- end switch (attribs.type)
+          }// -- end for attribs
 
-                createdObjectAttribs.points = [xC, yC, xD, yD];
-              }
-              break;
-            default:
-              throw new Error(`Unrecognized canvas object data: ${JSON.stringify(createdObjectAttribs)}`);
-          }// -- end switch (createdObjectAttribs.type)
+          createdObjectAttribs.sort((a, b) => {
+            if ((a.zIndex || 0) < (b.zIndex || 0)) {
+              return -1;
+            } else if ((a.zIndex || 0) > (b.zIndex || 0)) {
+              return 1;
+            } else {
+              return 0;
+            }
+          });
 
           clientMessenger.sendCreateCanvasObjects({
             type: 'create_canvas_objects',
             canvasId: selectedCanvasId,
-            canvasObjects: [createdObjectAttribs],
+            canvasObjects: createdObjectAttribs,
           });
         };// -- end handlePaste
 
@@ -653,6 +743,8 @@ const CanvasCard = ({
       clientMessenger,
       currentDispatcherRef,
       canvasGroupRefsByIdRef,
+      width,
+      height,
     ]
   );
 

--- a/Frontend/src/pages/Whiteboard/CanvasCard.tsx
+++ b/Frontend/src/pages/Whiteboard/CanvasCard.tsx
@@ -415,12 +415,10 @@ const CanvasCard = ({
   const handleUnselect = useCallback(
     () => {
       // -- Indicate that user has unselected object(s)
-      for (const objId of selectedCanvasObjects) {
-        clientMessenger?.sendUnselectedCanvasObject({
-          type: 'unselected_canvas_object',
-          canvasObjectId: objId,
-        });
-      }// -- end for objId
+      clientMessenger?.sendUnselectedCanvasObjects({
+        type: 'unselected_canvas_objects',
+        canvasObjectIds: selectedCanvasObjects,
+      });
     },
     [clientMessenger, selectedCanvasObjects]
   );// -- end handleUnselect

--- a/Frontend/src/pages/Whiteboard/CanvasCard.tsx
+++ b/Frontend/src/pages/Whiteboard/CanvasCard.tsx
@@ -13,8 +13,6 @@ import {
 
 import lodash from 'lodash';
 
-import Konva from 'konva';
-
 import {
   Stage,
   Layer,
@@ -36,7 +34,6 @@ import CanvasMenu from "@/pages/Whiteboard/CanvasMenu";
 
 import {
   type ClientIdType,
-  type WhiteboardIdType,
   type CanvasIdType,
   type CanvasAttribs,
 } from "@/types/WebSocketProtocol";
@@ -115,7 +112,6 @@ import { captureImage, type ImageTypeEnum } from '@/lib/captureImage';
 import api from '@/api/axios';
 
 export interface CanvasCardProps {
-  whiteboardId: WhiteboardIdType;
   rootCanvasId: CanvasIdType,
   shapeAttributes: ShapeAttributesState;
   // -- editor identified by user id
@@ -123,7 +119,6 @@ export interface CanvasCardProps {
 }
 
 const CanvasCard = ({
-  whiteboardId,
   rootCanvasId,
   shapeAttributes,
   onSelectCanvasDimensions,
@@ -143,6 +138,11 @@ const CanvasCard = ({
   if (! whiteboardContext) {
     throw new Error('No WhiteboardContext provided to CanvasCard');
   }
+
+  const {
+    whiteboardId,
+    stageRef,
+  } = whiteboardContext;
 
   const {
     canvasGroupRefsByIdRef,
@@ -269,9 +269,7 @@ const CanvasCard = ({
   );
 
   // -- set up interval to broadcast cursor position
-  const stageRef = useRef<Konva.Stage | null>(null);
   const cursorPosRef = useRef<{ x: number; y: number; } | null>(null);
-
   const containerRef = useRef<HTMLDivElement>(null);
 
   // -- Set current zoom level

--- a/Frontend/src/pages/Whiteboard/ShapeAttributesMenu.tsx
+++ b/Frontend/src/pages/Whiteboard/ShapeAttributesMenu.tsx
@@ -137,8 +137,6 @@ const ShapeAttributesMenu = (props: ShapeAttributesMenuProps) => {
     return null;
   }
 
-  if (currentTool === 'create_canvas') return null;
-
   if (! selectedCanvasId) {
     return null;
   }
@@ -150,8 +148,7 @@ const ShapeAttributesMenu = (props: ShapeAttributesMenuProps) => {
     // Shape edit mode
     attributeComponents = getAttributesByShape(shapeType);
     useSelectedShapeValues = true;
-  }
-  else {
+  } else {
     // Tool mode
     if (currentTool === "hand") {
       return null;
@@ -159,6 +156,8 @@ const ShapeAttributesMenu = (props: ShapeAttributesMenuProps) => {
 
     attributeComponents = currentDispatcherRef.current?.getAttributes() ?? [];
   }
+
+  if ((! attributeComponents) || (attributeComponents.length < 1)) return null;
 
   return (
     <div className="flex flex-col flex-shrink-0 text-center p-4 pr-2 rounded-lg shadow-2xl backdrop-blur-md bg-bar-background/80 border-1 border-border">

--- a/Frontend/src/pages/Whiteboard/Toolbar.tsx
+++ b/Frontend/src/pages/Whiteboard/Toolbar.tsx
@@ -42,6 +42,7 @@ const tools: ToolChoice[] = [
   "ellipse",
   "text",
   "create_canvas",
+  "select",
 ];
 
 const ToolbarButton = React.forwardRef<HTMLButtonElement, ToolbarButtonProps>(

--- a/Frontend/src/pages/Whiteboard/Toolbar.tsx
+++ b/Frontend/src/pages/Whiteboard/Toolbar.tsx
@@ -37,12 +37,12 @@ interface ToolbarButtonProps {
 }
 const tools: ToolChoice[] = [
   "hand",
+  "select",
   "vector",
   "rect",
   "ellipse",
   "text",
   "create_canvas",
-  "select",
 ];
 
 const ToolbarButton = React.forwardRef<HTMLButtonElement, ToolbarButtonProps>(

--- a/Frontend/src/pages/Whiteboard/index.tsx
+++ b/Frontend/src/pages/Whiteboard/index.tsx
@@ -246,8 +246,6 @@ const Whiteboard = () => {
 
   // Current tool choice will be saved to localStorage to ensure seamless UX
   // after page reloads.
-  // TODO: save default tool choice ('hand') in a separate config file.
-  // const [currentTool, setCurrentTool] = useState<ToolChoice>('hand');
   const LS_CURRENT_TOOL_KEY = 'current_tool';
 
   // -- Reload previous current tool on page refresh

--- a/Frontend/src/pages/Whiteboard/index.tsx
+++ b/Frontend/src/pages/Whiteboard/index.tsx
@@ -621,7 +621,6 @@ const Whiteboard = () => {
                 {/* Display Canvases */}
                 <div className="flex flex-1 flex-row justify-center flex-wrap">
                   <CanvasCard
-                    whiteboardId={whiteboardId}
                     rootCanvasId={rootCanvasId}
                     shapeAttributes={shapeAttributesState}
                     onSelectCanvasDimensions={handleCreateCanvasDimensions}
@@ -718,7 +717,6 @@ const Whiteboard = () => {
                 {/* Display Canvases */}
                 <div className="flex flex-1 flex-row justify-center flex-wrap">
                   <CanvasCard
-                    whiteboardId={whiteboardId}
                     rootCanvasId={rootCanvasId}
                     shapeAttributes={shapeAttributesState}
                     onSelectCanvasDimensions={handleCreateCanvasDimensions}
@@ -788,6 +786,10 @@ const WrappedWhiteboard = () => {
     throw new Error("No whiteboard ID provided to Whiteboard page");
   }
 
+  const stageRef : RefObject<Konva.Stage | null> = useRef(null);
+  const canvasObjectRefsByIdRef : RefObject<Record<CanvasObjectIdType, RefObject<Konva.Shape | null>>> = useRef({});
+  const selectedObjectRefsByIdRef : RefObject<Record<CanvasObjectIdType, RefObject<Konva.Shape | null>>> = useRef({});
+
   // -- track refs to canvas groups (frames)
   const canvasGroupRefsByIdRef: RefObject<Record<CanvasIdType, RefObject<Konva.Group | null>>> = useRef({});
 
@@ -834,6 +836,9 @@ const WrappedWhiteboard = () => {
     <WhiteboardProvider
       handleUpdateShapes={handleUpdateShapes}
       whiteboardId={whiteboardId}
+      stageRef={stageRef}
+      canvasObjectRefsByIdRef={canvasObjectRefsByIdRef}
+      selectedObjectRefsByIdRef={selectedObjectRefsByIdRef}
       currentDispatcherRef={currentDispatcherRef}
       canvasGroupRefsByIdRef={canvasGroupRefsByIdRef}
     >

--- a/Frontend/src/pages/Whiteboard/index.tsx
+++ b/Frontend/src/pages/Whiteboard/index.tsx
@@ -295,12 +295,10 @@ const Whiteboard = () => {
         currentTool: choice,
       });
 
-      for (const objId of selectedCanvasObjects) {
-        clientMessenger?.sendUnselectedCanvasObject({
-          type: 'unselected_canvas_object',
-          canvasObjectId: objId,
-        });
-      }// -- end for objId
+      clientMessenger?.sendUnselectedCanvasObjects({
+        type: 'unselected_canvas_objects',
+        canvasObjectIds: selectedCanvasObjects,
+      });
 
       removeSelectorsByCanvasObject(dispatch, selectedCanvasObjects);
     },

--- a/Frontend/src/services/whiteboardSocketMessenger.ts
+++ b/Frontend/src/services/whiteboardSocketMessenger.ts
@@ -7,8 +7,8 @@ import {
   type ClientMessageSetCursorPos,
   type ClientMessageLogin,
   type ClientMessageEditingCanvas,
-  type ClientMessageSelectedCanvasObject,
-  type ClientMessageUnselectedCanvasObject,
+  type ClientMessageSelectedCanvasObjects,
+  type ClientMessageUnselectedCanvasObjects,
   type ClientMessageCreateCanvasObjects,
   type ClientMessageUpdateCanvasObjects,
   type ClientMessageDeleteCanvasObjects,
@@ -63,13 +63,13 @@ class WhiteboardSocketMessenger {
     this.#sendMessage(msg);
   }// -- end sendEditingCanvas
 
-  sendSelectedCanvasObject(msg: ClientMessageSelectedCanvasObject) {
+  sendSelectedCanvasObjects(msg: ClientMessageSelectedCanvasObjects) {
     this.#sendMessage(msg);
-  }// -- end sendSelectedCanvasObject
+  }// -- end sendSelectedCanvasObjects
 
-  sendUnselectedCanvasObject(msg: ClientMessageUnselectedCanvasObject) {
+  sendUnselectedCanvasObjects(msg: ClientMessageUnselectedCanvasObjects) {
     this.#sendMessage(msg);
-  }// -- end sendUnselectedCanvasObject
+  }// -- end sendUnselectedCanvasObjects
 
   sendCreateCanvas(msg: ClientMessageCreateCanvas) {
     this.#sendMessage(msg);

--- a/Frontend/src/store/activeUsers/selectorsByCanvasObjectSlice.ts
+++ b/Frontend/src/store/activeUsers/selectorsByCanvasObjectSlice.ts
@@ -40,7 +40,14 @@ export const selectorsByCanvasObjectSlice = createSlice({
         }
 
         selectorsByCanvasObject[objId] = clientId;
-        canvasObjectsBySelector[clientId][objId] = true;
+
+        if (! (clientId in canvasObjectsBySelector)) {
+          canvasObjectsBySelector[clientId] = {
+            [objId]: true,
+          };
+        } else {
+          canvasObjectsBySelector[clientId][objId] = true;
+        }
       }// -- end for objId, clientId
 
       return state;
@@ -68,7 +75,7 @@ export const selectorsByCanvasObjectSlice = createSlice({
 
       for (const clientId of action.payload) {
         if (clientId in canvasObjectsBySelector) {
-          for (const objId of Object.keys(canvasObjectsBySelector)) {
+          for (const objId of Object.keys(canvasObjectsBySelector[clientId])) {
             delete selectorsByCanvasObject[objId];
           }// -- end for (const objId of Object.keys(canvasObjectsBySelector))
 

--- a/Frontend/src/store/activeUsers/selectorsByCanvasObjectSlice.ts
+++ b/Frontend/src/store/activeUsers/selectorsByCanvasObjectSlice.ts
@@ -11,9 +11,10 @@ import {
   type CanvasObjectIdType,
 } from '@/types/CanvasObjectModel';
 
+// -- One to many binding: Client => {CanvasObject}
 interface SelectorsByCanvasObjectState {
   selectorsByCanvasObject: Record<CanvasObjectIdType, ClientIdType>;
-  canvasObjectsBySelector: Record<ClientIdType, CanvasObjectIdType>;
+  canvasObjectsBySelector: Record<ClientIdType, Record<CanvasObjectIdType, unknown>>;
 }
 
 const initialState: SelectorsByCanvasObjectState = {
@@ -32,12 +33,14 @@ export const selectorsByCanvasObjectSlice = createSlice({
       } = state;
 
       for (const [objId, clientId] of Object.entries(action.payload)) {
-        // -- Delete old mapping
-        delete canvasObjectsBySelector[selectorsByCanvasObject[objId]];
-        delete selectorsByCanvasObject[canvasObjectsBySelector[clientId]];
+        // -- Delete old mappings
+        if (objId in selectorsByCanvasObject) {
+          delete canvasObjectsBySelector[selectorsByCanvasObject[objId]][objId];
+          delete selectorsByCanvasObject[objId];
+        }
 
         selectorsByCanvasObject[objId] = clientId;
-        canvasObjectsBySelector[clientId] = objId;
+        canvasObjectsBySelector[clientId][objId] = true;
       }// -- end for objId, clientId
 
       return state;
@@ -50,7 +53,7 @@ export const selectorsByCanvasObjectSlice = createSlice({
 
       for (const objId of action.payload) {
         if (objId in selectorsByCanvasObject) {
-          delete canvasObjectsBySelector[selectorsByCanvasObject[objId]];
+          delete canvasObjectsBySelector[selectorsByCanvasObject[objId]][objId];
           delete selectorsByCanvasObject[objId];
         }
       }// -- end for objId
@@ -65,7 +68,10 @@ export const selectorsByCanvasObjectSlice = createSlice({
 
       for (const clientId of action.payload) {
         if (clientId in canvasObjectsBySelector) {
-          delete selectorsByCanvasObject[canvasObjectsBySelector[clientId]];
+          for (const objId of Object.keys(canvasObjectsBySelector)) {
+            delete selectorsByCanvasObject[objId];
+          }// -- end for (const objId of Object.keys(canvasObjectsBySelector))
+
           delete canvasObjectsBySelector[clientId];
         }
       }// -- end for clientId

--- a/Frontend/src/store/canvasObjects/canvasObjectsSelectors.ts
+++ b/Frontend/src/store/canvasObjects/canvasObjectsSelectors.ts
@@ -170,6 +170,29 @@ export const selectSelectedCanvasObjectsByWhiteboard = (
   }
 };// -- end selectSelectedCanvasObjectsByWhiteboard
 
+export const selectSelectedCanvasObjectsByCanvas = (
+  state: RootState,
+  canvasId: CanvasIdType,
+  clientId: ClientIdType | null,
+): CanvasObjectIdType[] => {
+  if (! clientId) return [];
+
+  const out : CanvasObjectIdType[] = [];
+  const canvasObjectIdSet = state.canvasObjectsByCanvas.canvasObjectsByCanvas[canvasId];
+
+  if (! canvasObjectIdSet) {
+    return [];
+  }
+
+  for (const objId of Object.keys(canvasObjectIdSet)) {
+    if (state.selectorsByCanvasObject.selectorsByCanvasObject[objId] === clientId) {
+      out.push(objId);
+    }
+  }// -- end for objId
+
+  return out;
+};// -- end selectSelectedCanvasObjectsByCanvas
+
 export const selectCanvasObjectById = (
   state: RootState,
   objectId: CanvasObjectIdType,

--- a/Frontend/src/types/IWhiteboardClientMessenger.ts
+++ b/Frontend/src/types/IWhiteboardClientMessenger.ts
@@ -17,8 +17,8 @@ import {
   type ClientMessageCreateCanvasObjects,
   type ClientMessageDeleteCanvasObjects,
   type ClientMessageEditingCanvas,
-  type ClientMessageSelectedCanvasObject,
-  type ClientMessageUnselectedCanvasObject,
+  type ClientMessageSelectedCanvasObjects,
+  type ClientMessageUnselectedCanvasObjects,
   type ClientMessageCreateCanvas,
   type ClientMessageUpdateCanvasObjects,
   type ClientMessageUndoHistory,
@@ -33,8 +33,8 @@ export interface IWhiteboardClientMessenger {
   sendCreateCanvasObjects: (msg: ClientMessageCreateCanvasObjects) => unknown;
   sendDeleteCanvasObjects: (msg: ClientMessageDeleteCanvasObjects) => unknown;
   sendEditingCanvas: (msg: ClientMessageEditingCanvas) => unknown;
-  sendSelectedCanvasObject: (msg: ClientMessageSelectedCanvasObject) => unknown;
-  sendUnselectedCanvasObject: (msg: ClientMessageUnselectedCanvasObject) => unknown;
+  sendSelectedCanvasObjects: (msg: ClientMessageSelectedCanvasObjects) => unknown;
+  sendUnselectedCanvasObjects: (msg: ClientMessageUnselectedCanvasObjects) => unknown;
   sendCreateCanvas: (msg: ClientMessageCreateCanvas) => unknown;
   sendMergeCanvas: (msg: ClientMessageMergeCanvas) => unknown;
   sendUpdateCanvasObjects: (msg: ClientMessageUpdateCanvasObjects) => unknown;

--- a/Frontend/src/types/WebSocketProtocol.ts
+++ b/Frontend/src/types/WebSocketProtocol.ts
@@ -246,18 +246,18 @@ export interface ServerMessageEditingCanvas {
 
 // Notifies clients that a given client has selected a certain canvas object,
 // and thus they shouldn't attempt to edit the object themselves.
-export interface ServerMessageSelectedCanvasObject {
-  type: 'selected_canvas_object';
+export interface ServerMessageSelectedCanvasObjects {
+  type: 'selected_canvas_objects';
   clientId: ClientIdType;
-  canvasObjectId: CanvasIdType;
+  canvasObjectIds: CanvasIdType[];
 }
 
 // Notifies clients that a given client has unselected a certain canvas object,
 // and thus they are free to select it themselves.
-export interface ServerMessageUnselectedCanvasObject {
-  type: 'unselected_canvas_object';
+export interface ServerMessageUnselectedCanvasObjects {
+  type: 'unselected_canvas_objects';
   clientId: ClientIdType;
-  canvasObjectId: CanvasIdType;
+  canvasObjectIds: CanvasIdType[];
 }
 
 // Creates a new shape in a canvas
@@ -345,8 +345,8 @@ export type SocketServerMessage =
   | ServerMessageSetPermissions
   | ServerMessageUpdateWhiteboardMetadata
   | ServerMessageEditingCanvas
-  | ServerMessageSelectedCanvasObject
-  | ServerMessageUnselectedCanvasObject
+  | ServerMessageSelectedCanvasObjects
+  | ServerMessageUnselectedCanvasObjects
   | ServerMessageCreateCanvasObjects
   | ServerMessageUpdateCanvasObjects
   | ServerMessageCreateCanvas
@@ -380,16 +380,16 @@ export interface ClientMessageEditingCanvas {
 
 // Notifies clients that a given client has selected a certain canvas object,
 // and thus they shouldn't attempt to edit the object themselves.
-export interface ClientMessageSelectedCanvasObject {
-  type: 'selected_canvas_object';
-  canvasObjectId: CanvasIdType;
+export interface ClientMessageSelectedCanvasObjects {
+  type: 'selected_canvas_objects';
+  canvasObjectIds: CanvasObjectIdType[];
 }
 
 // Notifies clients that a given client has unselected a certain canvas object,
 // and thus they are free to select it themselves.
-export interface ClientMessageUnselectedCanvasObject {
-  type: 'unselected_canvas_object';
-  canvasObjectId: CanvasIdType;
+export interface ClientMessageUnselectedCanvasObjects {
+  type: 'unselected_canvas_objects';
+  canvasObjectIds: CanvasObjectIdType[];
 }
 
 // Notify the server that the client has created a new shape.
@@ -463,8 +463,8 @@ export interface ClientMessageRequestCanvasEditPermission {
 export type SocketClientMessage =
   | ClientMessageLogin
   | ClientMessageEditingCanvas
-  | ClientMessageSelectedCanvasObject
-  | ClientMessageUnselectedCanvasObject
+  | ClientMessageSelectedCanvasObjects
+  | ClientMessageUnselectedCanvasObjects
   | ClientMessageCreateCanvasObjects
   | ClientMessageUpdateCanvasObjects
   | ClientMessageCreateCanvas

--- a/WebSocketServer/src/main.rs
+++ b/WebSocketServer/src/main.rs
@@ -357,7 +357,7 @@ async fn handle_connection(
                             broadcaster: tx.clone(),
                             active_clients: Arc::new(Mutex::new(HashMap::new())),
                             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-                            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+                            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
                             edits: Arc::new(Mutex::new(Vec::new())),
                         };
 

--- a/WebSocketServer/src/wss/collections.rs
+++ b/WebSocketServer/src/wss/collections.rs
@@ -131,12 +131,14 @@ impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToM
 // relations once created.
 //
 // =================================================================================================
+#[allow(unused)]
 #[derive(Clone,Debug)]
 pub struct OneToOne <K, V> {
     values_by_key: HashMap<K, V>,
     keys_by_value: HashMap<V, K>,
 }// -- end pub struct OneToOne
 
+#[allow(unused)]
 impl <K: Clone + std::hash::Hash + Ord, V: Clone + std::hash::Hash + Ord> OneToOne <K, V> {
     pub fn new() -> Self {
         Self {

--- a/WebSocketServer/src/wss/protocol.rs
+++ b/WebSocketServer/src/wss/protocol.rs
@@ -159,17 +159,17 @@ pub enum ServerSocketBroadcastMessage {
     UpdateWhiteboardMetadata {
         name: Option<String>,
     },
-    SelectedCanvasObject {
+    SelectedCanvasObjects {
         #[serde_as(as = "DisplayFromStr")]
         client_id: ClientIdType,
-        #[serde_as(as = "DisplayFromStr")]
-        canvas_object_id: CanvasObjectIdType,
+        #[serde_as(as = "Vec<DisplayFromStr>")]
+        canvas_object_ids: Vec<CanvasObjectIdType>,
     },
-    UnselectedCanvasObject {
+    UnselectedCanvasObjects {
         #[serde_as(as = "DisplayFromStr")]
         client_id: ClientIdType,
-        #[serde_as(as = "DisplayFromStr")]
-        canvas_object_id: CanvasObjectIdType,
+        #[serde_as(as = "Vec<DisplayFromStr>")]
+        canvas_object_ids: Vec<CanvasObjectIdType>,
     },
     EditingCanvas {
         #[serde_as(as = "DisplayFromStr")]
@@ -290,13 +290,13 @@ pub enum ClientSocketMessage {
         #[serde_as(as = "DisplayFromStr")]
         canvas_id: CanvasIdType,
     },
-    SelectedCanvasObject {
-        #[serde_as(as = "DisplayFromStr")]
-        canvas_object_id: CanvasObjectIdType,
+    SelectedCanvasObjects {
+        #[serde_as(as = "Vec<DisplayFromStr>")]
+        canvas_object_ids: Vec<CanvasObjectIdType>,
     },
-    UnselectedCanvasObject {
-        #[serde_as(as = "DisplayFromStr")]
-        canvas_object_id: CanvasObjectIdType,
+    UnselectedCanvasObjects {
+        #[serde_as(as = "Vec<DisplayFromStr>")]
+        canvas_object_ids: Vec<CanvasObjectIdType>,
     },
     CreateCanvasObjects {
         #[serde_as(as = "DisplayFromStr")]

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -32,7 +32,7 @@ pub struct SharedWhiteboardEntry {
     pub active_clients: Arc<Mutex<HashMap<ClientIdType, UserSummary>>>,
     pub clients_by_user_id: Arc<Mutex<OneToMany<UserIdType, ClientIdType>>>,
     // -- tracking which client is selecting, thereby currently owns, a given canvas object
-    pub selectors_to_canvas_objects: Arc<Mutex<OneToOne<ClientIdType, CanvasObjectIdType>>>,
+    pub selectors_to_canvas_objects: Arc<Mutex<OneToMany<ClientIdType, CanvasObjectIdType>>>,
     pub edits: Arc<Mutex<Vec<Edit>>>,
 } // -- end pub struct SharedWhiteboardEntry
 
@@ -66,7 +66,7 @@ pub struct ClientStateBase {
     pub active_clients: Arc<Mutex<HashMap<ClientIdType, UserSummary>>>,
     pub clients_by_user_id: Arc<Mutex<OneToMany<UserIdType, ClientIdType>>>,
     // -- tracking which client is selecting, thereby currently owns, a given canvas object
-    pub selectors_to_canvas_objects: Arc<Mutex<OneToOne<ClientIdType, CanvasObjectIdType>>>,
+    pub selectors_to_canvas_objects: Arc<Mutex<OneToMany<ClientIdType, CanvasObjectIdType>>>,
     pub edits: Arc<Mutex<Vec<Edit>>>,
 } // -- end pub struct ClientStateBase
 
@@ -259,124 +259,125 @@ pub async fn handle_authenticated_client_message<'a>(
                         }
                     }
                 }
-                SelectedCanvasObject {
-                    canvas_object_id,
+                SelectedCanvasObjects {
+                    canvas_object_ids,
                 } => {
                     let wb = client_state.base.whiteboard_ref.lock().await;
                     let mut selectors_to_canvas_objects
                         = client_state.base.selectors_to_canvas_objects.lock().await;
+                    let mut messages = Vec::<ServerSocketMessage>::new();
+                    let mut approved_selected_objects = Vec::<CanvasObjectIdType>::new();
 
-                    // -- ensure the client has permission to edit the canvas
-                    if let Some(canvas_id) = wb.canvases_to_canvas_objects().get_key_by_value(&canvas_object_id) {
-                        if let Some(canvas) = wb.canvases().get(&canvas_id) {
-                            if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
-                                return ClientMessageResponse {
-                                    messages: vec![ServerSocketMessage::Individual {
+                    for canvas_object_id in canvas_object_ids.iter() {
+                        // -- ensure the client has permission to edit the canvas
+                        if let Some(canvas_id) = wb.canvases_to_canvas_objects().get_key_by_value(canvas_object_id) {
+                            if let Some(canvas) = wb.canvases().get(&canvas_id) {
+                                if ! canvas.user_can_edit(&client_state.user_summary.user_id) {
+                                    messages.push(ServerSocketMessage::Individual {
                                         target_client_id: client_state.base.client_id.clone(),
                                         msg: ServerSocketIndividualMessage::Error {
                                             error: ClientError::UnauthorizedCanvas {
                                                 canvas_id: canvas_id.clone(),
                                             },
                                         }
-                                    }],
-                                    notifications: vec![],
-                                };
-                            }
-                        } else {
-                            return ClientMessageResponse {
-                                messages: vec![ServerSocketMessage::Individual {
+                                    });
+                                }
+                            } else {
+                                messages.push(ServerSocketMessage::Individual {
                                     target_client_id: client_state.base.client_id.clone(),
                                     msg: ServerSocketIndividualMessage::Error {
                                         error: ClientError::CanvasNotFound {
                                             canvas_id: canvas_id.clone(),
                                         },
                                     }
-                                }],
-                                notifications: vec![],
-                            };
-                        }
-                    } else {
-                        return ClientMessageResponse {
-                            messages: vec![ServerSocketMessage::Individual {
+                                });
+                            }
+                        } else {
+                            messages.push(ServerSocketMessage::Individual {
                                 target_client_id: client_state.base.client_id.clone(),
                                 msg: ServerSocketIndividualMessage::Error {
                                     error: ClientError::CanvasObjectNotFound {
                                         canvas_object_id: canvas_object_id.clone(),
                                     },
                                 }
-                            }],
-                            notifications: vec![],
-                        };
+                            });
+                        }
+
+                        // -- ensure the object isn't already selected by someone else
+                        match selectors_to_canvas_objects.get_key_by_value(&canvas_object_id).cloned() {
+                            Some(selector_id) if selector_id != client_state.base.client_id => {
+                                messages.push(ServerSocketMessage::Individual {
+                                    target_client_id: client_state.base.client_id.clone(),
+                                    msg: ServerSocketIndividualMessage::Error {
+                                        error: ClientError::CanvasObjectAlreadySelected {
+                                            client_id: selector_id.clone(),
+                                        },
+                                    }
+                                });
+                            },
+                            _ => {
+                                // -- set this client as the current selector
+                                selectors_to_canvas_objects.insert(
+                                    client_state.base.client_id.clone(), canvas_object_id.clone()
+                                );
+
+                                approved_selected_objects.push(canvas_object_id.clone());
+                            }
+                        }// -- end match
+                    }// -- end for canvas_object_id
+
+                    // -- Add one last message to add approved selected objects
+                    if ! approved_selected_objects.is_empty() {
+                        messages.push(ServerSocketMessage::Broadcast {
+                            msg: ServerSocketBroadcastMessage::SelectedCanvasObjects {
+                                client_id: client_state.base.client_id.clone(),
+                                canvas_object_ids: approved_selected_objects,
+                            },
+                        });
                     }
 
-                    // -- ensure the object isn't already selected by someone else
-                    match selectors_to_canvas_objects.get_key_by_value(&canvas_object_id).cloned() {
-                        Some(selector_id) if selector_id != client_state.base.client_id => {
-                            ClientMessageResponse {
-                                messages: vec![ServerSocketMessage::Individual {
-                                    target_client_id: client_state.base.client_id.clone(),
-                                    msg: ServerSocketIndividualMessage::Error {
-                                        error: ClientError::CanvasObjectAlreadySelected {
-                                            client_id: selector_id.clone(),
-                                        },
-                                    }
-                                }],
-                                notifications: vec![],
-                            }
-                        },
-                        _ => {
-                            // -- set this client as the current selector
-                            selectors_to_canvas_objects.insert(
-                                client_state.base.client_id.clone(), canvas_object_id.clone()
-                            );
-
-                            ClientMessageResponse {
-                                messages: vec![ServerSocketMessage::Broadcast {
-                                    msg: ServerSocketBroadcastMessage::SelectedCanvasObject {
-                                        client_id: client_state.base.client_id.clone(),
-                                        canvas_object_id: canvas_object_id.clone(),
-                                    },
-                                }],
-                                notifications: vec![],
-                            }
-                        }
-                    }// -- end match
+                    ClientMessageResponse { messages, notifications: vec![], }
                 }
-                UnselectedCanvasObject {
-                    canvas_object_id,
+                UnselectedCanvasObjects {
+                    canvas_object_ids,
                 } => {
                     let mut selectors_to_canvas_objects = client_state.base.selectors_to_canvas_objects.lock().await;
+                    let mut messages = Vec::<ServerSocketMessage>::new();
+                    let mut approved_unselected_objects = Vec::<CanvasObjectIdType>::new();
 
-                    match selectors_to_canvas_objects.get_key_by_value(&canvas_object_id).cloned() {
-                        Some(selector_id) if selector_id != client_state.base.client_id => {
-                            ClientMessageResponse {
-                                messages: vec![ServerSocketMessage::Individual {
+                    for canvas_object_id in canvas_object_ids.iter() {
+                        match selectors_to_canvas_objects.get_key_by_value(&canvas_object_id).cloned() {
+                            Some(selector_id) if selector_id != client_state.base.client_id => {
+                                messages.push(ServerSocketMessage::Individual {
                                     target_client_id: client_state.base.client_id.clone(),
                                     msg: ServerSocketIndividualMessage::Error {
                                         error: ClientError::CanvasObjectAlreadySelected {
                                             client_id: selector_id.clone(),
                                         },
                                     }
-                                }],
-                                notifications: vec![],
-                            }
-                        },
-                        _ => {
-                            // -- remove client->object mapping
-                            selectors_to_canvas_objects.remove_value(&canvas_object_id);
+                                });
+                            },
+                            _ => {
+                                // -- remove client->object mapping
+                                selectors_to_canvas_objects.remove_value(&canvas_object_id);
 
-                            // -- echo back to other clients
-                            ClientMessageResponse {
-                                messages: vec![ServerSocketMessage::Broadcast {
-                                    msg: ServerSocketBroadcastMessage::UnselectedCanvasObject {
-                                        client_id: client_state.base.client_id.clone(),
-                                        canvas_object_id: canvas_object_id.clone(),
-                                    },
-                                }],
-                                notifications: vec![],
-                            }
-                        },
-                    }// -- end match
+                                // -- echo back to other clients
+                                approved_unselected_objects.push(canvas_object_id.clone());
+                            },
+                        };// -- end match
+                    }// -- end for canvas_object_id
+
+                    // -- Add one last message to add approved unselected objects
+                    if ! approved_unselected_objects.is_empty() {
+                        messages.push(ServerSocketMessage::Broadcast {
+                            msg: ServerSocketBroadcastMessage::UnselectedCanvasObjects {
+                                client_id: client_state.base.client_id.clone(),
+                                canvas_object_ids: approved_unselected_objects,
+                            },
+                        });
+                    }
+
+                    ClientMessageResponse { messages, notifications: vec![], }
                 }
                 SetCursorPos {
                     x,
@@ -924,22 +925,30 @@ pub async fn handle_authenticated_client_message<'a>(
                         for removed_user_id in users_removed.iter() {
                             if let Some(removed_client_ids) = clients_by_user_id.get_values_by_key(&removed_user_id) {
                                 for client_id in removed_client_ids.iter() {
-                                    if let Some(obj_id) = selectors_to_canvas_objects.get_value_by_key(&client_id).cloned() {
-                                        match whiteboard.canvases_to_canvas_objects().get_key_by_value(&obj_id) {
-                                            Some(canv_id) if *canv_id == canvas_id => {
-                                                // -- found an object to deselect
-                                                selectors_to_canvas_objects.remove_key(&client_id);
+                                    if let Some(obj_ids) = selectors_to_canvas_objects.get_values_by_key(&client_id).cloned() {
+                                        let mut unselected_canvas_objects = Vec::<CanvasObjectIdType>::new();
 
-                                                // -- notify clients of forced deselect
-                                                response_msgs.push(ServerSocketMessage::Broadcast {
-                                                    msg: ServerSocketBroadcastMessage::UnselectedCanvasObject {
-                                                        client_id: client_id.clone(),
-                                                        canvas_object_id: obj_id.clone(),
-                                                    },
-                                                });
-                                            },
-                                            _ => {},
-                                        };// -- end match
+                                        for obj_id in obj_ids.iter() {
+                                            match whiteboard.canvases_to_canvas_objects().get_key_by_value(&obj_id) {
+                                                Some(canv_id) if *canv_id == canvas_id => {
+                                                    // -- found an object to deselect
+                                                    selectors_to_canvas_objects.remove_key(&client_id);
+
+                                                    // -- notify clients of forced deselect
+                                                    unselected_canvas_objects.push(obj_id.clone());
+                                                },
+                                                _ => {},
+                                            };// -- end match
+                                        }// -- end for obj_id
+
+                                        if ! unselected_canvas_objects.is_empty() {
+                                            response_msgs.push(ServerSocketMessage::Broadcast {
+                                                msg: ServerSocketBroadcastMessage::UnselectedCanvasObjects {
+                                                    client_id: client_id.clone(),
+                                                    canvas_object_ids: unselected_canvas_objects,
+                                                },
+                                            });
+                                        }
                                     }
                                 }// -- end for client_id
                             }
@@ -1371,7 +1380,7 @@ pub async fn handle_unauthenticated_client_message<
                                                 whiteboard: whiteboard.to_client_view(),
                                                 active_clients,
                                                 selectors_by_canvas_objects: selectors_to_canvas_objects
-                                                    .iter_key_value()
+                                                    .iter()
                                                     .map(|(selector_id, obj_id)| (obj_id.clone(), selector_id.clone()))
                                                     .collect()
                                             },
@@ -1479,7 +1488,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -1646,7 +1655,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -1902,7 +1911,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -2166,7 +2175,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -2435,7 +2444,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -2602,7 +2611,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -2799,7 +2808,7 @@ mod unit_tests {
             whiteboard_ref: Arc::new(Mutex::new(whiteboard.clone())),
             active_clients: Arc::new(Mutex::new(HashMap::new())),
             clients_by_user_id: Arc::new(Mutex::new(collections::OneToMany::new())),
-            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToOne::new())),
+            selectors_to_canvas_objects: Arc::new(Mutex::new(collections::OneToMany::new())),
             edits: Arc::new(Mutex::new(Vec::new())),
         };
 
@@ -2971,7 +2980,7 @@ mod unit_tests {
         let whiteboard_ref = Arc::new(Mutex::new(whiteboard.clone()));
         let active_clients = Arc::new(Mutex::new(HashMap::new()));
         let clients_by_user_id = Arc::new(Mutex::new(collections::OneToMany::new()));
-        let selectors_to_canvas_objects = Arc::new(Mutex::new(collections::OneToOne::new()));
+        let selectors_to_canvas_objects = Arc::new(Mutex::new(collections::OneToMany::new()));
         let edits = Arc::new(Mutex::new(Vec::new()));
 
         let client_state_a_base = ClientStateBase {


### PR DESCRIPTION
It is now possible to select and manipulate multiple objects at the same time.
The easiest way is using the rectangle select tool in the toolbar, just below
the hand tool.

New key bindings include:
- Shift + click to add a shape to the current selection
- Ctrl + click to remove a shape from the current selection
- Escape to unselect all objects

- **Implemented useSelectDispatcher.**
- **Refactored web socket protocol to accomodate selecting multiple objects per client.**
- **Implemented handleSingleSelect for EditableText and EditableVector.**
- **Multi-select implemented using web socket message.**
- **Augmented handleSingleSelect in Editable components to allow adding new shapes by holding the shift key and removing shapes from the current selection by holding the control key.**
- **Hide edit attributes menu in whiteboard editor when attributes array is empty.**
- **Implemented copying and pasting multiple objects at once.**
- **Implemented articulated dragging of selected objects for EditableShape, EditableText.**
- **Implemented articulated moving of multiple selected objects by comparing the dragged object's initial position with its current position. New implementation also resets vector x and y offsets whenever the component re-renders.**
- **Removed unnecessary console log and useEffect dependency from EditableVector.**
- **Change current tool to hand after multi select.**
- **Use escape key to unselect all objects.**
