### PR TITLE
Bugfix: Remove Stale Data on Exiting Whiteboard Editor

### DIFF
--- a/Frontend/src/context/WebSocketClientMessengerProvider.tsx
+++ b/Frontend/src/context/WebSocketClientMessengerProvider.tsx
@@ -81,6 +81,7 @@ import {
   setClientCursorPos,
   addWhiteboard,
   updateWhiteboard,
+  clearWhiteboard,
   deleteWhiteboard,
   setWhiteboardStatus,
   setCanvasObjects,
@@ -655,7 +656,14 @@ const WebSocketClientMessengerProvider = ({
       ws.onerror = (e: Event) => {
         console.error('Error opening web socket connection:', e);
       };// -- end onerror
+
       ws.onopen = makeHandleWebSocketOpen(ws, wsUri);
+
+      // -- make sure to clear redux store on close
+      ws.onclose = () => {
+        clearWhiteboard(store.dispatch, whiteboardId);
+      };
+
       webSocketRef.current = ws;
 
       // -- Close web socket connection when page closed

--- a/Frontend/src/controllers/index.ts
+++ b/Frontend/src/controllers/index.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   addWhiteboard,
+  clearWhiteboard,
   deleteWhiteboard,
   setWhiteboardStatus,
   updateWhiteboard,
@@ -59,6 +60,7 @@ export {
   removeCurrentEditorsByCanvas,
   setSelectedCanvasByWhiteboard,
   addWhiteboard,
+  clearWhiteboard,
   deleteWhiteboard,
   setWhiteboardStatus,
   updateWhiteboard,

--- a/Frontend/src/controllers/whiteboards.ts
+++ b/Frontend/src/controllers/whiteboards.ts
@@ -108,6 +108,14 @@ export const addWhiteboard = (
   ));
 };
 
+// -- Clear whiteboard data without signalling deletion status
+export const clearWhiteboard = (
+  dispatch: AppDispatch,
+  whiteboardId: WhiteboardIdType,
+) => {
+  dispatch(deleteWhiteboardsAction([whiteboardId]));
+};// -- end clearWhiteboard
+
 export const deleteWhiteboard = (
   dispatch: AppDispatch,
   whiteboardId: WhiteboardIdType,

--- a/Frontend/src/store/whiteboards/deleteWhiteboardsReducer.ts
+++ b/Frontend/src/store/whiteboards/deleteWhiteboardsReducer.ts
@@ -10,6 +10,8 @@ import {
   createAction,
 } from '@reduxjs/toolkit';
 
+import lodash from 'lodash';
+
 // -- local imports
 import {
   type RootState,
@@ -41,75 +43,83 @@ export const deleteWhiteboardsReducer = (
   //                                    => CanvasObject
   //              => ActiveUser
   //              => WhiteboardStatus
+  const draftState : RootState = lodash.cloneDeep(state);
   const whiteboardIds : WhiteboardIdType[] = action.payload;
 
   for (const whiteboardId of whiteboardIds) {
-    if (! (whiteboardId in state.whiteboards)) continue;
+    if (! (whiteboardId in draftState.whiteboards)) continue;
     
     const canvasIds : CanvasIdType[] = Object.keys(
-      state.canvasesByWhiteboard.canvasesByWhiteboard[whiteboardId]
+      draftState.canvasesByWhiteboard.canvasesByWhiteboard[whiteboardId]
     );
 
     for (const canvasId of canvasIds) {
-      if (! (canvasId in state.canvases)) continue;
+      if (! (canvasId in draftState.canvases)) continue;
 
       // -- remove current editor entry, if set
-      if (canvasId in state.currentEditorsByCanvas.currentEditorsByCanvas) {
-        const userId = state.currentEditorsByCanvas.currentEditorsByCanvas[canvasId];
-        delete state.currentEditorsByCanvas.canvasesByCurrentEditor[userId];
-        delete state.currentEditorsByCanvas.currentEditorsByCanvas[canvasId];
+      if (canvasId in draftState.currentEditorsByCanvas.currentEditorsByCanvas) {
+        const userId = draftState.currentEditorsByCanvas.currentEditorsByCanvas[canvasId];
+        delete draftState.currentEditorsByCanvas.canvasesByCurrentEditor[userId];
+        delete draftState.currentEditorsByCanvas.currentEditorsByCanvas[canvasId];
       }
 
       // -- delete allowed user entries, if set
-      if (canvasId in state.allowedUsersByCanvas) {
-        delete state.allowedUsersByCanvas[canvasId];
+      if (canvasId in draftState.allowedUsersByCanvas) {
+        delete draftState.allowedUsersByCanvas[canvasId];
       }
 
       // -- delete child canvas entries
-      if (canvasId in state.childCanvasesByCanvas.parentCanvasesByCanvas) {
-        delete state.childCanvasesByCanvas.parentCanvasesByCanvas[canvasId];
+      if (canvasId in draftState.childCanvasesByCanvas.parentCanvasesByCanvas) {
+        delete draftState.childCanvasesByCanvas.parentCanvasesByCanvas[canvasId];
       }
 
-      if (canvasId in state.childCanvasesByCanvas.childCanvasesByCanvas) {
-        delete state.childCanvasesByCanvas.childCanvasesByCanvas[canvasId];
+      if (canvasId in draftState.childCanvasesByCanvas.childCanvasesByCanvas) {
+        delete draftState.childCanvasesByCanvas.childCanvasesByCanvas[canvasId];
       }
 
       // -- delete associated canvas objects
-      if (canvasId in state.canvasObjectsByCanvas.canvasObjectsByCanvas) {
-        const objIds = Object.keys(state.canvasObjectsByCanvas.canvasObjectsByCanvas[canvasId]);
+      if (canvasId in draftState.canvasObjectsByCanvas.canvasObjectsByCanvas) {
+        const objIds = Object.keys(draftState.canvasObjectsByCanvas.canvasObjectsByCanvas[canvasId]);
 
         for (const objId of objIds) {
-          delete state.canvasObjects[objId];
-          delete state.canvasObjectsByCanvas.canvasesByCanvasObjects[objId];
+          delete draftState.canvasObjects[objId];
+          delete draftState.canvasObjectsByCanvas.canvasesByCanvasObjects[objId];
+
+          // -- Remove selectors
+          if (objId in draftState.selectorsByCanvasObject.selectorsByCanvasObject) {
+            const selectorId = draftState.selectorsByCanvasObject.selectorsByCanvasObject[objId];
+
+            delete draftState.selectorsByCanvasObject.canvasObjectsBySelector[selectorId];
+            delete draftState.selectorsByCanvasObject.selectorsByCanvasObject[objId];
+          }
         }
 
-        delete state.canvasObjectsByCanvas.canvasObjectsByCanvas[canvasId];
+        delete draftState.canvasObjectsByCanvas.canvasObjectsByCanvas[canvasId];
       }
 
-      delete state.canvases[canvasId];
+      delete draftState.canvases[canvasId];
     }// -- end for canvasId
 
     // -- delete activeUser records
-    if (whiteboardId in state.activeUsersByWhiteboard.clientsByWhiteboard) {
+    if (whiteboardId in draftState.activeUsersByWhiteboard.clientsByWhiteboard) {
       const clientIds = Object.keys(
-        state.activeUsersByWhiteboard.clientsByWhiteboard[whiteboardId]
+        draftState.activeUsersByWhiteboard.clientsByWhiteboard[whiteboardId]
       );
 
       for (const clientId of clientIds) {
-        delete state.activeUsers[clientId];
-        delete state.activeUsersByWhiteboard.whiteboardsByClient[clientId];
+        delete draftState.activeUsers[clientId];
+        delete draftState.activeUsersByWhiteboard.whiteboardsByClient[clientId];
       }// -- end for clientId
 
-      delete state.activeUsersByWhiteboard.clientsByWhiteboard[whiteboardId];
+      delete draftState.activeUsersByWhiteboard.clientsByWhiteboard[whiteboardId];
     }
 
     // Don't bother updating whiteboardStatuses; we want a record of the
     // whiteboard having been deleted so the user will be redirected to their
     // dashboard if they try to return to the whiteboard page.
 
-    delete state.whiteboards[whiteboardId];
+    delete draftState.whiteboards[whiteboardId];
   }// -- end for whiteboardId
 
-
-  return state;
-};
+  return draftState;
+};// -- end deleteWhiteboardsReducer


### PR DESCRIPTION
Clears a whiteboard's data from the state store when the user navigates off the whiteboard editor page. Previously, whiteboard data persisted in the state store after the user navigated off the whiteboard editor page, which caused some stale information like canvas object selectors to remain when the user navigated back to the editor page.
