### PR TITLE
Implement corner radius for rectangles

### DIFF
--- a/Frontend/src/components/AttributeCornerRadius.tsx
+++ b/Frontend/src/components/AttributeCornerRadius.tsx
@@ -1,0 +1,89 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+
+import {
+  useSelector,
+} from 'react-redux';
+
+import lodash from 'lodash';
+
+import {
+  type RootState,
+} from '@/store';
+
+import {
+  selectCanvasObjectsByCanvas,
+} from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
+import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
+import AttributeMenuItem from "./AttributeMenuItem";
+
+const CornerRadiusComponent = ({
+  selectedShapeIds,
+  handleUpdateShapes,
+  dispatch,
+  canvasId,
+  value,
+}: AttributeProps) => {
+  const canvasObjectsById = useSelector(
+    (state: RootState) => selectCanvasObjectsByCanvas(state, canvasId),
+    lodash.isEqual
+  );
+  const [inputValue, setInputValue] = useState(value?.toString() ?? '0');
+
+  useEffect(() => {
+    setInputValue(value?.toString() ?? '0');
+  }, [value]);
+
+  const onChangeCornerRadius = useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => {
+      ev.preventDefault();
+
+      const val = ev.target.value;
+      setInputValue(val);
+
+      const cornerRadiusParsed = parseFloat(val);
+
+      if (!isNaN(cornerRadiusParsed) && cornerRadiusParsed >= 0) {
+        dispatch({ type: 'SET_CORNER_RADIUS', payload: cornerRadiusParsed });
+
+        if (canvasObjectsById) {
+          handleUpdateShapes(
+            canvasId,
+            canvasObjectsById,
+            Object.fromEntries(selectedShapeIds.map(id => [id, { cornerRadius: cornerRadiusParsed }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+          );
+        }
+      }
+    },
+    [setInputValue, dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
+  );
+
+  return (
+    <div>
+      <AttributeMenuItem title="Corner Radius">
+        <input
+          name="corner-radius"
+          type="number"
+          min={0}
+          step={1}
+          value={inputValue}
+          onChange={onChangeCornerRadius}
+          className="w-16 mr-0"
+        />
+      </AttributeMenuItem>
+    </div>
+  );
+}
+
+const AttributeCornerRadius: AttributeDefinition = {
+  name: "Corner Radius",
+  key: "cornerRadius",
+  Component: CornerRadiusComponent,
+}
+
+export default AttributeCornerRadius;

--- a/Frontend/src/components/RectCanvasObject.tsx
+++ b/Frontend/src/components/RectCanvasObject.tsx
@@ -53,6 +53,7 @@ export const RectCanvasObject = ({
     width,
     height,
     rotation,
+    cornerRadius,
   } = model;
 
   const handleTransformEnd = useCallback(
@@ -94,6 +95,7 @@ export const RectCanvasObject = ({
         stroke={strokeColor}
         strokeWidth={strokeWidth}
         rotation={rotation}
+        cornerRadius={cornerRadius ?? 0}
         {...shadowProps(model.shadow)}
       />
     </EditableShape>

--- a/Frontend/src/pages/Whiteboard/index.tsx
+++ b/Frontend/src/pages/Whiteboard/index.tsx
@@ -232,6 +232,7 @@ const Whiteboard = () => {
     arrowStart: 'none',
     arrowEnd: 'none',
     shadow: 0,
+    cornerRadius: 0,
   });
 
   const name : string | null = useSelector(

--- a/Frontend/src/reducers/shapeAttributesReducer.ts
+++ b/Frontend/src/reducers/shapeAttributesReducer.ts
@@ -24,6 +24,7 @@ export type ShapeAttributesState = ShapeModelBase & {
   arrowStart: ArrowTip;
   arrowEnd: ArrowTip;
   shadow: number;
+  cornerRadius: number;
 };
 
 export type ShapeAttributesAction =
@@ -37,6 +38,7 @@ export type ShapeAttributesAction =
   | { type: 'SET_ARROW_START'; payload: ArrowTip }
   | { type: 'SET_ARROW_END'; payload: ArrowTip }
   | { type: 'SET_SHADOW'; payload: number }
+  | { type: 'SET_CORNER_RADIUS'; payload: number }
 ;
 
 const shapeAttributesReducer = (state: ShapeAttributesState, action: ShapeAttributesAction) => {
@@ -61,6 +63,8 @@ const shapeAttributesReducer = (state: ShapeAttributesState, action: ShapeAttrib
       return ({ ...state, arrowEnd: action.payload });
     case 'SET_SHADOW':
       return ({ ...state, shadow: action.payload });
+    case 'SET_CORNER_RADIUS':
+      return ({ ...state, cornerRadius: action.payload });
     default:
       return state;
   }// end switch (action.type)

--- a/Frontend/src/types/Attribute.ts
+++ b/Frontend/src/types/Attribute.ts
@@ -41,6 +41,7 @@ import {
   AttributeArrowEnd,
 } from "@/components/AttributeArrowTips";
 import AttributeShadow from "@/components/AttributeShadow";
+import AttributeCornerRadius from "@/components/AttributeCornerRadius";
 
 export type AttributeType =
   | "number"
@@ -105,6 +106,7 @@ export const shapeAttributes: Record<ShapeType, AttributeDefinition[]> = {
     AttributeStrokeColor,
     AttributeFillColor,
     AttributeShadow,
+    AttributeCornerRadius,
     AttributeZOrder,
   ],
   ellipse: [

--- a/Frontend/src/types/CanvasObjectModel.ts
+++ b/Frontend/src/types/CanvasObjectModel.ts
@@ -44,6 +44,9 @@ export interface RectModel extends ShapeModelBase {
   type: 'rect';
   width: number;
   height: number;
+  // -- optional: radius in px applied to all four corners; rects created
+  // -- before rounded corners have none (treated as 0 = square corners)
+  cornerRadius?: number;
 }
 
 export interface RectRecord extends RectModel, RecordBase {}

--- a/WebSocketServer/src/wss/models.rs
+++ b/WebSocketServer/src/wss/models.rs
@@ -45,6 +45,9 @@ pub enum CanvasObjectModel {
         // -- default covers documents/messages predating shadows
         #[serde(default)]
         shadow: Option<f64>,
+        // -- default covers documents/messages predating rounded corners
+        #[serde(default)]
+        corner_radius: Option<f64>,
         // -- default covers documents/messages predating z-ordering
         #[serde(default)]
         z_index: f64,

--- a/WebSocketServer/src/wss/server.rs
+++ b/WebSocketServer/src/wss/server.rs
@@ -1625,6 +1625,7 @@ mod unit_tests {
                 rotation: 0.0,
                 z_index: 0.0,
                 shadow: Some(0.0),
+                corner_radius: None,
             },
             CanvasObjectModel::Rect {
                 x: 200.0,
@@ -1637,6 +1638,7 @@ mod unit_tests {
                 rotation: 0.0,
                 z_index: 0.0,
                 shadow: Some(0.0),
+                corner_radius: None,
             },
             CanvasObjectModel::Rect {
                 x: 300.0,
@@ -1649,6 +1651,7 @@ mod unit_tests {
                 rotation: 0.0,
                 z_index: 0.0,
                 shadow: Some(0.0),
+                corner_radius: None,
             },
         ];
         let client_msg_s = format!(
@@ -1803,6 +1806,7 @@ mod unit_tests {
                                         rotation,
                                         z_index,
                                         shadow: _,
+                                        corner_radius: _,
                                     },
                                     CanvasObjectModel::Rect {
                                         x: x_exp,
@@ -1815,6 +1819,7 @@ mod unit_tests {
                                         rotation: rotation_exp,
                                         z_index: z_index_exp,
                                         shadow: _,
+                                        corner_radius: _,
                                     },
                                 ) => {
                                     if (x - x_exp).abs() > f64_prec {
@@ -1909,6 +1914,7 @@ mod unit_tests {
                     rotation: 0.0,
                     z_index: 0.0,
                     shadow: None,
+                    corner_radius: None,
                 },
             ),
             (
@@ -1924,6 +1930,7 @@ mod unit_tests {
                     rotation: 0.0,
                     z_index: 0.0,
                     shadow: None,
+                    corner_radius: None,
                 },
             ),
             (
@@ -1939,6 +1946,7 @@ mod unit_tests {
                     rotation: 0.0,
                     z_index: 0.0,
                     shadow: None,
+                    corner_radius: None,
                 },
             ),
         ];


### PR DESCRIPTION
Rectangles now have a corner radius attribute to round their corners. Similar to the shadow attribute, it defaults to 0 and the user can increase it via the toolbar.