### PR TITLE
Bugfix: properly roll out updates on ec2 test deployment

### DIFF
--- a/RestAPI/src/controllers/health.ts
+++ b/RestAPI/src/controllers/health.ts
@@ -13,6 +13,6 @@ export const getHealthCheck = (
   res: Response
 ) => {
   res.status(200).json({
-    message: "service foobar"
+    message: "service healthy"
   });
 };// -- end getHealthCheck

--- a/RestAPI/src/controllers/health.ts
+++ b/RestAPI/src/controllers/health.ts
@@ -13,6 +13,6 @@ export const getHealthCheck = (
   res: Response
 ) => {
   res.status(200).json({
-    message: "service healthy"
+    message: "service foobar"
   });
 };// -- end getHealthCheck

--- a/deployment.d/update.sh
+++ b/deployment.d/update.sh
@@ -14,3 +14,6 @@ kubectl -n whiteboard-editor delete secret mailserver-config
 kubectl -n whiteboard-editor delete secret samba-credentials
 
 exec ./deploy.sh
+
+# -- Trigger rollout of new images
+kubectl -n whiteboard-editor rollout restart deployment

--- a/deployment.d/update.sh
+++ b/deployment.d/update.sh
@@ -13,7 +13,7 @@ kubectl -n whiteboard-editor delete secret ssl-key
 kubectl -n whiteboard-editor delete secret mailserver-config
 kubectl -n whiteboard-editor delete secret samba-credentials
 
-exec ./deploy.sh
+./deploy.sh
 
 # -- Trigger rollout of new images
 kubectl -n whiteboard-editor rollout restart deployment


### PR DESCRIPTION
Update script now properly rolls out new updates whenever the ec2_deploy_testing workflow is invoked.

- **deployment.d/update.sh rolls out updates by restarting deployments.**
- **TEST: changed output of GET /api/v1/health to ensure updated images are rolled out properly.**
- **Removed exec before ./deploy.sh in deployment.d/update.sh, in order to permit execution of rollout afterwards.**
- **Revert "TEST: changed output of GET /api/v1/health to ensure updated images are rolled out properly."**
