### PR TITLE
Feat/shift constraints

### DIFF
--- a/Frontend/src/dispatchers/useEllipseDispatcher.tsx
+++ b/Frontend/src/dispatchers/useEllipseDispatcher.tsx
@@ -19,6 +19,8 @@ import type {
 
 import { getAttributesByShape, type AttributeDefinition } from '@/types/Attribute';
 
+import { constrainToSquare } from '@/lib/dragConstraints';
+
 // === useEllipseDispatcher ====================================================
 //
 // Tool for drawing ellipses.
@@ -59,7 +61,10 @@ const useEllipseDispatcher = ({
         const pos = ev.currentTarget.getRelativePointerPosition();
 
         if (pos) {
-          const { x, y } = pos;
+          // -- shift constrains the drag to a perfect circle
+          const { x, y } = ev.evt.shiftKey
+            ? constrainToSquare(mouseDownCoords, pos)
+            : pos;
 
           setMouseCoords({ x, y });
         }
@@ -75,7 +80,10 @@ const useEllipseDispatcher = ({
       const pos = ev.currentTarget.getRelativePointerPosition();
 
       if (pos && mouseDownCoords) {
-        const { x: xRelease, y: yRelease } = pos;
+        // -- shift constrains the drag to a perfect circle
+        const { x: xRelease, y: yRelease } = ev.evt.shiftKey
+          ? constrainToSquare(mouseDownCoords, pos)
+          : pos;
         const { x: xOrigin, y: yOrigin } = mouseDownCoords;
 
         const xCenter = (xOrigin + xRelease) / 2;
@@ -139,7 +147,7 @@ const useEllipseDispatcher = ({
   const getTooltipText = useCallback(
     () => {
       if (mouseDownCoords) {
-        return 'Drag to desired shape, then release';
+        return 'Drag to desired shape, then release (hold Shift for a circle)';
       } else {
         return 'Click to draw an ellipse';
       }

--- a/Frontend/src/dispatchers/useRectangleDispatcher.tsx
+++ b/Frontend/src/dispatchers/useRectangleDispatcher.tsx
@@ -19,6 +19,8 @@ import type {
 
 import { getAttributesByShape, type AttributeDefinition } from '@/types/Attribute';
 
+import { constrainToSquare } from '@/lib/dragConstraints';
+
 // === useRectangleDispatcher ==================================================
 //
 // Tool for drawing rectangles.
@@ -57,7 +59,10 @@ const useRectangleDispatcher = ({
         const pos = ev.currentTarget.getRelativePointerPosition();
 
         if (pos) {
-          const { x, y } = pos;
+          // -- shift constrains the drag to a perfect square
+          const { x, y } = ev.evt.shiftKey
+            ? constrainToSquare(mouseDownCoords, pos)
+            : pos;
 
           setMouseCoords({ x, y });
         }
@@ -71,7 +76,10 @@ const useRectangleDispatcher = ({
       const pos = ev.currentTarget.getRelativePointerPosition();
 
       if (pos && mouseDownCoords) {
-        const { x: xA, y: yA } = pos;
+        // -- shift constrains the drag to a perfect square
+        const { x: xA, y: yA } = ev.evt.shiftKey
+          ? constrainToSquare(mouseDownCoords, pos)
+          : pos;
         const { x: xB, y: yB } = mouseDownCoords;
         const xMin = Math.min(xA, xB);
         const yMin = Math.min(yA, yB);
@@ -122,7 +130,7 @@ const useRectangleDispatcher = ({
 
   const getTooltipText = () => {
     if (mouseDownCoords) {
-      return 'Drag to desired shape, then release';
+      return 'Drag to desired shape, then release (hold Shift for a square)';
     } else {
       return 'Click to draw a rectangle';
     }

--- a/Frontend/src/dispatchers/useVectorDispatcher.tsx
+++ b/Frontend/src/dispatchers/useVectorDispatcher.tsx
@@ -18,6 +18,8 @@ import type {
 } from '@/types/EventCoords';
 import { getAttributesByShape, type AttributeDefinition } from '@/types/Attribute';
 
+import { constrainToAngle } from '@/lib/dragConstraints';
+
 // === useVectorDispatcher =====================================================
 //
 // Tool for drawing vectors.
@@ -56,7 +58,10 @@ const useVectorDispatcher = ({
         const pos = ev.currentTarget.getRelativePointerPosition();
 
         if (pos) {
-          const { x, y } = pos;
+          // -- shift snaps the vector to horizontal, vertical, or 45 degrees
+          const { x, y } = ev.evt.shiftKey
+            ? constrainToAngle(mouseDownCoords, pos)
+            : pos;
 
           setMouseCoords({ x, y });
         }
@@ -70,7 +75,10 @@ const useVectorDispatcher = ({
       const pos = ev.currentTarget.getRelativePointerPosition();
 
       if (pos && mouseDownCoords) {
-        const { x: xA, y: yA } = pos;
+        // -- shift snaps the vector to horizontal, vertical, or 45 degrees
+        const { x: xA, y: yA } = ev.evt.shiftKey
+          ? constrainToAngle(mouseDownCoords, pos)
+          : pos;
         const { x: xB, y: yB } = mouseDownCoords;
 
         addShapes([{
@@ -123,7 +131,7 @@ const useVectorDispatcher = ({
   const getTooltipText = useCallback(
     () => {
       if (mouseDownCoords) {
-        return 'Drag to desired length, then release';
+        return 'Drag to desired length, then release (hold Shift to snap the angle)';
       } else {
         return 'Click to draw a vector';
       }

--- a/Frontend/src/lib/dragConstraints.ts
+++ b/Frontend/src/lib/dragConstraints.ts
@@ -1,0 +1,47 @@
+// === dragConstraints =========================================================
+//
+// Helpers for constraining shape-drawing drags while the shift key is held.
+// Each takes the drag origin (pointer down position) and the current pointer
+// position, and returns an adjusted pointer position.
+//
+// =============================================================================
+
+import type {
+  EventCoords,
+} from '@/types/EventCoords';
+
+// -- constrain the drag box to a square: both sides take the longer dragged
+// -- axis, preserving the drag direction. Yields perfect squares for rects and
+// -- perfect circles for ellipses.
+export const constrainToSquare = (
+  origin: EventCoords,
+  point: EventCoords
+): EventCoords => {
+  const dx = point.x - origin.x;
+  const dy = point.y - origin.y;
+  const size = Math.max(Math.abs(dx), Math.abs(dy));
+
+  return ({
+    x: origin.x + ((dx >= 0) ? size : -size),
+    y: origin.y + ((dy >= 0) ? size : -size),
+  });
+};// -- end constrainToSquare
+
+// -- snap the dragged segment to the nearest 45-degree increment (horizontal,
+// -- vertical, or diagonal), preserving its length
+export const constrainToAngle = (
+  origin: EventCoords,
+  point: EventCoords
+): EventCoords => {
+  const dx = point.x - origin.x;
+  const dy = point.y - origin.y;
+  const length = Math.hypot(dx, dy);
+
+  const snapIncrement = Math.PI / 4;
+  const angle = Math.round(Math.atan2(dy, dx) / snapIncrement) * snapIncrement;
+
+  return ({
+    x: origin.x + length * Math.cos(angle),
+    y: origin.y + length * Math.sin(angle),
+  });
+};// -- end constrainToAngle


### PR DESCRIPTION
Holding shift while creating ellipses will constrain to circles, rectangles to squares and vectors to horizontal, vertical, and 45 degree orientations. This is done through the dragConstraints helper functions that take in the origin and pointer positions to adjust them accordingly. 