### PR TITLE
Implement numeric attribute input hook to prevent laggy behavior

### DIFF
--- a/Frontend/src/components/AttributeCornerRadius.tsx
+++ b/Frontend/src/components/AttributeCornerRadius.tsx
@@ -1,7 +1,5 @@
 import {
   useCallback,
-  useEffect,
-  useState,
 } from 'react';
 
 import {
@@ -18,6 +16,10 @@ import {
   selectCanvasObjectsByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
+import {
+  useNumericAttributeInput,
+} from '@/hooks/useNumericAttributeInput';
+
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
@@ -33,35 +35,33 @@ const CornerRadiusComponent = ({
     (state: RootState) => selectCanvasObjectsByCanvas(state, canvasId),
     lodash.isEqual
   );
-  const [inputValue, setInputValue] = useState(value?.toString() ?? '0');
 
-  useEffect(() => {
-    setInputValue(value?.toString() ?? '0');
-  }, [value]);
+  const commitCornerRadius = useCallback(
+    (cornerRadius: number) => {
+      dispatch({ type: 'SET_CORNER_RADIUS', payload: cornerRadius });
 
-  const onChangeCornerRadius = useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement>) => {
-      ev.preventDefault();
-
-      const val = ev.target.value;
-      setInputValue(val);
-
-      const cornerRadiusParsed = parseFloat(val);
-
-      if (!isNaN(cornerRadiusParsed) && cornerRadiusParsed >= 0) {
-        dispatch({ type: 'SET_CORNER_RADIUS', payload: cornerRadiusParsed });
-
-        if (canvasObjectsById) {
-          handleUpdateShapes(
-            canvasId,
-            canvasObjectsById,
-            Object.fromEntries(selectedShapeIds.map(id => [id, { cornerRadius: cornerRadiusParsed }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
-          );
-        }
+      if (canvasObjectsById) {
+        handleUpdateShapes(
+          canvasId,
+          canvasObjectsById,
+          Object.fromEntries(selectedShapeIds.map(id => [id, { cornerRadius }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+        );
       }
     },
-    [setInputValue, dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
+    [dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
   );
+
+  const {
+    inputValue,
+    onChange,
+    onFocus,
+    onBlur,
+  } = useNumericAttributeInput({
+    value,
+    fallback: '0',
+    min: 0,
+    commit: commitCornerRadius,
+  });
 
   return (
     <div>
@@ -72,7 +72,9 @@ const CornerRadiusComponent = ({
           min={0}
           step={1}
           value={inputValue}
-          onChange={onChangeCornerRadius}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
           className="w-16 mr-0"
         />
       </AttributeMenuItem>

--- a/Frontend/src/components/AttributeFontSize.tsx
+++ b/Frontend/src/components/AttributeFontSize.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
 } from 'react';
+
 import {
   useSelector,
 } from 'react-redux';
@@ -14,16 +15,20 @@ import {
 import {
   selectCanvasObjectsByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
+
+import {
+  useNumericAttributeInput,
+} from '@/hooks/useNumericAttributeInput';
+
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
-import { useEffect, useState } from "react";
 
 const FontSizeComponent = ({
-  selectedShapeIds, 
-  handleUpdateShapes, 
-  dispatch, 
-  canvasId, 
+  selectedShapeIds,
+  handleUpdateShapes,
+  dispatch,
+  canvasId,
   value,
 }: AttributeProps) => {
   const canvasObjectsById = useSelector(
@@ -31,36 +36,31 @@ const FontSizeComponent = ({
     lodash.isEqual
   );
 
-  const [inputValue, setInputValue] = useState(value?.toString() ?? '');
+  const commitFontSize = useCallback(
+    (fontSize: number) => {
+      dispatch({ type: 'SET_FONT_SIZE', payload: fontSize });
 
-  useEffect(() => {
-    setInputValue(value?.toString() ?? '');
-  }, [value]);
-  
-  const onChangeFontSize = useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement>) => {
-      ev.preventDefault();
-
-      const val = ev.target.value;
-      setInputValue(val);
-
-      const size = parseFloat(val);
-      
-      if (!isNaN(size)) {
-        dispatch({ type: 'SET_FONT_SIZE', payload: size });
-
-        if (canvasObjectsById) {
-          handleUpdateShapes(
-            canvasId,
-            canvasObjectsById,
-            Object.fromEntries(selectedShapeIds.map(id => [id, { fontSize: size }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
-          );
-        }
+      if (canvasObjectsById) {
+        handleUpdateShapes(
+          canvasId,
+          canvasObjectsById,
+          Object.fromEntries(selectedShapeIds.map(id => [id, { fontSize }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+        );
       }
     },
-    [dispatch, handleUpdateShapes, canvasObjectsById, canvasId, selectedShapeIds]
+    [dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
   );
- 
+
+  const {
+    inputValue,
+    onChange,
+    onFocus,
+    onBlur,
+  } = useNumericAttributeInput({
+    value,
+    commit: commitFontSize,
+  });
+
   return (
     <div>
       <AttributeMenuItem title="Font Size">
@@ -68,7 +68,9 @@ const FontSizeComponent = ({
           name="font-size"
           type="number"
           value={inputValue}
-          onChange={onChangeFontSize}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
           className="w-16 mr-0"
         />
       </AttributeMenuItem>

--- a/Frontend/src/components/AttributeShadow.tsx
+++ b/Frontend/src/components/AttributeShadow.tsx
@@ -1,7 +1,5 @@
 import {
   useCallback,
-  useEffect,
-  useState,
 } from 'react';
 
 import {
@@ -18,6 +16,10 @@ import {
   selectCanvasObjectsByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
+import {
+  useNumericAttributeInput,
+} from '@/hooks/useNumericAttributeInput';
+
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
@@ -33,35 +35,33 @@ const ShadowComponent = ({
     (state: RootState) => selectCanvasObjectsByCanvas(state, canvasId),
     lodash.isEqual
   );
-  const [inputValue, setInputValue] = useState(value?.toString() ?? '0');
 
-  useEffect(() => {
-    setInputValue(value?.toString() ?? '0');
-  }, [value]);
+  const commitShadow = useCallback(
+    (shadow: number) => {
+      dispatch({ type: 'SET_SHADOW', payload: shadow });
 
-  const onChangeShadow = useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement>) => {
-      ev.preventDefault();
-
-      const val = ev.target.value;
-      setInputValue(val);
-
-      const shadowParsed = parseFloat(val);
-
-      if (!isNaN(shadowParsed) && shadowParsed >= 0) {
-        dispatch({ type: 'SET_SHADOW', payload: shadowParsed });
-
-        if (canvasObjectsById) {
-          handleUpdateShapes(
-            canvasId,
-            canvasObjectsById,
-            Object.fromEntries(selectedShapeIds.map(id => [id, { shadow: shadowParsed }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
-          );
-        }
+      if (canvasObjectsById) {
+        handleUpdateShapes(
+          canvasId,
+          canvasObjectsById,
+          Object.fromEntries(selectedShapeIds.map(id => [id, { shadow }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+        );
       }
     },
-    [setInputValue, dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
+    [dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
   );
+
+  const {
+    inputValue,
+    onChange,
+    onFocus,
+    onBlur,
+  } = useNumericAttributeInput({
+    value,
+    fallback: '0',
+    min: 0,
+    commit: commitShadow,
+  });
 
   return (
     <div>
@@ -72,7 +72,9 @@ const ShadowComponent = ({
           min={0}
           step={1}
           value={inputValue}
-          onChange={onChangeShadow}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
           className="w-16 mr-0"
         />
       </AttributeMenuItem>

--- a/Frontend/src/components/AttributeStrokeWidth.tsx
+++ b/Frontend/src/components/AttributeStrokeWidth.tsx
@@ -16,52 +16,51 @@ import {
   selectCanvasObjectsByCanvas,
 } from '@/store/canvasObjects/canvasObjectsSelectors';
 
+import {
+  useNumericAttributeInput,
+} from '@/hooks/useNumericAttributeInput';
+
 import type { AttributeDefinition, AttributeProps } from "@/types/Attribute";
 import type { CanvasObjectIdType, CanvasObjectModel } from "@/types/CanvasObjectModel";
 import AttributeMenuItem from "./AttributeMenuItem";
-import { useEffect, useState } from "react";
 
 const StrokeWidthComponent = ({
-  selectedShapeIds, 
-  handleUpdateShapes, 
-  dispatch, 
-  canvasId, 
+  selectedShapeIds,
+  handleUpdateShapes,
+  dispatch,
+  canvasId,
   value,
 }: AttributeProps) => {
   const canvasObjectsById = useSelector(
     (state: RootState) => selectCanvasObjectsByCanvas(state, canvasId),
     lodash.isEqual
   );
-  const [inputValue, setInputValue] = useState(value?.toString() ?? '');
 
-  useEffect(() => {
-    setInputValue(value?.toString() ?? '');
-  }, [value]);
+  const commitStrokeWidth = useCallback(
+    (strokeWidth: number) => {
+      dispatch({ type: 'SET_STROKE_WIDTH', payload: strokeWidth });
 
-  const onChangeStrokeWidth = useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement>) => {
-      ev.preventDefault();
-
-      const val = ev.target.value;
-      setInputValue(val);
-
-      const widthParsed = parseFloat(val);  
-      
-      if (!isNaN(widthParsed)) {
-        dispatch({ type: 'SET_STROKE_WIDTH', payload: widthParsed });
-        
-        if (canvasObjectsById) {
-          handleUpdateShapes(
-            canvasId,
-            canvasObjectsById,
-            Object.fromEntries(selectedShapeIds.map(id => [id, { strokeWidth: widthParsed }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
-          );
-        }
+      if (canvasObjectsById) {
+        handleUpdateShapes(
+          canvasId,
+          canvasObjectsById,
+          Object.fromEntries(selectedShapeIds.map(id => [id, { strokeWidth }])) as Record<CanvasObjectIdType, Partial<CanvasObjectModel>>
+        );
       }
     },
-    [setInputValue, dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
+    [dispatch, handleUpdateShapes, canvasId, canvasObjectsById, selectedShapeIds]
   );
- 
+
+  const {
+    inputValue,
+    onChange,
+    onFocus,
+    onBlur,
+  } = useNumericAttributeInput({
+    value,
+    commit: commitStrokeWidth,
+  });
+
   return (
     <div>
       <AttributeMenuItem title="Stroke Width">
@@ -71,7 +70,9 @@ const StrokeWidthComponent = ({
           min={1}
           step={0.5}
           value={inputValue}
-          onChange={onChangeStrokeWidth}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
           className="w-16 mr-0"
         />
       </AttributeMenuItem>

--- a/Frontend/src/hooks/useNumericAttributeInput.ts
+++ b/Frontend/src/hooks/useNumericAttributeInput.ts
@@ -1,0 +1,111 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import lodash from 'lodash';
+
+interface UseNumericAttributeInputOptions {
+  /** Attribute value from the store (server-synced). */
+  value: unknown;
+  /** Display string when value is nullish. */
+  fallback?: string;
+  /** Commits a parsed value to the store and the server. */
+  commit: (parsed: number) => void;
+  /** Smallest committable value; out-of-range input is displayed but not committed. */
+  min?: number;
+  debounceMs?: number;
+}
+
+interface UseNumericAttributeInput {
+  inputValue: string;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus: (ev: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur: (ev: React.FocusEvent<HTMLInputElement>) => void;
+}
+
+/**
+ * Local state for a numeric attribute input backed by server-synced store
+ * state.
+ *
+ * The input updates instantly on every change, while commits are debounced so
+ * a burst of edits sends a single update carrying the final value. While the
+ * input is focused, incoming store values are ignored so that stale server
+ * echoes of in-flight edits cannot overwrite what the user is typing; the
+ * input resyncs with the store once editing ends.
+ */
+export function useNumericAttributeInput({
+  value,
+  fallback = '',
+  commit,
+  min,
+  debounceMs = 250,
+}: UseNumericAttributeInputOptions): UseNumericAttributeInput {
+  const [inputValue, setInputValue] = useState(value?.toString() ?? fallback);
+  const editingRef = useRef(false);
+
+  const latestCommit = useRef(commit);
+  latestCommit.current = commit;
+
+  const debouncedCommit = useRef(
+    lodash.debounce(
+      (parsed: number) => latestCommit.current(parsed),
+      debounceMs
+    )
+  ).current;
+
+  // -- commit any pending edit rather than dropping it on unmount
+  useEffect(() => () => debouncedCommit.flush(), [debouncedCommit]);
+
+  useEffect(() => {
+    if (! editingRef.current) {
+      setInputValue(value?.toString() ?? fallback);
+    }
+  }, [value, fallback]);
+
+  const isCommittable = useCallback(
+    (parsed: number) => !isNaN(parsed) && (min === undefined || parsed >= min),
+    [min]
+  );
+
+  const onChange = useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => {
+      ev.preventDefault();
+
+      editingRef.current = true;
+
+      const val = ev.target.value;
+      setInputValue(val);
+
+      const parsed = parseFloat(val);
+
+      if (isCommittable(parsed)) {
+        debouncedCommit(parsed);
+      }
+    },
+    [debouncedCommit, isCommittable]
+  );
+
+  const onFocus = useCallback(() => {
+    editingRef.current = true;
+  }, []);
+
+  const onBlur = useCallback(() => {
+    editingRef.current = false;
+    debouncedCommit.flush();
+
+    // -- leftover uncommittable text resyncs with the last committed value
+    if (! isCommittable(parseFloat(inputValue))) {
+      setInputValue(value?.toString() ?? fallback);
+    }
+  }, [debouncedCommit, isCommittable, inputValue, value, fallback]);
+
+  return {
+    inputValue,
+    onChange,
+    onFocus,
+    onBlur,
+  };
+}


### PR DESCRIPTION
The lagging while incrementing and modifying the numeric input attributes was being caused by a server-echo feedback loop. This is fixed by debouncing the change inside Frontend/src/hooks/useNumericAttributeInput.ts.